### PR TITLE
Fix stock filter dropdown null handling

### DIFF
--- a/lib/modules/warehouse/stock_list_screen.dart
+++ b/lib/modules/warehouse/stock_list_screen.dart
@@ -36,17 +36,21 @@ class _StockListScreenState extends State<StockListScreen> {
       appBar: AppBar(
         title: const Text('Остатки на складе'),
         actions: [
-          DropdownButton<String>(
+          DropdownButton<String?>(
             value: _selectedType,
             hint: const Text('Фильтр по типу'),
             onChanged: (val) => setState(() => _selectedType = val),
             items: [
-              const DropdownMenuItem<String>(
-                  value: null, child: Text('Все')),
-              ...uniqueTypes.map((type) => DropdownMenuItem<String>(
-                    value: type,
-                    child: Text(type),
-                  )),
+              const DropdownMenuItem<String?>(
+                value: null,
+                child: Text('Все'),
+              ),
+              ...uniqueTypes.map(
+                (type) => DropdownMenuItem<String?>(
+                  value: type,
+                  child: Text(type),
+                ),
+              ),
             ],
           ),
         ],


### PR DESCRIPTION
## Summary
- allow stock type filter dropdown to accept a null value for "All" option

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbe003660832f9781585063711307