### PR TITLE
Preserve stage names when saving production plans

### DIFF
--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -90,8 +90,11 @@ class _FormEditorScreenState extends State<FormEditorScreen> {
       ),
     );
     if (selectedId != null) {
+      final stage =
+          provider.stages.firstWhere((s) => s.id == selectedId);
       setState(() {
-        _stages.add(PlannedStage(stageId: selectedId!));
+        _stages.add(
+            PlannedStage(stageId: selectedId!, stageName: stage.name));
       });
     }
   }
@@ -215,7 +218,9 @@ class _FormEditorScreenState extends State<FormEditorScreen> {
 
   Widget _buildStageCard(int index, StageProvider provider) {
     final planned = _stages[index];
-    final stage = provider.stages.firstWhere((s) => s.id == planned.stageId);
+    final match = provider.stages
+        .where((s) => s.id == planned.stageId);
+    final name = match.isNotEmpty ? match.first.name : planned.stageName;
     return Card(
       key: ValueKey(planned.stageId),
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -224,13 +229,13 @@ class _FormEditorScreenState extends State<FormEditorScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-
-            Text(stage.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+            Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
             TextFormField(
               initialValue: planned.comment,
               decoration: const InputDecoration(labelText: 'Комментарий'),
               onChanged: (val) => setState(
-                  () => _stages[index] = _stages[index].copyWith(comment: val)),
+                  () => _stages[index] =
+                      _stages[index].copyWith(comment: val)),
             ),
           ],
         ),

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -116,6 +116,20 @@ class _FormEditorScreenState extends State<FormEditorScreen> {
 
   Future<void> _save() async {
     if (_stages.isEmpty && _photoUrl == null) return;
+    final provider = context.read<StageProvider>();
+    for (var i = 0; i < _stages.length; i++) {
+      final s = _stages[i];
+      if (s.stageName.isEmpty) {
+        final match = provider.stages.where((st) => st.id == s.stageId);
+        if (match.isNotEmpty) {
+          _stages[i] = PlannedStage(
+            stageId: s.stageId,
+            stageName: match.first.name,
+            comment: s.comment,
+          );
+        }
+      }
+    }
     final plan = <String, dynamic>{};
     if (_stages.isNotEmpty) {
       plan['stages'] = _stages.map((s) => s.toMap()).toList();

--- a/lib/modules/production_planning/planned_stage_model.dart
+++ b/lib/modules/production_planning/planned_stage_model.dart
@@ -1,22 +1,29 @@
 class PlannedStage {
   final String stageId;
+  final String stageName;
   String? comment;
 
-  PlannedStage({required this.stageId, this.comment});
+  PlannedStage({
+    required this.stageId,
+    required this.stageName,
+    this.comment,
+  });
 
   PlannedStage copyWith({String? comment}) => PlannedStage(
         stageId: stageId,
+        stageName: stageName,
         comment: comment ?? this.comment,
       );
 
   Map<String, dynamic> toMap() => {
         'stageId': stageId,
+        'stageName': stageName,
         if (comment != null && comment!.isNotEmpty) 'comment': comment,
       };
 
-  factory PlannedStage.fromMap(Map<String, dynamic> map) =>
-      PlannedStage(
+  factory PlannedStage.fromMap(Map<String, dynamic> map) => PlannedStage(
         stageId: map['stageId'] as String,
+        stageName: map['stageName'] as String? ?? '',
         comment: map['comment'] as String?,
       );
 }


### PR DESCRIPTION
## Summary
- store each stage's name alongside its ID when planning production
- show saved stage name in plan editor when the provider data is missing

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68912d4391a0832fa05c88654f2f26c6