### PR TITLE
Add production planning UI screens

### DIFF
--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+class FormEditorScreen extends StatefulWidget {
+  const FormEditorScreen({super.key});
+
+  @override
+  State<FormEditorScreen> createState() => _FormEditorScreenState();
+}
+
+class _FormEditorScreenState extends State<FormEditorScreen> {
+  bool isRequired = true;
+  String fieldType1 = 'Логическое';
+  String fieldType2 = 'Строка';
+  final fieldTypes = ['Логическое', 'Строка', 'Число'];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Редактор формы')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildFieldCard(
+              title: 'Наличие ручки',
+              fieldName: 'Наличие ручки',
+              fieldType: fieldType1,
+              helpText: 'Имеется ли ручка в заказе?',
+              description: 'В данном П-Пакете должна быть ручка',
+              isRequired: isRequired,
+              onTypeChanged: (val) => setState(() => fieldType1 = val!),
+              onRequiredChanged: (val) => setState(() => isRequired = val),
+            ),
+            const SizedBox(height: 24),
+            _buildFieldCard(
+              title: 'Приметы',
+              fieldName: 'Особые примечания',
+              fieldType: fieldType2,
+              helpText: 'Окей',
+              description: 'Если есть что добавить — пиши',
+              isRequired: false,
+              onTypeChanged: (val) => setState(() => fieldType2 = val!),
+            ),
+            const SizedBox(height: 32),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton.icon(
+                onPressed: () {},
+                icon: const Icon(Icons.add),
+                label: const Text('Добавить поле'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFieldCard({
+    required String title,
+    required String fieldName,
+    required String fieldType,
+    required String helpText,
+    required String description,
+    required bool isRequired,
+    required ValueChanged<String?> onTypeChanged,
+    ValueChanged<bool>? onRequiredChanged,
+  }) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextFormField(
+                    initialValue: fieldName,
+                    decoration: const InputDecoration(labelText: 'Имя поля'),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    value: fieldType,
+                    decoration: const InputDecoration(labelText: 'Тип поля'),
+                    items: fieldTypes
+                        .map((type) => DropdownMenuItem(value: type, child: Text(type)))
+                        .toList(),
+                    onChanged: onTypeChanged,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextFormField(
+                    initialValue: title,
+                    decoration: const InputDecoration(labelText: 'Метка'),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: TextFormField(
+                    initialValue: helpText,
+                    decoration: const InputDecoration(labelText: 'Подсказка'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              initialValue: description,
+              decoration: const InputDecoration(labelText: 'Описание'),
+            ),
+            if (onRequiredChanged != null)
+              SwitchListTile(
+                value: isRequired,
+                onChanged: onRequiredChanged,
+                title: const Text('Обязательное'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/production_planning/form_preview_screen.dart
+++ b/lib/modules/production_planning/form_preview_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+class FormPreviewScreen extends StatelessWidget {
+  const FormPreviewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    bool hasHandle = false;
+    final noteController = TextEditingController(text: 'Окей');
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Предпросмотр формы')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Наличие ручки *',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            const Text('В Даном П-Пакете должна быть ручка',
+                style: TextStyle(fontSize: 12)),
+            Row(
+              children: [
+                StatefulBuilder(
+                  builder: (context, setState) => Switch(
+                    value: hasHandle,
+                    onChanged: (val) => setState(() => hasHandle = val),
+                  ),
+                ),
+                const Text('Имеется ли ручка в заказе?'),
+              ],
+            ),
+            const SizedBox(height: 24),
+            const Text('Приметы',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            const Text('Если есть что добавить – пиши',
+                style: TextStyle(fontSize: 12)),
+            const SizedBox(height: 4),
+            TextField(
+              controller: noteController,
+              decoration: const InputDecoration(border: OutlineInputBorder()),
+            ),
+            const SizedBox(height: 24),
+            Center(
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 40, vertical: 14)),
+                child: const Text('Отправить'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/production_planning/production_planning_screen.dart
+++ b/lib/modules/production_planning/production_planning_screen.dart
@@ -1,16 +1,39 @@
 import 'package:flutter/material.dart';
+import 'form_editor_screen.dart';
+import 'form_preview_screen.dart';
+import 'stage_editor_screen.dart';
 
 class ProductionPlanningScreen extends StatelessWidget {
   const ProductionPlanningScreen({super.key});
+
+  void _open(BuildContext context, Widget page) {
+    Navigator.push(context, MaterialPageRoute(builder: (_) => page));
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Планирование производства')),
-      body: const Center(
-        child: Text(
-          'Здесь будет модуль планирования производства',
-          style: TextStyle(fontSize: 18),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton(
+              onPressed: () => _open(context, const StageEditorScreen()),
+              child: const Text('Создать этап'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => _open(context, const FormEditorScreen()),
+              child: const Text('Редактор формы'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => _open(context, const FormPreviewScreen()),
+              child: const Text('Предпросмотр формы'),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/modules/production_planning/stage_editor_screen.dart
+++ b/lib/modules/production_planning/stage_editor_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+class StageEditorScreen extends StatelessWidget {
+  const StageEditorScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final stageNameController = TextEditingController();
+    final stageDescController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Новый этап')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: stageNameController,
+              decoration: const InputDecoration(
+                labelText: 'Название',
+                hintText: 'Введите название этапа',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: stageDescController,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                labelText: 'Описание',
+                hintText: 'Введите описание этапа',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              decoration: const InputDecoration(
+                labelText: 'Оборудование / Рабочее место',
+                border: OutlineInputBorder(),
+              ),
+              items: const [
+                DropdownMenuItem(value: 'Станок', child: Text('Станок')),
+                DropdownMenuItem(value: 'Упаковка', child: Text('Упаковка')),
+              ],
+              onChanged: (val) {},
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const Text('Временные метки'),
+                const SizedBox(width: 8),
+                ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.add),
+                  label: const Text('Добавить'),
+                ),
+              ],
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: () {},
+                icon: const Icon(Icons.save_alt),
+                label: const Text('Создать этап'),
+                style:
+                    ElevatedButton.styleFrom(padding: const EdgeInsets.all(14)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,9 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sheet_clone/my_app.dart';
 
 void main() {
-  testWidgets('shows admin panel title', (tester) async {
+  testWidgets('shows login screen', (tester) async {
     await tester.pumpWidget(const MyApp());
-    expect(find.text('Панель администратора'), findsOneWidget);
+    expect(find.text('Логин'), findsOneWidget);
+    expect(find.text('Войти'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary
- Add stage editor screen for creating production stages
- Introduce form editor and preview screens to configure and display custom fields
- Link new screens from production planning screen and update widget test for login view

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890a2f44348832fb36d9795531664b2