### PR TITLE
Enable chat cleanup for leads and display sender names

### DIFF
--- a/lib/modules/chat/chat_screen.dart
+++ b/lib/modules/chat/chat_screen.dart
@@ -56,6 +56,48 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
+  Future<void> _handleMenu(String value) async {
+    final chat = context.read<ChatProvider>();
+    switch (value) {
+      case 'clear':
+        final ok = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('Очистить чат?'),
+            content: const Text('Все сообщения будут удалены.'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Отмена'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Очистить'),
+              ),
+            ],
+          ),
+        );
+        if (ok == true) {
+          await chat.clearRoom(widget.roomId);
+        }
+        break;
+      case 'range':
+        final range = await showDateRangePicker(
+          context: context,
+          firstDate: DateTime(2020),
+          lastDate: DateTime.now(),
+        );
+        if (range != null) {
+          await chat.deleteMessagesInRange(
+            roomId: widget.roomId,
+            from: range.start,
+            to: range.end.add(const Duration(days: 1)),
+          );
+        }
+        break;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<ChatProvider>(
@@ -67,6 +109,16 @@ class _ChatScreenState extends State<ChatScreen> {
         return Scaffold(
           appBar: AppBar(
             title: Text('Чат • ${widget.roomId}'),
+            actions: [
+              if (widget.isLead)
+                PopupMenuButton<String>(
+                  onSelected: _handleMenu,
+                  itemBuilder: (ctx) => const [
+                    PopupMenuItem(value: 'clear', child: Text('Очистить чат')),
+                    PopupMenuItem(value: 'range', child: Text('Удалить за период')),
+                  ],
+                ),
+            ],
           ),
           body: Column(
             children: [

--- a/lib/modules/personnel/employee_workspace_screen.dart
+++ b/lib/modules/personnel/employee_workspace_screen.dart
@@ -142,6 +142,29 @@ class _EmployeeWorkspaceTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final personnel = context.watch<PersonnelProvider>();
+    final EmployeeModel emp = personnel.employees.firstWhere(
+      (e) => e.id == employeeId,
+      orElse: () => EmployeeModel(
+        id: employeeId,
+        lastName: '',
+        firstName: '',
+        patronymic: '',
+        iin: '',
+        photoUrl: null,
+        positionIds: const [],
+        isFired: false,
+        comments: '',
+        login: '',
+        password: '',
+      ),
+    );
+
+    final fio = [emp.lastName, emp.firstName, emp.patronymic]
+        .where((s) => s.trim().isNotEmpty)
+        .join(' ')
+        .trim();
+
     return DefaultTabController(
       length: 2,
       child: Scaffold(
@@ -160,7 +183,10 @@ class _EmployeeWorkspaceTab extends StatelessWidget {
         body: TabBarView(
           children: [
             TasksScreen(employeeId: employeeId),
-            ChatTab(currentUserId: employeeId),
+            ChatTab(
+              currentUserId: employeeId,
+              currentUserName: fio.isEmpty ? 'Сотрудник' : fio,
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- allow technical leads to clear entire chat or messages in a date range
- display employee names in chat messages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a47766cd9c832291ae94fb4c69d009