### PR TITLE
Implement basic production planning with stage sequences

### DIFF
--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -1,5 +1,15 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:firebase_database/firebase_database.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:provider/provider.dart';
+
 import '../orders/order_model.dart';
+import 'planned_stage_model.dart';
+import 'stage_provider.dart';
+
 class FormEditorScreen extends StatefulWidget {
   final OrderModel order;
   const FormEditorScreen({super.key, required this.order});
@@ -9,125 +19,146 @@ class FormEditorScreen extends StatefulWidget {
 }
 
 class _FormEditorScreenState extends State<FormEditorScreen> {
-  bool isRequired = true;
-  String fieldType1 = 'Логическое';
-  String fieldType2 = 'Строка';
-  final fieldTypes = ['Логическое', 'Строка', 'Число'];
+  final List<PlannedStage> _stages = [];
+  final _plansRef = FirebaseDatabase.instance.ref('production_plans');
+
+  Future<void> _addStage() async {
+    final provider = context.read<StageProvider>();
+    String? selectedId;
+    await showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Выберите этап'),
+        content: DropdownButtonFormField<String>(
+          items: [
+            for (final s in provider.stages)
+              DropdownMenuItem(value: s.id, child: Text(s.name)),
+          ],
+          onChanged: (val) => selectedId = val,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(ctx);
+            },
+            child: const Text('Добавить'),
+          ),
+        ],
+      ),
+    );
+    if (selectedId != null) {
+      setState(() {
+        _stages.add(PlannedStage(stageId: selectedId!));
+      });
+    }
+  }
+
+  Future<void> _pickImage(int index) async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+    if (picked == null) return;
+    final file = File(picked.path);
+    final ref = FirebaseStorage.instance
+        .ref('plan_photos/${widget.order.id}/${DateTime.now().millisecondsSinceEpoch}.jpg');
+    await ref.putFile(file);
+    final url = await ref.getDownloadURL();
+    setState(() {
+      _stages[index].photoUrl = url;
+    });
+  }
+
+  Future<void> _save() async {
+    if (_stages.isEmpty) return;
+    final data = _stages.map((s) => s.toMap()).toList();
+    await _plansRef.child(widget.order.id).set({'stages': data});
+    if (mounted) Navigator.pop(context);
+  }
 
   @override
   Widget build(BuildContext context) {
+    final stageProvider = context.watch<StageProvider>();
     return Scaffold(
-        appBar: AppBar(title: Text('Форма для ${widget.order.id}')),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildFieldCard(
-              title: 'Наличие ручки',
-              fieldName: 'Наличие ручки',
-              fieldType: fieldType1,
-              helpText: 'Имеется ли ручка в заказе?',
-              description: 'В данном П-Пакете должна быть ручка',
-              isRequired: isRequired,
-              onTypeChanged: (val) => setState(() => fieldType1 = val!),
-              onRequiredChanged: (val) => setState(() => isRequired = val),
+      appBar: AppBar(title: Text('План для ${widget.order.id}')),
+      body: Column(
+        children: [
+          Expanded(
+            child: ReorderableListView(
+              onReorder: (oldIndex, newIndex) {
+                setState(() {
+                  if (newIndex > oldIndex) newIndex--;
+                  final item = _stages.removeAt(oldIndex);
+                  _stages.insert(newIndex, item);
+                });
+              },
+              children: [
+                for (int i = 0; i < _stages.length; i++)
+                  _buildStageCard(i, stageProvider),
+              ],
             ),
-            const SizedBox(height: 24),
-            _buildFieldCard(
-              title: 'Приметы',
-              fieldName: 'Особые примечания',
-              fieldType: fieldType2,
-              helpText: 'Окей',
-              description: 'Если есть что добавить — пиши',
-              isRequired: false,
-              onTypeChanged: (val) => setState(() => fieldType2 = val!),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: _addStage,
+                    icon: const Icon(Icons.add),
+                    label: const Text('Добавить этап'),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: _save,
+                    icon: const Icon(Icons.save),
+                    label: const Text('Сохранить'),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 32),
-            Align(
-              alignment: Alignment.centerRight,
-              child: ElevatedButton.icon(
-                onPressed: () {},
-                icon: const Icon(Icons.add),
-                label: const Text('Добавить поле'),
-              ),
-            )
-          ],
-        ),
+          )
+        ],
       ),
     );
   }
 
-  Widget _buildFieldCard({
-    required String title,
-    required String fieldName,
-    required String fieldType,
-    required String helpText,
-    required String description,
-    required bool isRequired,
-    required ValueChanged<String?> onTypeChanged,
-    ValueChanged<bool>? onRequiredChanged,
-  }) {
+  Widget _buildStageCard(int index, StageProvider provider) {
+    final planned = _stages[index];
+    final stage = provider.stages.firstWhere((s) => s.id == planned.stageId);
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      key: ValueKey(planned.stageId),
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
-            const SizedBox(height: 12),
             Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Expanded(
-                  child: TextFormField(
-                    initialValue: fieldName,
-                    decoration: const InputDecoration(labelText: 'Имя поля'),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: DropdownButtonFormField<String>(
-                    value: fieldType,
-                    decoration: const InputDecoration(labelText: 'Тип поля'),
-                    items: fieldTypes
-                        .map((type) => DropdownMenuItem(value: type, child: Text(type)))
-                        .toList(),
-                    onChanged: onTypeChanged,
-                  ),
+                Text(stage.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                IconButton(
+                  icon: const Icon(Icons.image),
+                  onPressed: () => _pickImage(index),
                 ),
               ],
             ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                Expanded(
-                  child: TextFormField(
-                    initialValue: title,
-                    decoration: const InputDecoration(labelText: 'Метка'),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: TextFormField(
-                    initialValue: helpText,
-                    decoration: const InputDecoration(labelText: 'Подсказка'),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            TextFormField(
-              initialValue: description,
-              decoration: const InputDecoration(labelText: 'Описание'),
-            ),
-            if (onRequiredChanged != null)
-              SwitchListTile(
-                value: isRequired,
-                onChanged: onRequiredChanged,
-                title: const Text('Обязательное'),
+            if (planned.photoUrl != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Image.network(planned.photoUrl!, height: 100),
               ),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Комментарий'),
+              onChanged: (val) => planned.comment = val,
+            ),
           ],
         ),
       ),

--- a/lib/modules/production_planning/planned_stage_model.dart
+++ b/lib/modules/production_planning/planned_stage_model.dart
@@ -1,0 +1,19 @@
+class PlannedStage {
+  final String stageId;
+  String? comment;
+  String? photoUrl;
+
+  PlannedStage({required this.stageId, this.comment, this.photoUrl});
+
+  Map<String, dynamic> toMap() => {
+        'stageId': stageId,
+        if (comment != null && comment!.isNotEmpty) 'comment': comment,
+        if (photoUrl != null) 'photoUrl': photoUrl,
+      };
+
+  factory PlannedStage.fromMap(Map<String, dynamic> map) => PlannedStage(
+        stageId: map['stageId'] as String,
+        comment: map['comment'] as String?,
+        photoUrl: map['photoUrl'] as String?,
+      );
+}

--- a/lib/modules/production_planning/production_planning_screen.dart
+++ b/lib/modules/production_planning/production_planning_screen.dart
@@ -3,11 +3,11 @@ import 'package:provider/provider.dart';
 
 import '../orders/orders_provider.dart';
 import 'form_editor_screen.dart';
-
 import 'stage_editor_screen.dart';
 
 class ProductionPlanningScreen extends StatelessWidget {
   const ProductionPlanningScreen({super.key});
+
   void _open(BuildContext context, Widget page) {
     Navigator.push(context, MaterialPageRoute(builder: (_) => page));
   }
@@ -17,39 +17,31 @@ class ProductionPlanningScreen extends StatelessWidget {
     final orders = context.watch<OrdersProvider>().orders;
     return Scaffold(
       appBar: AppBar(title: const Text('Планирование производства')),
-       body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () => _open(context, const StageEditorScreen()),
-                child: const Text('Создать этап'),
-              ),
-            ),
-            
-            ),
-             const Divider(height: 1),
-          Expanded(
-            child: ListView.builder(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _open(context, const StageEditorScreen()),
+        child: const Icon(Icons.add),
+        tooltip: 'Создать этап',
+      ),
+      body: orders.isEmpty
+          ? const Center(child: Text('Заказы отсутствуют'))
+          : ListView.builder(
               itemCount: orders.length,
               itemBuilder: (context, index) {
                 final order = orders[index];
-                return ListTile(
-                  title: Text(order.id),
-                  subtitle: Text(order.customer),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => _open(
-                    context,
-                    FormEditorScreen(order: order),
+                return Card(
+                  margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  child: ListTile(
+                    title: Text(order.id),
+                    subtitle: Text(order.customer),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => _open(
+                      context,
+                      FormEditorScreen(order: order),
+                    ),
                   ),
                 );
               },
-            )
-          ),
-        ],
-      ),
+            ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Add `PlannedStage` model to store selected production stages with comments and photos
- Redesign production planning UI to list orders and create stages via a FAB
- Build a new form editor for sequencing stages, attaching photos, and saving plans to Firebase

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890d515c498832f9c9dc222d23b4cb6