### PR TITLE
Restrict chat clearing to technical leader

### DIFF
--- a/lib/admin_panel.dart
+++ b/lib/admin_panel.dart
@@ -106,6 +106,7 @@ class _AdminPanelScreenState extends State<AdminPanelScreen> {
           currentUserId: meId,
           currentUserName: _meName ?? 'Пользователь', // не-null
           roomId: 'general',
+          isLead: isLead,
         ),
       },
       {'label': '📊\nАналитика', 'page': const AnalyticsScreen()},

--- a/lib/modules/manager/manager_workspace_screen.dart
+++ b/lib/modules/manager/manager_workspace_screen.dart
@@ -56,7 +56,6 @@ class ManagerWorkspaceScreen extends StatelessWidget {
               currentUserId: emp.id,
               currentUserName: fio.isEmpty ? 'Менеджер' : fio,
               roomId: 'general', // общий чат
-              isLead: true,
             ),
           ],
         ),

--- a/lib/modules/warehouse_manager/warehouse_manager_workspace_screen.dart
+++ b/lib/modules/warehouse_manager/warehouse_manager_workspace_screen.dart
@@ -56,7 +56,6 @@ class WarehouseManagerWorkspaceScreen extends StatelessWidget {
               currentUserName:
                   fio.isEmpty ? 'Заведующий складом' : fio,
               roomId: 'general',
-              isLead: true,
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- Allow admin panel's chat to know if current user is the technical lead
- Remove elevated privileges from manager and warehouse manager chat tabs

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4956c9c1c8322ac0312c0e3adaf6a