### PR TITLE
Handle order photos separately from stages

### DIFF
--- a/lib/modules/production_planning/planned_stage_model.dart
+++ b/lib/modules/production_planning/planned_stage_model.dart
@@ -4,10 +4,9 @@ class PlannedStage {
 
   PlannedStage({required this.stageId, this.comment});
 
-  PlannedStage copyWith({String? comment, String? photoUrl}) => PlannedStage(
+  PlannedStage copyWith({String? comment}) => PlannedStage(
         stageId: stageId,
         comment: comment ?? this.comment,
-        photoUrl: photoUrl ?? this.photoUrl,
       );
 
   Map<String, dynamic> toMap() => {


### PR DESCRIPTION
## Summary
- remove photo field from `PlannedStage`
- upload and manage order photo separately and persist `photoUrl` with plan
- show saved comment text when editing stages

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890efa01da4832fb956a52c3561cdba