### PR TITLE
Save stage template to production plan

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -307,6 +307,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         });
       }
 
+      // сохраняем план этапов для отображения в модуле производства
+      await supabase.from('production_plans').upsert({
+        'order_id': createdOrUpdatedOrder.id,
+        'stages': stageMaps,
+      }, onConflict: 'order_id');
+
       // удалим прежние задачи этого заказа, чтобы не было дублей
       await supabase.from('tasks').delete().eq('orderid', createdOrUpdatedOrder.id);
 
@@ -377,8 +383,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           }
         });
       }
+      // сохраняем план этапов
+      await supabase.from('production_plans').upsert({
+        'order_id': createdOrUpdatedOrder.id,
+        'stages': stageMaps,
+      }, onConflict: 'order_id');
       // очищаем старые задания (на случай повторного выбора шаблона)
-      await supabase.from('tasks').delete().eq('orderId', createdOrUpdatedOrder.id);
+      await supabase.from('tasks').delete().eq('orderid', createdOrUpdatedOrder.id);
       // создаём новые задания
       for (final stage in stageMaps) {
         final stageId = stage['stageId'] as String?;


### PR DESCRIPTION
## Summary
- upsert selected stage template into `production_plans` when saving an order
- clear existing tasks with correct column name and recreate tasks from template

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acad9dc65c83228999ce5ecc54f4e0