### PR TITLE
Add template management and fix plan saving

### DIFF
--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -166,7 +166,7 @@ Future<void> _pickOrderImage() async {
       'order_id': orderId,
       'stages': stageMaps,
       if (_photoUrl != null) 'photo_url': _photoUrl,
-    });
+    }, onConflict: 'order_id');
     
     await _supabase.from('tasks').delete().eq('orderId', orderId);
 

--- a/lib/modules/production_planning/production_planning_screen.dart
+++ b/lib/modules/production_planning/production_planning_screen.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../orders/orders_provider.dart';
 import 'form_editor_screen.dart';
-import 'template_editor_screen.dart';
+import 'templates_screen.dart';
 
 class ProductionPlanningScreen extends StatelessWidget {
   const ProductionPlanningScreen({super.key});
@@ -18,9 +18,9 @@ class ProductionPlanningScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Планирование производства')),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _open(context, const TemplateEditorScreen()),
-        child: const Icon(Icons.add),
-        tooltip: 'Создать шаблон',
+        onPressed: () => _open(context, const TemplatesScreen()),
+        child: const Icon(Icons.list),
+        tooltip: 'Шаблоны',
       ),
       body: orders.isEmpty
           ? const Center(child: Text('Заказы отсутствуют'))

--- a/lib/modules/production_planning/template_provider.dart
+++ b/lib/modules/production_planning/template_provider.dart
@@ -43,4 +43,28 @@ class TemplateProvider with ChangeNotifier {
       'stages': stages.map((s) => s.toMap()).toList(),
     });
   }
+
+  Future<void> updateTemplate({
+    required String id,
+    required String name,
+    required List<PlannedStage> stages,
+  }) async {
+    final index = _templates.indexWhere((t) => t.id == id);
+    if (index == -1) return;
+    _templates[index] = TemplateModel(id: id, name: name, stages: stages);
+    notifyListeners();
+    await _supabase
+        .from('plan_templates')
+        .update({
+          'name': name,
+          'stages': stages.map((s) => s.toMap()).toList(),
+        })
+        .eq('id', id);
+  }
+
+  Future<void> deleteTemplate(String id) async {
+    _templates.removeWhere((t) => t.id == id);
+    notifyListeners();
+    await _supabase.from('plan_templates').delete().eq('id', id);
+  }
 }

--- a/lib/modules/production_planning/templates_screen.dart
+++ b/lib/modules/production_planning/templates_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'template_editor_screen.dart';
+import 'template_provider.dart';
+import 'template_model.dart';
+
+class TemplatesScreen extends StatelessWidget {
+  const TemplatesScreen({super.key});
+
+  void _openEditor(BuildContext context, [TemplateModel? template]) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TemplateEditorScreen(template: template),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final templates = context.watch<TemplateProvider>().templates;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Шаблоны')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openEditor(context),
+        child: const Icon(Icons.add),
+        tooltip: 'Создать шаблон',
+      ),
+      body: templates.isEmpty
+          ? const Center(child: Text('Шаблоны отсутствуют'))
+          : ListView.builder(
+              itemCount: templates.length,
+              itemBuilder: (context, index) {
+                final tpl = templates[index];
+                return ListTile(
+                  title: Text(tpl.name),
+                  onTap: () => _openEditor(context, tpl),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: () async {
+                      final confirm = await showDialog<bool>(
+                        context: context,
+                        builder: (ctx) => AlertDialog(
+                          title: const Text('Удалить шаблон?'),
+                          content: Text('Вы уверены, что хотите удалить "${tpl.name}"?'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, false),
+                              child: const Text('Отмена'),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, true),
+                              child: const Text('Удалить'),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (confirm == true) {
+                        await context.read<TemplateProvider>().deleteTemplate(tpl.id);
+                      }
+                    },
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Introduce template list screen to view, edit, and delete templates
- Allow editing templates with feedback on save
- Ensure production plans save templates with `onConflict` upsert

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3709e625483229becadf2f20ae7b3