### PR TITLE
Fix createOrder async

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -47,7 +47,7 @@ class OrdersProvider with ChangeNotifier {
     bool contractSigned = false,
     bool paymentDone = false,
     String comments = '',
-  }) {
+  }) async {
     final newOrder = OrderModel(
       id: _generateOrderNumber(),
       customer: customer,


### PR DESCRIPTION
## Summary
- make createOrder async so await can be used and the new order returned

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a068d3e0b883228103bfe8190f38c4