### PR TITLE
feat: support employee login credentials

### DIFF
--- a/lib/modules/personnel/employee_model.dart
+++ b/lib/modules/personnel/employee_model.dart
@@ -34,6 +34,8 @@ class EmployeeModel {
         'positionIds': positionIds,
         'isFired': isFired,
         'comments': comments,
+        'login': login,
+        'password': password,
       };
 
   factory EmployeeModel.fromJson(Map<String, dynamic> json, String id) {

--- a/lib/modules/personnel/employees_screen.dart
+++ b/lib/modules/personnel/employees_screen.dart
@@ -123,7 +123,7 @@ class _EmployeeDialogState extends State<_EmployeeDialog> {
   bool _isFired = false;
   final Set<String> _selectedPositions = {};
 
- @override
+  @override
   void initState() {
     super.initState();
     final emp = widget.employee;
@@ -136,6 +136,8 @@ class _EmployeeDialogState extends State<_EmployeeDialog> {
       _comments.text = emp.comments;
       _isFired = emp.isFired;
       _selectedPositions.addAll(emp.positionIds);
+      _login.text = emp.login;
+      _password.text = emp.password;
     }
   }
 
@@ -190,6 +192,8 @@ class _EmployeeDialogState extends State<_EmployeeDialog> {
         positionIds: _selectedPositions.toList(),
         isFired: _isFired,
         comments: _comments.text.trim(),
+        login: _login.text.trim(),
+        password: _password.text.trim(),
       );
     }
     Navigator.of(context).pop();

--- a/lib/modules/personnel/personnel_provider.dart
+++ b/lib/modules/personnel/personnel_provider.dart
@@ -163,6 +163,8 @@ class PersonnelProvider with ChangeNotifier {
     required List<String> positionIds,
     bool isFired = false,
     String comments = '',
+    String login = '',
+    String password = '',
   }) {
     final index = _employees.indexWhere((e) => e.id == id);
     if (index == -1) return;
@@ -176,6 +178,8 @@ class PersonnelProvider with ChangeNotifier {
       positionIds: positionIds,
       isFired: isFired,
       comments: comments,
+      login: login,
+      password: password,
     );
     _employees[index] = updated;
     notifyListeners();


### PR DESCRIPTION
## Summary
- persist login and password fields for employees
- allow editing dialog to load and update employee credentials

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689119f177e4832faa1338c6f5ca0c1f