### PR TITLE
Fix production planning photo persistence and loading

### DIFF
--- a/lib/modules/production_planning/planned_stage_model.dart
+++ b/lib/modules/production_planning/planned_stage_model.dart
@@ -5,6 +5,12 @@ class PlannedStage {
 
   PlannedStage({required this.stageId, this.comment, this.photoUrl});
 
+  PlannedStage copyWith({String? comment, String? photoUrl}) => PlannedStage(
+        stageId: stageId,
+        comment: comment ?? this.comment,
+        photoUrl: photoUrl ?? this.photoUrl,
+      );
+
   Map<String, dynamic> toMap() => {
         'stageId': stageId,
         if (comment != null && comment!.isNotEmpty) 'comment': comment,


### PR DESCRIPTION
## Summary
- load previously saved production plans from Firebase
- update planned stage model with copyWith helper
- refresh image/comment handling so photos appear beneath stages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e9b63848832fa392d4170caaa17e