### PR TITLE
Persist personnel data using Firebase

### DIFF
--- a/lib/modules/personnel/position_model.dart
+++ b/lib/modules/personnel/position_model.dart
@@ -3,4 +3,13 @@ class PositionModel {
   final String name;
 
   PositionModel({required this.id, required this.name});
+
+  /// Преобразование модели в Map для хранения в Firebase.
+  Map<String, dynamic> toMap() => {
+        'name': name,
+      };
+
+  /// Создание модели из Map, полученного из Firebase.
+  factory PositionModel.fromMap(Map<String, dynamic> map, String id) =>
+      PositionModel(id: id, name: map['name'] as String? ?? '');
 }

--- a/lib/modules/personnel/terminal_model.dart
+++ b/lib/modules/personnel/terminal_model.dart
@@ -8,4 +8,18 @@ class TerminalModel {
     required this.name,
     required this.workplaceIds,
   });
+
+  /// Преобразование модели терминала в Map для Firebase.
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'workplaceIds': workplaceIds,
+      };
+
+  /// Создание модели из Map, полученного из Firebase.
+  factory TerminalModel.fromMap(Map<String, dynamic> map, String id) =>
+      TerminalModel(
+        id: id,
+        name: map['name'] as String? ?? '',
+        workplaceIds: List<String>.from(map['workplaceIds'] ?? []),
+      );
 }

--- a/lib/modules/personnel/workplace_model.dart
+++ b/lib/modules/personnel/workplace_model.dart
@@ -8,4 +8,18 @@ class WorkplaceModel {
     required this.name,
     required this.positionIds,
   });
+
+  /// Преобразование модели рабочего места в Map для Firebase.
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'positionIds': positionIds,
+      };
+
+  /// Создание модели из Map, полученного из Firebase.
+  factory WorkplaceModel.fromMap(Map<String, dynamic> map, String id) =>
+      WorkplaceModel(
+        id: id,
+        name: map['name'] as String? ?? '',
+        positionIds: List<String>.from(map['positionIds'] ?? []),
+      );
 }


### PR DESCRIPTION
## Summary
- allow PersonnelProvider to store staff data in Firebase Realtime Database
- add mapping helpers to position, workplace and terminal models for Firebase use

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68905c938728832fabcb292b56087c6a