### PR TITLE
feat: emphasize customers and expand order details

### DIFF
--- a/lib/modules/orders/view_order_screen.dart
+++ b/lib/modules/orders/view_order_screen.dart
@@ -1,43 +1,76 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
 import 'order_model.dart';
 
-/// Displays the details of a single order. This is a very basic
-/// implementation that simply lays out a few fields from the order. You can
-/// extend this screen with more information and actions as needed.
+/// Расширенный экран просмотра заказа. Показывает всю информацию,
+/// доступную в модуле оформления заказа, с акцентом на заказчика.
 class ViewOrderScreen extends StatelessWidget {
   final OrderModel order;
 
   const ViewOrderScreen({super.key, required this.order});
 
+  String _formatDate(DateTime date) => DateFormat('dd.MM.yyyy').format(date);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Заказ ${order.id}'),
+        title: Text(order.customer),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Клиент: ${order.customer}'),
-              const SizedBox(height: 8),
-              Text('Дата заказа: ${order.orderDate.toIso8601String()}'),
-              const SizedBox(height: 8),
-              Text('Срок: ${order.dueDate.toIso8601String()}'),
-              const SizedBox(height: 8),
-              // ProductModel uses `type` as a name/description field
-              Text('Продукт: ${order.product.type}'),
-              const SizedBox(height: 8),
-              Text('Количество доп. параметров: ${order.additionalParams.length}'),
-              const SizedBox(height: 8),
-              Text('Материал: ${order.material?.name ?? '—'}'),
-              // You can continue to display other fields if needed
-            ],
-          ),
-        ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _sectionTitle('Основная информация'),
+          _infoTile('ID заказа', order.id, Icons.confirmation_number_outlined),
+          _infoTile('Дата заказа', _formatDate(order.orderDate), Icons.event),
+          _infoTile('Срок', _formatDate(order.dueDate), Icons.event_note),
+          _infoTile('Статус', order.status, Icons.flag),
+          const SizedBox(height: 16),
+
+          _sectionTitle('Изделие'),
+          _infoTile('Тип', order.product.type, Icons.widgets_outlined),
+          _infoTile('Тираж', '${order.product.quantity}', Icons.layers),
+          if (order.additionalParams.isNotEmpty)
+            _infoTile('Доп. параметры', order.additionalParams.join(', '), Icons.list),
+          const SizedBox(height: 16),
+
+          _sectionTitle('Материалы'),
+          _infoTile('Ручка', order.handle, Icons.pan_tool_outlined),
+          _infoTile('Картон', order.cardboard, Icons.style_outlined),
+          _infoTile('Материал', order.material?.name ?? '—', Icons.inventory_2_outlined),
+          _infoTile('Макулатура', order.makeready.toString(), Icons.calculate_outlined),
+          _infoTile('Стоимость', order.val.toString(), Icons.attach_money),
+          const SizedBox(height: 16),
+
+          _sectionTitle('Дополнительно'),
+          _infoTile('Договор подписан', order.contractSigned ? 'Да' : 'Нет', Icons.assignment_turned_in_outlined),
+          _infoTile('Оплата получена', order.paymentDone ? 'Да' : 'Нет', Icons.payment_outlined),
+          if (order.pdfUrl != null)
+            _infoTile('PDF', order.pdfUrl!, Icons.picture_as_pdf_outlined),
+          if (order.comments.isNotEmpty)
+            _infoTile('Комментарии', order.comments, Icons.comment_outlined),
+        ],
       ),
+    );
+  }
+
+  Widget _sectionTitle(String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        text,
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  Widget _infoTile(String label, String value, IconData icon) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(icon, color: Colors.blueGrey),
+      title: Text(label, style: const TextStyle(fontSize: 14, color: Colors.black54)),
+      subtitle: Text(value, style: const TextStyle(fontSize: 14, color: Colors.black)),
     );
   }
 }

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -212,7 +212,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('Производственное задание №${widget.order.assignmentId ?? widget.order.id}'),
+        title: Text(widget.order.customer),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).pop(),
@@ -243,19 +243,19 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(widget.order.assignmentId ?? widget.order.id,
+                          Text(widget.order.customer,
                               style: const TextStyle(
                                   fontSize: 20, fontWeight: FontWeight.bold)),
                           const SizedBox(height: 4),
                           Text(
-                            widget.order.product.type,
-                            style: const TextStyle(fontSize: 16),
+                            widget.order.assignmentId ?? widget.order.id,
+                            style: TextStyle(
+                                color: Colors.grey.shade600, fontSize: 14),
                           ),
                           const SizedBox(height: 2),
                           Text(
-                            widget.order.customer,
-                            style: TextStyle(
-                                color: Colors.grey.shade600, fontSize: 14),
+                            widget.order.product.type,
+                            style: const TextStyle(fontSize: 16),
                           ),
                           const SizedBox(height: 8),
                           Row(

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -302,7 +302,7 @@ class _ProductionScreenState extends State<ProductionScreen>
                   children: [
                     Expanded(
                       child: Text(
-                        displayId,
+                        order.customer,
                         style: const TextStyle(
                           fontWeight: FontWeight.bold,
                           fontSize: 16,
@@ -324,17 +324,16 @@ class _ProductionScreenState extends State<ProductionScreen>
                   ],
                 ),
                 const SizedBox(height: 4),
+                Text(
+                  displayId,
+                  style: TextStyle(color: Colors.grey.shade700, fontSize: 12),
+                ),
+                const SizedBox(height: 2),
                 if (productDesc.isNotEmpty)
                   Text(
                     productDesc,
                     style: const TextStyle(fontSize: 14),
                   ),
-                const SizedBox(height: 2),
-                // заказчик
-                Text(
-                  order.customer,
-                  style: TextStyle(color: Colors.grey.shade600, fontSize: 12),
-                ),
                 const SizedBox(height: 8),
                 Row(
                   children: [


### PR DESCRIPTION
## Summary
- show complete order details in dedicated view with customer-focused design
- highlight customers ahead of orders in production screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd5e6d3d08322b70bff763b275193