### PR TITLE
Fix persistence of planned stages

### DIFF
--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -37,6 +37,8 @@ class _FormEditorScreenState extends State<FormEditorScreen> {
     Map<String, dynamic> data = {};
     if (value is Map) {
       data = Map<String, dynamic>.from(value as Map);
+    } else if (value is List) {
+      data = {'stages': value};
     }
 
     final loaded = <PlannedStage>[];
@@ -44,17 +46,20 @@ class _FormEditorScreenState extends State<FormEditorScreen> {
     if (stagesData is List) {
       for (final item in stagesData) {
         if (item is Map) {
-          loaded.add(PlannedStage.fromMap(Map<String, dynamic>.from(item)));
+          loaded.add(
+              PlannedStage.fromMap(Map<String, dynamic>.from(item as Map)));
         }
       }
     } else if (stagesData is Map) {
       stagesData.forEach((_, value) {
         if (value is Map) {
-          loaded.add(PlannedStage.fromMap(Map<String, dynamic>.from(value)));
+          loaded.add(PlannedStage.fromMap(
+              Map<String, dynamic>.from(value as Map)));
         }
       });
     }
 
+    if (!mounted) return;
     setState(() {
       _stages..clear()..addAll(loaded);
       _photoUrl = data['photoUrl'] as String?;


### PR DESCRIPTION
## Summary
- handle both Map and List structures when loading a production plan
- guard setState in loader with a mounted check

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891bf4962a8832fb7130c6c0a9e3f50