### PR TITLE
Handle PDF upload and viewing

### DIFF
--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -82,6 +82,58 @@ Future<String> uploadOrderPdf({
   return objectPath;
 }
 
+/// Загрузка уже выбранного PDF-файла в Supabase Storage.
+/// Принимает [PlatformFile], полученный, например, через FilePicker.
+/// Возвращает [objectPath] загруженного файла.
+Future<String> uploadPickedOrderPdf({
+  required String orderId,
+  required PlatformFile file,
+  String? customFileName,
+}) async {
+  final fileName = customFileName?.trim().isNotEmpty == true
+      ? customFileName!.trim()
+      : (file.name.isNotEmpty ? file.name : 'document.pdf');
+
+  final safeName = fileName.replaceAll(RegExp(r'[^\w\.\-]+'), '_');
+  final objectPath =
+      'orders/$orderId/${DateTime.now().millisecondsSinceEpoch}_$safeName';
+
+  if (file.bytes != null) {
+    await supabase.storage.from(kOrderBucket).uploadBinary(
+          objectPath,
+          file.bytes!,
+          fileOptions: const FileOptions(
+            upsert: true,
+            contentType: 'application/pdf',
+          ),
+        );
+  } else if (file.path != null) {
+    await supabase.storage.from(kOrderBucket).upload(
+          objectPath,
+          File(file.path!),
+          fileOptions: const FileOptions(
+            upsert: true,
+            contentType: 'application/pdf',
+          ),
+        );
+  } else {
+    throw Exception('Не удалось прочитать файл');
+  }
+
+  try {
+    await linkOrderPdf(
+      orderId: orderId,
+      objectPath: objectPath,
+      fileName: safeName,
+      sizeBytes: file.size,
+    );
+  } catch (_) {
+    // файл загружен, метаданные не критичны
+  }
+
+  return objectPath;
+}
+
 /// Запись метаданных в таблицу order_files (создана SQL-скриптом)
 Future<void> linkOrderPdf({
   required String orderId,


### PR DESCRIPTION
## Summary
- Support uploading already picked PDF files to Supabase storage
- Save and update orders with uploaded PDF paths
- Allow opening attached PDFs through signed URLs

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc36e5c58832293db36826f64bb7b