### PR TITLE
Ensure stage IDs persist to Firebase

### DIFF
--- a/lib/modules/production_planning/stage_model.dart
+++ b/lib/modules/production_planning/stage_model.dart
@@ -12,13 +12,14 @@ class StageModel {
   });
 
   Map<String, dynamic> toMap() => {
+        'id': id,
         'name': name,
         'description': description,
         'workplaceId': workplaceId,
       };
 
-  factory StageModel.fromMap(Map<String, dynamic> map, String id) => StageModel(
-        id: id,
+  factory StageModel.fromMap(Map<String, dynamic> map) => StageModel(
+        id: map['id'] as String? ?? '',
         name: map['name'] as String? ?? '',
         description: map['description'] as String? ?? '',
         workplaceId: map['workplaceId'] as String? ?? '',

--- a/lib/modules/production_planning/stage_provider.dart
+++ b/lib/modules/production_planning/stage_provider.dart
@@ -23,8 +23,11 @@ class StageProvider with ChangeNotifier {
       _stages.clear();
       if (data is Map) {
         data.forEach((key, value) {
-          final map = Map<String, dynamic>.from(value as Map);
-          _stages.add(StageModel.fromMap(map, key));
+          if (value is Map) {
+            final map = Map<String, dynamic>.from(value as Map);
+            map['id'] = key;
+            _stages.add(StageModel.fromMap(map));
+          }
         });
       }
       notifyListeners();


### PR DESCRIPTION
## Summary
- include the stage `id` when serializing to Firebase
- rebuild stages from Firebase snapshots using the stored `id`

## Testing
- `dart format lib/modules/production_planning/stage_model.dart lib/modules/production_planning/stage_provider.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68912a902eb0832fa60c65023eee5ffc