### PR TITLE
Fix employee position null check in TasksScreen

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -32,16 +32,17 @@ class _TasksScreenState extends State<TasksScreen> {
     final ordersProvider = context.watch<OrdersProvider>();
     final taskProvider = context.watch<TaskProvider>();
 
-    final EmployeeModel? employee =
-        personnel.employees.firstWhere(
-            (e) => e.id == widget.employeeId,
-            orElse: () => EmployeeModel(
-                id: '',
-                lastName: '',
-                firstName: '',
-                patronymic: '',
-                iin: '',
-                positionIds: []));
+    final EmployeeModel employee = personnel.employees.firstWhere(
+      (e) => e.id == widget.employeeId,
+      orElse: () => EmployeeModel(
+        id: '',
+        lastName: '',
+        firstName: '',
+        patronymic: '',
+        iin: '',
+        positionIds: [],
+      ),
+    );
 
     final workplaces = personnel.workplaces
         .where((w) => w.positionIds


### PR DESCRIPTION
## Summary
- Ensure `TasksScreen` retrieves a non-null `EmployeeModel` so `positionIds` can be accessed safely

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib/modules/tasks/tasks_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891247a98a4832faa820e4174db85d1