### PR TITLE
feat: move plan photo to order level

### DIFF
--- a/lib/modules/production_planning/planned_stage_model.dart
+++ b/lib/modules/production_planning/planned_stage_model.dart
@@ -1,19 +1,17 @@
 class PlannedStage {
   final String stageId;
   String? comment;
-  String? photoUrl;
 
-  PlannedStage({required this.stageId, this.comment, this.photoUrl});
+  PlannedStage({required this.stageId, this.comment});
 
   Map<String, dynamic> toMap() => {
         'stageId': stageId,
         if (comment != null && comment!.isNotEmpty) 'comment': comment,
-        if (photoUrl != null) 'photoUrl': photoUrl,
       };
 
-  factory PlannedStage.fromMap(Map<String, dynamic> map) => PlannedStage(
+  factory PlannedStage.fromMap(Map<String, dynamic> map) =>
+      PlannedStage(
         stageId: map['stageId'] as String,
         comment: map['comment'] as String?,
-        photoUrl: map['photoUrl'] as String?,
       );
 }


### PR DESCRIPTION
## Summary
- store production plan photo at the order level rather than per-stage
- show uploaded order photo below planned stages
- simplify PlannedStage model by removing stage photo property
- avoid setState after photo upload if widget is disposed

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890e1d4fb84832f8144e7e1d7f5cb02