### PR TITLE
feat: add basic products module

### DIFF
--- a/lib/admin_panel.dart
+++ b/lib/admin_panel.dart
@@ -7,6 +7,7 @@ import 'modules/personnel/personnel_screen.dart';
 import 'modules/production/production_screen.dart';
 import 'modules/warehouse/warehouse_screen.dart';
 import 'modules/analytics/analytics_screen.dart';
+import 'modules/products/products_screen.dart';
 import 'services/auth_service.dart';
 import 'modules/chat/chat_tab.dart';
 
@@ -96,6 +97,7 @@ class _AdminPanelScreenState extends State<AdminPanelScreen> {
 
     final modules = [
       {'label': '📦\nСклад', 'page': const WarehouseDashboard()},
+      {'label': '🛍️\nПродукция', 'page': const ProductsScreen()},
       {'label': '👥\nПерсонал', 'page': const PersonnelScreen()},
       {'label': '🧾\nЗаказы', 'page': const OrdersScreen()},
       {'label': '🗓️\nПланир.', 'page': const ProductionPlanningScreen()},

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'modules/orders/orders_provider.dart';
 import 'modules/production_planning/template_provider.dart';
 import 'modules/tasks/task_provider.dart';
 import 'modules/analytics/analytics_provider.dart';
+import 'modules/products/products_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -67,6 +68,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => WarehouseProvider()),
         ChangeNotifierProvider(create: (_) => PersonnelProvider()),
         ChangeNotifierProvider(create: (_) => OrdersProvider()),
+        ChangeNotifierProvider(create: (_) => ProductsProvider()),
         ChangeNotifierProvider(create: (_) => SupplierProvider()),
         ChangeNotifierProvider(create: (_) => TemplateProvider()),
         ChangeNotifierProvider(create: (_) => TaskProvider()),

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -5,6 +5,7 @@ import 'package:uuid/uuid.dart';
 import 'orders_provider.dart';
 import 'order_model.dart';
 import 'product_model.dart';
+import '../products/products_provider.dart';
 
 /// Экран редактирования или создания заказа.
 /// Если [order] передан, экран открывается для редактирования существующего заказа.
@@ -330,20 +331,27 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             Row(
               children: [
                 Expanded(
-                  child: DropdownButtonFormField<String>(
-                    value: product.type,
-                    decoration: const InputDecoration(
-                      labelText: 'Наименование изделия',
-                      border: OutlineInputBorder(),
-                    ),
-                    items: const [
-                      DropdownMenuItem(value: 'П-пакет', child: Text('П‑пакет')),
-                      DropdownMenuItem(value: 'V-пакет', child: Text('V‑пакет')),
-                      DropdownMenuItem(value: 'Листы', child: Text('Листы')),
-                      DropdownMenuItem(value: 'Маффин', child: Text('Маффин')),
-                      DropdownMenuItem(value: 'Тюльпан', child: Text('Тюльпан')),
-                    ],
-                    onChanged: (val) => setState(() => product.type = val ?? product.type),
+                  child: Consumer<ProductsProvider>(
+                    builder: (context, provider, _) {
+                      final items = provider.products;
+                      final value =
+                          items.contains(product.type) ? product.type : null;
+                      return DropdownButtonFormField<String>(
+                        value: value,
+                        decoration: const InputDecoration(
+                          labelText: 'Наименование изделия',
+                          border: OutlineInputBorder(),
+                        ),
+                        items: items
+                            .map((p) => DropdownMenuItem(
+                                  value: p,
+                                  child: Text(p),
+                                ))
+                            .toList(),
+                        onChanged: (val) =>
+                            setState(() => product.type = val ?? product.type),
+                      );
+                    },
                   ),
                 ),
                 const SizedBox(width: 12),

--- a/lib/modules/products/products_provider.dart
+++ b/lib/modules/products/products_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+
+/// Простой провайдер для управления списком типов продукции.
+class ProductsProvider with ChangeNotifier {
+  final List<String> _products = [
+    'П-пакет',
+    'V-пакет',
+    'Листы',
+    'Маффин',
+    'Тюльпан',
+  ];
+
+  /// Текущий список доступных изделий.
+  List<String> get products => List.unmodifiable(_products);
+
+  /// Добавляет новое изделие в список.
+  void addProduct(String name) {
+    _products.add(name);
+    notifyListeners();
+  }
+
+  /// Обновляет наименование изделия по индексу.
+  void updateProduct(int index, String name) {
+    if (index < 0 || index >= _products.length) return;
+    _products[index] = name;
+    notifyListeners();
+  }
+
+  /// Удаляет изделие из списка.
+  void removeProduct(int index) {
+    if (index < 0 || index >= _products.length) return;
+    _products.removeAt(index);
+    notifyListeners();
+  }
+}
+

--- a/lib/modules/products/products_screen.dart
+++ b/lib/modules/products/products_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'products_provider.dart';
+
+/// Экран управления списком продукции.
+class ProductsScreen extends StatelessWidget {
+  const ProductsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Продукция')),
+      body: Consumer<ProductsProvider>(
+        builder: (context, provider, _) {
+          final items = provider.products;
+          if (items.isEmpty) {
+            return const Center(child: Text('Список пуст'));
+          }
+          return ListView.builder(
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final name = items[index];
+              return ListTile(
+                title: Text(name),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.edit),
+                      tooltip: 'Редактировать',
+                      onPressed: () => _showEditDialog(context, provider, index, name),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete),
+                      tooltip: 'Удалить',
+                      onPressed: () => provider.removeProduct(index),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showAddDialog(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  void _showAddDialog(BuildContext context) {
+    final controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Добавить продукцию'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Наименование'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Отмена'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final name = controller.text.trim();
+              if (name.isNotEmpty) {
+                Provider.of<ProductsProvider>(context, listen: false)
+                    .addProduct(name);
+              }
+              Navigator.pop(context);
+            },
+            child: const Text('Сохранить'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showEditDialog(BuildContext context, ProductsProvider provider, int index, String current) {
+    final controller = TextEditingController(text: current);
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Редактирование'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Наименование'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Отмена'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final name = controller.text.trim();
+              if (name.isNotEmpty) {
+                provider.updateProduct(index, name);
+              }
+              Navigator.pop(context);
+            },
+            child: const Text('Сохранить'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ProductsProvider with editable list of product types
- expose new Products screen in admin panel
- use dynamic products in order creation form

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a744a65c4c8322bd5d9b6fe65f547f