### PR TITLE
feat: add warehouse head role

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'modules/personnel/employee_model.dart';        // <-- тип EmployeeModel
-import 'modules/personnel/personnel_constants.dart';   // <-- kManagerId
+import 'modules/personnel/personnel_constants.dart';   // <-- kManagerId, kWarehouseHeadId
 import 'modules/personnel/position_model.dart';        // <-- если используешь PositionModel в проверке
 
 import 'admin_panel.dart';
 import 'modules/personnel/employee_workspace_screen.dart';
 import 'modules/manager/manager_workspace_screen.dart';
+import 'modules/warehouse_manager/warehouse_manager_workspace_screen.dart';
 import 'modules/personnel/personnel_provider.dart';
 import 'utils/auth_helper.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -25,6 +26,19 @@ bool isManagerUser(EmployeeModel emp, PersonnelProvider pr) {
   // 3) По логину (email у модели нет)
   final loginLower = (emp.login ?? '').toLowerCase();
   if (loginLower.contains('manager') || loginLower.contains('менедж')) return true;
+
+  return false;
+}
+
+bool isWarehouseHeadUser(EmployeeModel emp, PersonnelProvider pr) {
+  final ids = emp.positionIds.map((e) => e.toString()).toSet();
+  if (ids.contains(kWarehouseHeadId)) return true;
+
+  final wh = pr.findWarehouseHeadPosition();
+  if (wh != null && ids.contains(wh.id)) return true;
+
+  final loginLower = (emp.login ?? '').toLowerCase();
+  if (loginLower.contains('warehouse') || loginLower.contains('склад')) return true;
 
   return false;
 }
@@ -247,7 +261,9 @@ class _LoginScreenState extends State<LoginScreen> {
 
                         final screen = isManagerUser(emp, pr)
                             ? ManagerWorkspaceScreen(employeeId: user.id)
-                            : EmployeeWorkspaceScreen(employeeId: user.id);
+                            : isWarehouseHeadUser(emp, pr)
+                                ? WarehouseManagerWorkspaceScreen(employeeId: user.id)
+                                : EmployeeWorkspaceScreen(employeeId: user.id);
 
                         Navigator.pushReplacement(
                           context,

--- a/lib/modules/personnel/personnel_constants.dart
+++ b/lib/modules/personnel/personnel_constants.dart
@@ -1,2 +1,3 @@
 
 const String kManagerId = 'manager';
+const String kWarehouseHeadId = 'warehouse_head';

--- a/lib/modules/personnel/personnel_provider.dart
+++ b/lib/modules/personnel/personnel_provider.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'personnel_constants.dart'; // <-- константа kManagerId
+import 'personnel_constants.dart'; // <-- константы kManagerId, kWarehouseHeadId
 import 'position_model.dart';  
 import 'position_model.dart';
 import 'employee_model.dart';
@@ -13,8 +13,9 @@ import 'terminal_model.dart';
 /// Источник данных сотрудников — Supabase (Postgres + Realtime).
 class PersonnelProvider with ChangeNotifier {
   PersonnelProvider() {
-    // гарантируем, что «Менеджер» есть среди должностей
+    // гарантируем, что «Менеджер» и «Заведующий складом» есть среди должностей
     ensureManagerPosition();
+    ensureWarehouseHeadPosition();
     // подтягиваем сотрудников и слушаем изменения
     _listenToEmployees();
   }
@@ -358,6 +359,7 @@ class PersonnelProvider with ChangeNotifier {
 
 extension PersonnelProviderHelpers on PersonnelProvider {
   bool isManagerPositionId(String id) => id == kManagerId;
+  bool isWarehouseHeadPositionId(String id) => id == kWarehouseHeadId;
 
   /// Возвращает позицию «Менеджер» (по id или названию)
   PositionModel? findManagerPosition() {
@@ -370,11 +372,26 @@ extension PersonnelProviderHelpers on PersonnelProvider {
     }
   }
 
-  /// Все обычные должности (без «Менеджера»)
-  List<PositionModel> get regularPositions =>
-      _positions
-          .where((p) => !(p.id == kManagerId || p.name.toLowerCase().trim() == 'менеджер'))
-          .toList();
+  /// Возвращает позицию «Заведующий складом» (по id или названию)
+  PositionModel? findWarehouseHeadPosition() {
+    try {
+      return _positions.firstWhere(
+        (p) =>
+            p.id == kWarehouseHeadId || p.name.toLowerCase().trim() == 'заведующий складом',
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Все обычные должности (без «Менеджера» и «Заведующего складом»)
+  List<PositionModel> get regularPositions => _positions
+      .where((p) =>
+          !(p.id == kManagerId ||
+            p.name.toLowerCase().trim() == 'менеджер' ||
+            p.id == kWarehouseHeadId ||
+            p.name.toLowerCase().trim() == 'заведующий складом'))
+      .toList();
 
   /// Имя должности по id (без падений)
   String positionNameById(String? id) {
@@ -425,6 +442,57 @@ extension PersonnelProviderHelpers on PersonnelProvider {
         'id': kManagerId,
         'name': 'Менеджер',
         'description': 'Управление заказами и чат менеджеров',
+        'created_at': DateTime.now().toIso8601String(),
+        'updated_at': DateTime.now().toIso8601String(),
+      });
+    } catch (_) {
+      // ок: локально уже есть
+    }
+  }
+
+  /// Гарантируем, что «Заведующий складом» есть и внизу списка
+  Future<void> ensureWarehouseHeadPosition() async {
+    // локально
+    final already = _positions.any(
+      (p) => p.id == kWarehouseHeadId ||
+          p.name.toLowerCase().trim() == 'заведующий складом',
+    );
+    if (!already) {
+      _positions.add(
+          PositionModel(id: kWarehouseHeadId, name: 'Заведующий складом'));
+      notifyListeners();
+    } else {
+      // переместим вниз
+      final copy = List<PositionModel>.from(_positions);
+      copy.removeWhere(
+        (p) => p.id == kWarehouseHeadId ||
+            p.name.toLowerCase().trim() == 'заведующий складом',
+      );
+      final wh = _positions.firstWhere(
+        (p) => p.id == kWarehouseHeadId ||
+            p.name.toLowerCase().trim() == 'заведующий складом',
+      );
+      copy.add(wh);
+      _positions
+        ..clear()
+        ..addAll(copy);
+      notifyListeners();
+    }
+
+    // при наличии таблицы positions — мягкая синхронизация
+    try {
+      final rows = await _supabase
+          .from('positions')
+          .select('id')
+          .ilike('name', 'заведующий складом')
+          .limit(1);
+
+      if (rows is List && rows.isNotEmpty) return;
+
+      await _supabase.from('positions').insert({
+        'id': kWarehouseHeadId,
+        'name': 'Заведующий складом',
+        'description': 'Управление складом и чат',
         'created_at': DateTime.now().toIso8601String(),
         'updated_at': DateTime.now().toIso8601String(),
       });

--- a/lib/modules/personnel/positions_picker.dart
+++ b/lib/modules/personnel/positions_picker.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'position_model.dart';
 import 'personnel_provider.dart';
-import 'personnel_constants.dart'; // <-- чтобы был kManagerId
+import 'personnel_constants.dart'; // <-- чтобы были kManagerId, kWarehouseHeadId
 
 
 /// Виджет выбора должностей:
-/// - «Менеджер» выделен отдельным блоком снизу
-/// - Если выбран «Менеджер», остальные должности выбрать нельзя
-/// - Если выбрать обычную должность — «Менеджер» снимается
+/// - «Менеджер» и «Заведующий складом» выделены отдельным блоком снизу
+/// - Если выбрана одна из этих ролей, остальные должности выбрать нельзя
+/// - Если выбрать обычную должность — специальные роли снимаются
 class ManagerAwarePositionsPicker extends StatefulWidget {
   final List<String> value; // выбранные ids
   final ValueChanged<List<String>> onChanged;
@@ -38,11 +38,15 @@ class _ManagerAwarePositionsPickerState extends State<ManagerAwarePositionsPicke
   Widget build(BuildContext context) {
     final pr = context.watch<PersonnelProvider>();
 
-    final regular = pr.regularPositions;
-    final manager = pr.findManagerPosition();
+      final regular = pr.regularPositions;
+      final manager = pr.findManagerPosition();
+      final wh = pr.findWarehouseHeadPosition();
 
-    final managerSelected = _selected.contains(kManagerId) ||
-        (manager != null && _selected.contains(manager.id));
+      final managerSelected = _selected.contains(kManagerId) ||
+          (manager != null && _selected.contains(manager.id));
+      final warehouseSelected = _selected.contains(kWarehouseHeadId) ||
+          (wh != null && _selected.contains(wh.id));
+      final specialSelected = managerSelected || warehouseSelected;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -59,9 +63,9 @@ class _ManagerAwarePositionsPickerState extends State<ManagerAwarePositionsPicke
             return FilterChip(
               label: Text(p.name),
               selected: sel,
-              onSelected: managerSelected
-                  ? null // если менеджер выбран — отключаем
-                  : (v) {
+                onSelected: specialSelected
+                    ? null // если выбран менеджер или зав. складом — отключаем
+                    : (v) {
                       setState(() {
                         if (v) {
                           _selected.add(p.id);
@@ -78,34 +82,55 @@ class _ManagerAwarePositionsPickerState extends State<ManagerAwarePositionsPicke
 
         const SizedBox(height: 16),
 
-        // Менеджер (блок 2)
-        if (manager != null) ...[
-          const Divider(height: 24),
-          Text('Роль с отдельным рабочим местом', style: Theme.of(context).textTheme.labelLarge),
-          const SizedBox(height: 8),
-          FilterChip(
-            label: const Text('Менеджер (эксклюзивно)'),
-            selected: managerSelected,
-            onSelected: (v) {
-              setState(() {
-                if (v) {
-                  _selected
-                    ..clear()
-                    ..add(kManagerId); // оставляем только менеджера
-                } else {
-                  _selected.remove(kManagerId);
-                  _selected.remove(manager.id);
-                }
-              });
-              _emit();
-            },
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Если выбран «Менеджер», выбрать другие должности нельзя, так как у менеджера отдельное рабочее пространство (Заказы + Чат).',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.black54),
-          ),
-        ],
+          // Спецроли (блок 2)
+          if (manager != null || wh != null) ...[
+            const Divider(height: 24),
+            Text('Роль с отдельным рабочим местом',
+                style: Theme.of(context).textTheme.labelLarge),
+            const SizedBox(height: 8),
+            if (manager != null)
+              FilterChip(
+                label: const Text('Менеджер (эксклюзивно)'),
+                selected: managerSelected,
+                onSelected: (v) {
+                  setState(() {
+                    if (v) {
+                      _selected
+                        ..clear()
+                        ..add(kManagerId); // оставляем только менеджера
+                    } else {
+                      _selected.remove(kManagerId);
+                      _selected.remove(manager.id);
+                    }
+                  });
+                  _emit();
+                },
+              ),
+            if (manager != null) const SizedBox(height: 8),
+            if (wh != null)
+              FilterChip(
+                label: const Text('Заведующий складом (эксклюзивно)'),
+                selected: warehouseSelected,
+                onSelected: (v) {
+                  setState(() {
+                    if (v) {
+                      _selected
+                        ..clear()
+                        ..add(kWarehouseHeadId); // только зав. складом
+                    } else {
+                      _selected.remove(kWarehouseHeadId);
+                      _selected.remove(wh.id);
+                    }
+                  });
+                  _emit();
+                },
+              ),
+            const SizedBox(height: 4),
+            Text(
+              'Если выбран «Менеджер» или «Заведующий складом», выбрать другие должности нельзя, так как у них отдельное рабочее пространство.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.black54),
+            ),
+          ],
       ],
     );
   }

--- a/lib/modules/warehouse_manager/warehouse_manager_workspace_screen.dart
+++ b/lib/modules/warehouse_manager/warehouse_manager_workspace_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../warehouse/warehouse_screen.dart';
+import '../chat/chat_tab.dart';
+import '../personnel/personnel_provider.dart';
+import '../personnel/employee_model.dart';
+
+class WarehouseManagerWorkspaceScreen extends StatelessWidget {
+  final String employeeId;
+  const WarehouseManagerWorkspaceScreen({super.key, required this.employeeId});
+
+  @override
+  Widget build(BuildContext context) {
+    final personnel = context.watch<PersonnelProvider>();
+    final EmployeeModel emp = personnel.employees.firstWhere(
+      (e) => e.id == employeeId,
+      orElse: () => EmployeeModel(
+        id: employeeId,
+        lastName: '',
+        firstName: '',
+        patronymic: '',
+        iin: '',
+        photoUrl: null,
+        positionIds: const [],
+        isFired: false,
+        comments: '',
+        login: '',
+        password: '',
+      ),
+    );
+
+    final fio = [emp.lastName, emp.firstName, emp.patronymic]
+        .where((s) => s.trim().isNotEmpty)
+        .join(' ')
+        .trim();
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+              fio.isEmpty ? 'Заведующий складом' : '$fio • Заведующий складом'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Склад', icon: Icon(Icons.warehouse)),
+              Tab(text: 'Чат', icon: Icon(Icons.chat_bubble_outline)),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            const WarehouseDashboard(),
+            ChatTab(
+              currentUserId: emp.id,
+              currentUserName:
+                  fio.isEmpty ? 'Заведующий складом' : fio,
+              roomId: 'general',
+              isLead: true,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow assigning exclusive "Заведующий складом" position
- add warehouse manager workspace with warehouse and chat tabs
- route warehouse heads to their workspace on login

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a353119050832287f4a8dcbe5820b0