### PR TITLE
Fix order status registration in order module

### DIFF
--- a/lib/modules/orders/order_model.dart
+++ b/lib/modules/orders/order_model.dart
@@ -62,6 +62,16 @@ class OrderModel {
         status            = status ?? 'newOrder',
         assignmentCreated = assignmentCreated ?? false;
 
+  /// Преобразует строковое поле [status] в [OrderStatus].
+  /// Если получено неизвестное значение, возвращается [OrderStatus.newOrder].
+  OrderStatus get statusEnum => OrderStatus.values.firstWhere(
+        (s) => s.name == status,
+        orElse: () => OrderStatus.newOrder,
+      );
+
+  /// Устанавливает статус, записывая строковое значение в [status].
+  set statusEnum(OrderStatus newStatus) => status = newStatus.name;
+
   /// В БД пишем SNAKE_CASE — соответствует SQL-схеме.
   Map<String, dynamic> toMap() => {
         'id': id,

--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -124,7 +124,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
                             final product = o.product;
                             final totalQty = product.quantity;
                             String statusLabel;
-                            switch (o.status) {
+                            switch (o.statusEnum) {
                               case OrderStatus.inWork:
                                 statusLabel = 'В работе';
                                 break;
@@ -296,13 +296,17 @@ class _OrdersScreenState extends State<OrdersScreen> {
     // Filter by status
     switch (_selectedFilter) {
       case 'new':
-        filtered = filtered.where((o) => o.status == OrderStatus.newOrder).toList();
+        filtered =
+            filtered.where((o) => o.statusEnum == OrderStatus.newOrder).toList();
         break;
       case 'inWork':
-        filtered = filtered.where((o) => o.status == OrderStatus.inWork).toList();
+        filtered =
+            filtered.where((o) => o.statusEnum == OrderStatus.inWork).toList();
         break;
       case 'completed':
-        filtered = filtered.where((o) => o.status == OrderStatus.completed).toList();
+        filtered = filtered
+            .where((o) => o.statusEnum == OrderStatus.completed)
+            .toList();
         break;
       case 'all':
       default:
@@ -580,7 +584,7 @@ void _showSortOptions() {
     // Определяем цвет и текст для статуса
     Color statusColor;
     String statusLabel;
-    switch (order.status) {
+    switch (order.statusEnum) {
       case OrderStatus.inWork:
         statusColor = Colors.orange;
         statusLabel = 'В работе';


### PR DESCRIPTION
## Summary
- convert stored status strings to `OrderStatus` enum via helper getters
- use enum-aware status when filtering and rendering order lists

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb0c7c8f88322b5fc00b1b3d65f4e