### PR TITLE
Show plan photo in production planning list

### DIFF
--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -112,9 +112,11 @@ class _FormEditorScreenState extends State<FormEditorScreen> {
   }
 
   Future<void> _save() async {
-    if (_stages.isEmpty) return;
-    final data = _stages.map((s) => s.toMap()).toList();
-    final plan = {'stages': data};
+    if (_stages.isEmpty && _photoUrl == null) return;
+    final plan = <String, dynamic>{};
+    if (_stages.isNotEmpty) {
+      plan['stages'] = _stages.map((s) => s.toMap()).toList();
+    }
     if (_photoUrl != null) plan['photoUrl'] = _photoUrl;
     await _plansRef.child(widget.order.id).set(plan);
     if (mounted) Navigator.pop(context);

--- a/lib/modules/production_planning/production_planning_screen.dart
+++ b/lib/modules/production_planning/production_planning_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:firebase_database/firebase_database.dart';
 
 import '../orders/orders_provider.dart';
 import 'form_editor_screen.dart';
@@ -29,8 +30,27 @@ class ProductionPlanningScreen extends StatelessWidget {
               itemBuilder: (context, index) {
                 final order = orders[index];
                 return Card(
-                  margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  margin:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                   child: ListTile(
+                    leading: StreamBuilder<DatabaseEvent>(
+                      stream: FirebaseDatabase.instance
+                          .ref('production_plans/${order.id}/photoUrl')
+                          .onValue,
+                      builder: (context, snapshot) {
+                        final url = snapshot.data?.snapshot.value as String?;
+                        if (url != null && url.isNotEmpty) {
+                          return Image.network(
+                            url,
+                            width: 56,
+                            height: 56,
+                            fit: BoxFit.cover,
+                          );
+                        }
+                        return const Icon(Icons.photo,
+                            color: Colors.grey);
+                      },
+                    ),
                     title: Text(order.id),
                     subtitle: Text(order.customer),
                     trailing: const Icon(Icons.chevron_right),


### PR DESCRIPTION
## Summary
- display a plan's photo in the production planning list using a Firebase stream

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891029091dc832fa26232d9135f44ea