### PR TITLE
feat: show grammage in material search

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -663,12 +663,36 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                       final provider =
                           Provider.of<WarehouseProvider>(context, listen: false);
                       final list = provider.getTmcByType('Бумага');
-                      if (text.text.isEmpty) return list;
-                      return list.where((t) => t.description
-                          .toLowerCase()
-                          .contains(text.text.toLowerCase()));
+                      final query = text.text.toLowerCase();
+                      if (query.isEmpty) return list;
+                      return list.where((t) =>
+                          t.description.toLowerCase().contains(query) ||
+                          (t.grammage?.toLowerCase().contains(query) ?? false));
                     },
                     displayStringForOption: (tmc) => tmc.description,
+                    optionsViewBuilder: (context, onSelected, options) {
+                      return Align(
+                        alignment: Alignment.topLeft,
+                        child: Material(
+                          elevation: 4,
+                          child: SizedBox(
+                            height: 200,
+                            child: ListView(
+                              padding: EdgeInsets.zero,
+                              children: options
+                                  .map((tmc) => ListTile(
+                                        title: Text(tmc.description),
+                                        subtitle: tmc.grammage != null && tmc.grammage!.isNotEmpty
+                                            ? Text('Граммаж: ${tmc.grammage}')
+                                            : null,
+                                        onTap: () => onSelected(tmc),
+                                      ))
+                                  .toList(),
+                            ),
+                          ),
+                        ),
+                      );
+                    },
                     fieldViewBuilder:
                         (context, controller, focusNode, onFieldSubmitted) {
                       if (_selectedMaterial?.name != null) {


### PR DESCRIPTION
## Summary
- show paper grammage in material autocomplete suggestions
- allow searching paper by grammage in order editor

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter analyze` *(fails: command not found)*
- `dart format lib/modules/orders/edit_order_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aeb4f90483229c9f27730046ca4c