### PR TITLE
refactor: use single product per order

### DIFF
--- a/lib/modules/analytics/analytics_screen.dart
+++ b/lib/modules/analytics/analytics_screen.dart
@@ -39,7 +39,7 @@ class AnalyticsScreen extends StatelessWidget {
     String getOrderName(String id) {
       try {
         final OrderModel o = ordersProvider.orders.firstWhere((o) => o.id == id);
-        final product = o.products.isNotEmpty ? o.products.first.type : '';
+        final product = o.product.type;
         return product.isNotEmpty ? '${o.id} ($product)' : o.id;
       } catch (_) {
         return id;

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -40,8 +40,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _dueDate = order?.dueDate;
     _contractSigned = order?.contractSigned ?? false;
     _paymentDone = order?.paymentDone ?? false;
-    if (order != null && order.products.isNotEmpty) {
-      final p = order.products.first;
+    if (order != null) {
+      final p = order.product;
       _product = ProductModel(
         id: p.id,
         type: p.type,
@@ -123,7 +123,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         customer: _customerController.text.trim(),
         orderDate: _orderDate!,
         dueDate: _dueDate!,
-        products: [_product],
+        product: _product,
         contractSigned: _contractSigned,
         paymentDone: _paymentDone,
         comments: _commentsController.text.trim(),
@@ -135,7 +135,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         customer: _customerController.text.trim(),
         orderDate: _orderDate!,
         dueDate: _dueDate!,
-        products: [_product],
+        product: _product,
         contractSigned: _contractSigned,
         paymentDone: _paymentDone,
         comments: _commentsController.text.trim(),

--- a/lib/modules/orders/order_model.dart
+++ b/lib/modules/orders/order_model.dart
@@ -9,7 +9,8 @@ class OrderModel {
   String customer;
   DateTime orderDate;
   DateTime dueDate;
-  List<ProductModel> products;
+  /// Единственный продукт, связанный с заказом.
+  ProductModel product;
   bool contractSigned;
   bool paymentDone;
   String comments;
@@ -24,7 +25,7 @@ class OrderModel {
     required this.customer,
     required this.orderDate,
     required this.dueDate,
-    required this.products,
+    required this.product,
     this.contractSigned = false,
     this.paymentDone = false,
     this.comments = '',
@@ -39,7 +40,7 @@ class OrderModel {
         'customer': customer,
         'orderDate': orderDate.toIso8601String(),
         'dueDate': dueDate.toIso8601String(),
-        'products': products.map((p) => p.toMap()).toList(),
+        'product': product.toMap(),
         'contractSigned': contractSigned,
         'paymentDone': paymentDone,
         'comments': comments,
@@ -54,9 +55,11 @@ class OrderModel {
         customer: map['customer'] as String? ?? '',
         orderDate: DateTime.parse(map['orderDate'] as String),
         dueDate: DateTime.parse(map['dueDate'] as String),
-        products: (map['products'] as List<dynamic>? ?? [])
-            .map((p) => ProductModel.fromMap(Map<String, dynamic>.from(p)))
-            .toList(),
+        product: ProductModel.fromMap(
+          Map<String, dynamic>.from(
+            map['product'] as Map? ?? const {},
+          ),
+        ),
         contractSigned: map['contractSigned'] as bool? ?? false,
         paymentDone: map['paymentDone'] as bool? ?? false,
         comments: map['comments'] as String? ?? '',

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -30,16 +30,17 @@ class OrdersProvider with ChangeNotifier {
         ..addAll(rows.map((row) {
           final map = Map<String, dynamic>.from(row);
 
-          // products в БД — jsonb; подстрахуемся, если пришла строка
-          final p = map['products'];
+          // product в БД — jsonb; подстрахуемся, если пришла строка
+          final p = map['product'];
           if (p is String) {
             try {
-              map['products'] = p.isEmpty ? [] : (jsonDecode(p) as List);
+              map['product'] =
+                  p.isEmpty ? <String, dynamic>{} : jsonDecode(p) as Map;
             } catch (_) {
-              map['products'] = const [];
+              map['product'] = <String, dynamic>{};
             }
           } else if (p == null) {
-            map['products'] = const [];
+            map['product'] = <String, dynamic>{};
           }
 
           return OrderModel.fromMap(map);
@@ -75,7 +76,7 @@ class OrdersProvider with ChangeNotifier {
     required String customer,
     required DateTime orderDate,
     required DateTime dueDate,
-    List<ProductModel>? products,
+    required ProductModel product,
     bool contractSigned = false,
     bool paymentDone = false,
     String comments = '',
@@ -85,7 +86,7 @@ class OrdersProvider with ChangeNotifier {
       customer: customer,
       orderDate: orderDate,
       dueDate: dueDate,
-      products: products ?? <ProductModel>[],
+      product: product,
       contractSigned: contractSigned,
       paymentDone: paymentDone,
       comments: comments,
@@ -164,12 +165,12 @@ class OrdersProvider with ChangeNotifier {
 
   // ===== Склад: вызывай сам в нужных местах UI/сценариев =====
 
-  /// Списание материалов по продуктам заказа (например, при «в производстве» или «завершён»).
+  /// Списание материалов по продукту заказа (например, при «в производстве» или «завершён»).
   Future<void> applyStockOnFulfillment(OrderModel order) async {
     await _applyStockDelta(order, isShipment: true);
   }
 
-  /// Возврат материалов по продуктам заказа (например, при «отменён»).
+  /// Возврат материалов по продукту заказа (например, при «отменён»).
   Future<void> revertStockOnCancel(OrderModel order) async {
     await _applyStockDelta(order, isShipment: false);
   }
@@ -179,31 +180,29 @@ class OrdersProvider with ChangeNotifier {
     OrderModel order, {
     required bool isShipment,
   }) async {
-    for (final p in order.products) {
-      final pm = p.toMap();
+    final pm = order.product.toMap();
 
-      // поддержим разные названия полей
-      final tmcId = (pm['tmcId'] ??
-          pm['tmc_id'] ??
-          pm['materialId'] ??
-          pm['material_id']) as String?;
+    // поддержим разные названия полей
+    final tmcId = (pm['tmcId'] ??
+            pm['tmc_id'] ??
+            pm['materialId'] ??
+            pm['material_id']) as String?;
 
-      final qRaw = (pm['quantity'] ?? pm['qty'] ?? pm['count']);
-      final qty =
-          (qRaw is num) ? qRaw.toDouble() : double.tryParse('$qRaw') ?? 0.0;
+    final qRaw = (pm['quantity'] ?? pm['qty'] ?? pm['count']);
+    final qty =
+        (qRaw is num) ? qRaw.toDouble() : double.tryParse('$qRaw') ?? 0.0;
 
-      if (tmcId == null || qty <= 0) continue;
+    if (tmcId == null || qty <= 0) return;
 
-      final delta = isShipment ? -qty : qty;
-      try {
-        await _supabase.rpc('materials_increment', params: {
-          'p_id': tmcId,
-          'p_delta': delta,
-        });
-      } catch (e) {
-        // не блокируем процесс — просто логируем
-        debugPrint('⚠️ stock delta failed for $tmcId: $e');
-      }
+    final delta = isShipment ? -qty : qty;
+    try {
+      await _supabase.rpc('materials_increment', params: {
+        'p_id': tmcId,
+        'p_delta': delta,
+      });
+    } catch (e) {
+      // не блокируем процесс — просто логируем
+      debugPrint('⚠️ stock delta failed for $tmcId: $e');
     }
   }
 

--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -189,8 +189,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
       default:
         break;
     }
-    int totalQty(OrderModel o) =>
-        o.products.isNotEmpty ? o.products.first.quantity : 0;
+    int totalQty(OrderModel o) => o.product.quantity;
     switch (_sortOption) {
       case SortOption.orderDateAsc:
         filtered.sort((a, b) => a.orderDate.compareTo(b.orderDate));
@@ -300,8 +299,8 @@ void _showSortOptions() {
         break;
     }
     // В текущей версии заказ содержит один продукт
-    final product = order.products.isNotEmpty ? order.products.first : null;
-    final totalQty = product?.quantity ?? 0;
+    final product = order.product;
+    final totalQty = product.quantity;
     return SizedBox(
       width: 320,
       child: Card(
@@ -346,15 +345,14 @@ void _showSortOptions() {
               ),
 
               const SizedBox(height: 6),
-              if (product != null)
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text('Изделие: ${product.type}', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
-                    const SizedBox(height: 2),
-                    Text('Тираж: $totalQty шт.', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
-                  ],
-                ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Изделие: ${product.type}', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                  const SizedBox(height: 2),
+                  Text('Тираж: $totalQty шт.', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                ],
+              ),
               const SizedBox(height: 6),
               Row(
                 children: [

--- a/lib/modules/orders/product_model.dart
+++ b/lib/modules/orders/product_model.dart
@@ -31,7 +31,7 @@ class ProductModel {
 
   /// Создаёт [ProductModel] из Map.
   factory ProductModel.fromMap(Map<String, dynamic> map) => ProductModel(
-        id: map['id'] as String,
+        id: map['id'] as String? ?? '',
         type: map['type'] as String? ?? '',
         quantity: (map['quantity'] as num?)?.toInt() ?? 0,
         width: (map['width'] as num?)?.toDouble() ?? 0,

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -247,9 +247,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                                   fontSize: 20, fontWeight: FontWeight.bold)),
                           const SizedBox(height: 4),
                           Text(
-                            widget.order.products.isNotEmpty
-                                ? widget.order.products.first.type
-                                : '',
+                            widget.order.product.type,
                             style: const TextStyle(fontSize: 16),
                           ),
                           const SizedBox(height: 2),
@@ -261,14 +259,11 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                           const SizedBox(height: 8),
                           Row(
                             children: [
-                              if (widget.order.products.isNotEmpty) ...[
-                                const Icon(Icons.layers,
-                                    size: 16, color: Colors.grey),
-                                const SizedBox(width: 4),
-                                Text(
-                                    '${widget.order.products.first.quantity} шт.'),
-                                const SizedBox(width: 16),
-                              ],
+                              const Icon(Icons.layers,
+                                  size: 16, color: Colors.grey),
+                              const SizedBox(width: 4),
+                              Text('${widget.order.product.quantity} шт.'),
+                              const SizedBox(width: 16),
                               const Icon(Icons.calendar_today,
                                   size: 16, color: Colors.grey),
                               const SizedBox(width: 4),

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -217,9 +217,9 @@ class _ProductionScreenState extends State<ProductionScreen>
         final aggStatus = _computeAggregatedStatus(orderTasks);
         final color = _statusColors[aggStatus] ?? Colors.grey;
         final label = _statusLabels[aggStatus] ?? '';
-        final product = order.products.isNotEmpty ? order.products.first : null;
-        final productDesc = product?.type ?? '';
-        final qty = product != null ? '${product.quantity} шт.' : '';
+        final product = order.product;
+        final productDesc = product.type;
+        final qty = '${product.quantity} шт.';
         final due = dateFormat.format(order.dueDate);
         // Вычисляем последний комментарий для заказа. Используется для
         // отображения причины паузы или проблемы, если такая есть.

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -197,7 +197,7 @@ Future<void> _pickOrderImage() async {
       customer: widget.order.customer,
       orderDate: widget.order.orderDate,
       dueDate: widget.order.dueDate,
-      products: widget.order.products,
+      product: widget.order.product,
       contractSigned: widget.order.contractSigned,
       paymentDone: widget.order.paymentDone,
       comments: widget.order.comments,

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -215,7 +215,7 @@ class _TasksScreenState extends State<TasksScreen> {
   }
 
   Widget _buildDetailsPanel(OrderModel order, WorkplaceModel stage) {
-    final product = order.products.isNotEmpty ? order.products.first : null;
+    final product = order.product;
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -240,12 +240,10 @@ class _TasksScreenState extends State<TasksScreen> {
                     const SizedBox(height: 16),
                     const Text('Информация о продукте',
                         style: TextStyle(fontWeight: FontWeight.bold)),
-                    if (product != null) ...[
-                      Text('Продукт: ${product.type}'),
-                      Text('Тираж: ${product.quantity} шт.'),
-                      Text(
-                          'Размер: ${product.width}x${product.depth}x${product.height} мм'),
-                    ],
+                    Text('Продукт: ${product.type}'),
+                    Text('Тираж: ${product.quantity} шт.'),
+                    Text(
+                        'Размер: ${product.width}x${product.depth}x${product.height} мм'),
                     Text('Заказчик: ${order.customer}'),
                   ],
                 ),
@@ -635,9 +633,7 @@ class _TaskCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = _statusColor(task.status);
-    final name = order?.products.isNotEmpty == true
-        ? order!.products.first.type
-        : '';
+    final name = order?.product.type ?? '';
     // Показываем идентификатор задания (assignmentId) если он назначен, иначе номер заказа.
     final displayId = order?.assignmentId ?? order?.id ?? task.orderId;
     return Card(


### PR DESCRIPTION
## Summary
- refactor orders to hold a single product instead of a list
- update order creation, editing, and display to use single product
- adjust related modules (tasks, production, analytics) for new model

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a749cdb6188322b9d9379079381455