### PR TITLE
feat: expand product and warehouse models

### DIFF
--- a/lib/modules/orders/material_model.dart
+++ b/lib/modules/orders/material_model.dart
@@ -1,0 +1,33 @@
+/// Модель материала (бумаги), выбираемого из склада.
+/// Содержит основные характеристики, которые подставляются в заказ.
+class MaterialModel {
+  final String id;
+  final String name; // название бумаги
+  final String format; // формат листа или рулона
+  final String grammage; // граммаж
+  final double? weight; // вес, если требуется
+
+  MaterialModel({
+    required this.id,
+    required this.name,
+    required this.format,
+    required this.grammage,
+    this.weight,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'name': name,
+        'format': format,
+        'grammage': grammage,
+        if (weight != null) 'weight': weight,
+      };
+
+  factory MaterialModel.fromMap(Map<String, dynamic> map) => MaterialModel(
+        id: map['id'] as String? ?? '',
+        name: map['name'] as String? ?? '',
+        format: map['format'] as String? ?? '',
+        grammage: map['grammage'] as String? ?? '',
+        weight: (map['weight'] as num?)?.toDouble(),
+      );
+}

--- a/lib/modules/orders/order_model.dart
+++ b/lib/modules/orders/order_model.dart
@@ -1,4 +1,5 @@
 import 'product_model.dart';
+import 'material_model.dart';
 
 /// Статус заказа определяет его стадия обработки.
 enum OrderStatus { newOrder, inWork, completed }
@@ -11,6 +12,22 @@ class OrderModel {
   DateTime dueDate;
   /// Единственный продукт, связанный с заказом.
   ProductModel product;
+  /// Дополнительные параметры изделия, выбранные пользователем.
+  List<String> additionalParams;
+  /// Выбранная ручка. По умолчанию прочерк "-".
+  String handle;
+  /// Выбранный картон. По умолчанию "нет".
+  String cardboard;
+  /// Материал (бумага) из склада.
+  MaterialModel? material;
+  /// Приладка.
+  double makeready;
+  /// ВАЛ.
+  double val;
+  /// Ссылка на прикреплённый PDF-файл.
+  String? pdfUrl;
+  /// Идентификатор выбранного шаблона этапов.
+  String? stageTemplateId;
   bool contractSigned;
   bool paymentDone;
   String comments;
@@ -26,6 +43,14 @@ class OrderModel {
     required this.orderDate,
     required this.dueDate,
     required this.product,
+    this.additionalParams = const [],
+    this.handle = '-',
+    this.cardboard = 'нет',
+    this.material,
+    this.makeready = 0,
+    this.val = 0,
+    this.pdfUrl,
+    this.stageTemplateId,
     this.contractSigned = false,
     this.paymentDone = false,
     this.comments = '',
@@ -41,6 +66,14 @@ class OrderModel {
         'orderDate': orderDate.toIso8601String(),
         'dueDate': dueDate.toIso8601String(),
         'product': product.toMap(),
+        'additionalParams': additionalParams,
+        'handle': handle,
+        'cardboard': cardboard,
+        if (material != null) 'material': material!.toMap(),
+        'makeready': makeready,
+        'val': val,
+        if (pdfUrl != null) 'pdfUrl': pdfUrl,
+        if (stageTemplateId != null) 'stageTemplateId': stageTemplateId,
         'contractSigned': contractSigned,
         'paymentDone': paymentDone,
         'comments': comments,
@@ -60,11 +93,22 @@ class OrderModel {
             map['product'] as Map? ?? const {},
           ),
         ),
+        additionalParams: List<String>.from(map['additionalParams'] as List? ?? const []),
+        handle: map['handle'] as String? ?? '-',
+        cardboard: map['cardboard'] as String? ?? 'нет',
+        material: map['material'] != null
+            ? MaterialModel.fromMap(
+                Map<String, dynamic>.from(map['material'] as Map))
+            : null,
+        makeready: (map['makeready'] as num?)?.toDouble() ?? 0,
+        val: (map['val'] as num?)?.toDouble() ?? 0,
+        pdfUrl: map['pdfUrl'] as String?,
+        stageTemplateId: map['stageTemplateId'] as String?,
         contractSigned: map['contractSigned'] as bool? ?? false,
         paymentDone: map['paymentDone'] as bool? ?? false,
         comments: map['comments'] as String? ?? '',
-        status:
-            OrderStatus.values.byName(map['status'] as String? ?? 'newOrder'),
+        status: OrderStatus.values
+            .byName(map['status'] as String? ?? 'newOrder'),
         assignmentId: map['assignmentId'] as String?,
         assignmentCreated: map['assignmentCreated'] as bool? ?? false,
       );

--- a/lib/modules/products/products_provider.dart
+++ b/lib/modules/products/products_provider.dart
@@ -10,8 +10,20 @@ class ProductsProvider with ChangeNotifier {
     'Тюльпан',
   ];
 
+  /// Дополнительные параметры для изделий (чекбоксы в заказе).
+  final List<String> _parameters = [];
+
+  /// Список возможных ручек.
+  final List<String> _handles = [];
+
   /// Текущий список доступных изделий.
   List<String> get products => List.unmodifiable(_products);
+
+  /// Список дополнительных параметров.
+  List<String> get parameters => List.unmodifiable(_parameters);
+
+  /// Список доступных ручек.
+  List<String> get handles => List.unmodifiable(_handles);
 
   /// Добавляет новое изделие в список.
   void addProduct(String name) {
@@ -30,6 +42,44 @@ class ProductsProvider with ChangeNotifier {
   void removeProduct(int index) {
     if (index < 0 || index >= _products.length) return;
     _products.removeAt(index);
+    notifyListeners();
+  }
+
+  // ----- Дополнительные параметры -----
+
+  void addParameter(String name) {
+    _parameters.add(name);
+    notifyListeners();
+  }
+
+  void updateParameter(int index, String name) {
+    if (index < 0 || index >= _parameters.length) return;
+    _parameters[index] = name;
+    notifyListeners();
+  }
+
+  void removeParameter(int index) {
+    if (index < 0 || index >= _parameters.length) return;
+    _parameters.removeAt(index);
+    notifyListeners();
+  }
+
+  // ----- Ручки -----
+
+  void addHandle(String name) {
+    _handles.add(name);
+    notifyListeners();
+  }
+
+  void updateHandle(int index, String name) {
+    if (index < 0 || index >= _handles.length) return;
+    _handles[index] = name;
+    notifyListeners();
+  }
+
+  void removeHandle(int index) {
+    if (index < 0 || index >= _handles.length) return;
+    _handles.removeAt(index);
     notifyListeners();
   }
 }

--- a/lib/modules/warehouse/paper_table.dart
+++ b/lib/modules/warehouse/paper_table.dart
@@ -59,6 +59,9 @@ class _PaperTableState extends State<PaperTable> {
                       columns: const [
                         DataColumn(label: Text('№')),
                         DataColumn(label: Text('Наименование')),
+                        DataColumn(label: Text('Формат')),
+                        DataColumn(label: Text('Грамаж')),
+                        DataColumn(label: Text('Вес')),
                         DataColumn(label: Text('Количество')),
                         DataColumn(label: Text('Ед.')),
                         DataColumn(label: Text('Действия')),
@@ -70,6 +73,9 @@ class _PaperTableState extends State<PaperTable> {
                           return DataRow(cells: [
                             DataCell(Text('${index + 1}')),
                             DataCell(Text(item.description)),
+                            DataCell(Text(item.format ?? '')),
+                            DataCell(Text(item.grammage ?? '')),
+                            DataCell(Text(item.weight?.toString() ?? '')),
                             DataCell(Text(item.quantity.toString())),
                             DataCell(Text(item.unit)),
                             DataCell(Row(

--- a/lib/modules/warehouse/tmc_model.dart
+++ b/lib/modules/warehouse/tmc_model.dart
@@ -6,6 +6,9 @@ class TmcModel {
   final String description;
   final double quantity;
   final String unit;
+  final String? format; // для бумаги
+  final String? grammage; // граммаж бумаги
+  final double? weight; // вес бумаги
   final String? note;
   /// URL изображения, если для записи загрузили фото (например, для красок).
   final String? imageUrl;
@@ -21,6 +24,9 @@ class TmcModel {
     required this.description,
     required this.quantity,
     required this.unit,
+    this.format,
+    this.grammage,
+    this.weight,
     this.note,
     this.imageUrl,
     this.imageBase64,
@@ -36,6 +42,9 @@ class TmcModel {
       description: map['description'] ?? '',
       quantity: (map['quantity'] as num).toDouble(),
       unit: map['unit'] ?? '',
+      format: map['format'],
+      grammage: map['grammage'],
+      weight: (map['weight'] as num?)?.toDouble(),
       note: map['note'],
       imageUrl: map['imageUrl'],
       imageBase64: map['imageBase64'],
@@ -52,6 +61,9 @@ class TmcModel {
       'description': description,
       'quantity': quantity,
       'unit': unit,
+      if (format != null) 'format': format,
+      if (grammage != null) 'grammage': grammage,
+      if (weight != null) 'weight': weight,
       'note': note,
       if (imageUrl != null) 'imageUrl': imageUrl,
       if (imageBase64 != null) 'imageBase64': imageBase64,

--- a/lib/modules/warehouse/warehouse_provider.dart
+++ b/lib/modules/warehouse/warehouse_provider.dart
@@ -48,6 +48,9 @@ class WarehouseProvider with ChangeNotifier {
         description: m['description'] as String,
         quantity: (m['quantity'] as num?)?.toDouble() ?? 0.0,
         unit: m['unit'] as String,
+        format: m['format'] as String?,
+        grammage: m['grammage'] as String?,
+        weight: (m['weight'] as num?)?.toDouble(),
         note: m['note'] as String?,
         imageUrl: m['imageUrl'] as String?,
         // поле в модели оставлено для обратной совместимости
@@ -81,6 +84,9 @@ class WarehouseProvider with ChangeNotifier {
     required double quantity,
     required String unit,
     String? note,
+    String? format,
+    String? grammage,
+    double? weight,
 
     Uint8List? imageBytes,
     String imageContentType = 'image/jpeg',
@@ -120,6 +126,9 @@ class WarehouseProvider with ChangeNotifier {
       'description': description,
       'quantity': quantity,
       'unit': unit,
+      if (format != null) 'format': format,
+      if (grammage != null) 'grammage': grammage,
+      if (weight != null) 'weight': weight,
       'note': note,
       if (finalImageUrl != null) 'imageUrl': finalImageUrl,
     };
@@ -149,6 +158,9 @@ class WarehouseProvider with ChangeNotifier {
     double? quantity,
     String? supplier,
     String? note,
+    String? format,
+    String? grammage,
+    double? weight,
 
     Uint8List? imageBytes,
     String imageContentType = 'image/jpeg',
@@ -161,6 +173,9 @@ class WarehouseProvider with ChangeNotifier {
     if (quantity != null) updates['quantity'] = quantity;
     if (supplier != null) updates['supplier'] = supplier;
     if (note != null) updates['note'] = note;
+    if (format != null) updates['format'] = format;
+    if (grammage != null) updates['grammage'] = grammage;
+    if (weight != null) updates['weight'] = weight;
 
     // Вычисляем новый imageUrl (если что-то из картинки передали)
     String? finalImageUrl = imageUrl;
@@ -199,6 +214,9 @@ class WarehouseProvider with ChangeNotifier {
         description: updates['description'] ?? prev.description,
         quantity: (updates['quantity'] as double?) ?? prev.quantity,
         unit: updates['unit'] ?? prev.unit,
+        format: updates['format'] ?? prev.format,
+        grammage: updates['grammage'] ?? prev.grammage,
+        weight: (updates['weight'] as double?) ?? prev.weight,
         note: updates['note'] ?? prev.note,
         imageUrl: updates['imageUrl'] ?? prev.imageUrl,
         imageBase64: prev.imageBase64,

--- a/test/products_provider_test.dart
+++ b/test/products_provider_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/products/products_provider.dart';
+
+void main() {
+  test('manage parameters and handles', () {
+    final provider = ProductsProvider();
+    provider.addParameter('ламинат');
+    provider.addHandle('верёвочная');
+    expect(provider.parameters, contains('ламинат'));
+    expect(provider.handles, contains('верёвочная'));
+    provider.updateParameter(0, 'тиснение');
+    provider.updateHandle(0, 'пластиковая');
+    expect(provider.parameters.first, 'тиснение');
+    expect(provider.handles.first, 'пластиковая');
+    provider.removeParameter(0);
+    provider.removeHandle(0);
+    expect(provider.parameters, isEmpty);
+    expect(provider.handles, isEmpty);
+  });
+}

--- a/test/tmc_model_test.dart
+++ b/test/tmc_model_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/warehouse/tmc_model.dart';
+
+void main() {
+  test('TmcModel serializes new paper fields', () {
+    final model = TmcModel(
+      id: '1',
+      date: '2024-01-01',
+      type: 'Бумага',
+      description: 'Тест',
+      quantity: 10,
+      unit: 'м',
+      format: 'A4',
+      grammage: '80',
+      weight: 5,
+    );
+    final map = model.toMap();
+    expect(map['format'], 'A4');
+    expect(map['grammage'], '80');
+    expect(map['weight'], 5);
+    final decoded = TmcModel.fromMap(map);
+    expect(decoded.format, 'A4');
+    expect(decoded.grammage, '80');
+    expect(decoded.weight, 5);
+  });
+}


### PR DESCRIPTION
## Summary
- extend order model with material selection and additional parameters
- manage extra product parameters and handles in ProductsProvider
- capture paper format, grammage and weight in warehouse inventory

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a792f7c6408322905b8f3b97e78076