### PR TITLE
feat: add material fields and pdf attachment

### DIFF
--- a/lib/modules/orders/product_model.dart
+++ b/lib/modules/orders/product_model.dart
@@ -7,6 +7,10 @@ class ProductModel {
   double height;
   double depth;
   String parameters; // параметры продукта (строка)
+  double? roll;
+  double? widthB;
+  double? length;
+  double? leftover;
 
   ProductModel({
     required this.id,
@@ -16,6 +20,10 @@ class ProductModel {
     required this.height,
     required this.depth,
     this.parameters = '',
+    this.roll,
+    this.widthB,
+    this.length,
+    this.leftover,
   });
 
   /// Преобразует модель продукта в Map.
@@ -27,6 +35,10 @@ class ProductModel {
         'height': height,
         'depth': depth,
         'parameters': parameters,
+        if (roll != null) 'roll': roll,
+        if (widthB != null) 'widthB': widthB,
+        if (length != null) 'length': length,
+        if (leftover != null) 'leftover': leftover,
       };
 
   /// Создаёт [ProductModel] из Map.
@@ -38,5 +50,9 @@ class ProductModel {
         height: (map['height'] as num?)?.toDouble() ?? 0,
         depth: (map['depth'] as num?)?.toDouble() ?? 0,
         parameters: map['parameters'] as String? ?? '',
+        roll: (map['roll'] as num?)?.toDouble(),
+        widthB: (map['widthB'] as num?)?.toDouble(),
+        length: (map['length'] as num?)?.toDouble(),
+        leftover: (map['leftover'] as num?)?.toDouble(),
       );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -464,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  open_filex:
+    dependency: "direct main"
+    description:
+      name: open_filex
+      sha256: a6c95237767c5647e68b71a476602fcf4f1bfc530c126265e53addae22ef5fc2
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.4"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   record: ^6.1.0
   audioplayers: ^6.5.0
   url_launcher: ^6.3.2
+  open_filex: ^4.3.4
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add open_filex dependency
- extend product model with roll, width, length and leftover
- enhance order editor with material selection, stock control and PDF attachments

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart format lib/modules/orders/edit_order_screen.dart lib/modules/orders/product_model.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a70c006883228c1caeb729b0207a