### PR TITLE
Group orders by customer and extend details

### DIFF
--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -193,12 +193,38 @@ class _OrdersScreenState extends State<OrdersScreen> {
                       ),
                     );
                   } else {
+                    final Map<String, List<OrderModel>> ordersByCustomer = {};
+                    for (final o in orders) {
+                      ordersByCustomer.putIfAbsent(o.customer, () => []).add(o);
+                    }
                     return SingleChildScrollView(
-                      child: Wrap(
-                        spacing: 12,
-                        runSpacing: 12,
-                        children:
-                            orders.map((o) => _buildOrderCard(o, tasks)).toList(),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: ordersByCustomer.entries.map((entry) {
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  entry.key,
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Wrap(
+                                  spacing: 12,
+                                  runSpacing: 12,
+                                  children: entry.value
+                                      .map((o) => _buildOrderCard(o, tasks))
+                                      .toList(),
+                                ),
+                              ],
+                            ),
+                          );
+                        }).toList(),
                       ),
                     );
                   }
@@ -672,26 +698,49 @@ void _showSortOptions() {
               const SizedBox(height: 2),
               Text('Тираж: $totalQty шт.', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
               const SizedBox(height: 6),
-              // Статусы договора и оплаты
-              Row(
-                children: [
-                  Row(
-                    children: [
-                      Icon(order.contractSigned ? Icons.check_circle_outline : Icons.error_outline, size: 16, color: order.contractSigned ? Colors.green : Colors.red),
-                      const SizedBox(width: 4),
-                      Text(order.contractSigned ? 'Договор подписан' : 'Договор не подписан', style: TextStyle(fontSize: 11, color: order.contractSigned ? Colors.green : Colors.red)),
-                    ],
+              // Дополнительная информация о заказе
+              if (order.additionalParams.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(
+                    'Доп. параметры: ${order.additionalParams.join(', ')}',
+                    style: const TextStyle(fontSize: 11),
                   ),
-                  const SizedBox(width: 8),
-                  Row(
-                    children: [
-                      Icon(order.paymentDone ? Icons.check_circle_outline : Icons.error_outline, size: 16, color: order.paymentDone ? Colors.green : Colors.red),
-                      const SizedBox(width: 4),
-                      Text(order.paymentDone ? 'Оплачено' : 'Не оплачено', style: TextStyle(fontSize: 11, color: order.paymentDone ? Colors.green : Colors.red)),
-                    ],
-                  ),
-                ],
+                ),
+              if (order.handle.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text('Ручка: ${order.handle}',
+                      style: const TextStyle(fontSize: 11)),
+                ),
+              if (order.cardboard.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text('Картон: ${order.cardboard}',
+                      style: const TextStyle(fontSize: 11)),
+                ),
+              if (order.material != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text('Материал: ${order.material!.name}',
+                      style: const TextStyle(fontSize: 11)),
+                ),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text('Макулатура: ${order.makeready}',
+                    style: const TextStyle(fontSize: 11)),
               ),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child:
+                    Text('Стоимость: ${order.val}', style: const TextStyle(fontSize: 11)),
+              ),
+              if (order.comments.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text('Комментарии: ${order.comments}',
+                      style: const TextStyle(fontSize: 11)),
+                ),
               const SizedBox(height: 8),
               // Кнопки действий
               Wrap(

--- a/lib/modules/orders/view_order_screen.dart
+++ b/lib/modules/orders/view_order_screen.dart
@@ -44,8 +44,6 @@ class ViewOrderScreen extends StatelessWidget {
           const SizedBox(height: 16),
 
           _sectionTitle('Дополнительно'),
-          _infoTile('Договор подписан', order.contractSigned ? 'Да' : 'Нет', Icons.assignment_turned_in_outlined),
-          _infoTile('Оплата получена', order.paymentDone ? 'Да' : 'Нет', Icons.payment_outlined),
           if (order.pdfUrl != null)
             _infoTile('PDF', order.pdfUrl!, Icons.picture_as_pdf_outlined),
           if (order.comments.isNotEmpty)

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -261,143 +261,148 @@ class _ProductionScreenState extends State<ProductionScreen>
     if (filtered.isEmpty) {
       return const Center(child: Text('Задания отсутствуют'));
     }
-    return ListView.builder(
+    final Map<String, List<OrderModel>> byCustomer = {};
+    for (final o in filtered) {
+      byCustomer.putIfAbsent(o.customer, () => []).add(o);
+    }
+    return ListView(
       padding: const EdgeInsets.all(8),
-      itemCount: filtered.length,
-      itemBuilder: (context, index) {
-        final order = filtered[index];
-        // Если для заказа создано производственное задание, отображаем его id (ЗК-...).
-        final displayId = order.assignmentId ?? order.id;
-        final orderTasks = tasksByOrder[order.id] ?? const [];
-        final aggStatus = _computeAggregatedStatus(orderTasks);
-        final color = _statusColors[aggStatus] ?? Colors.grey;
-        final label = _statusLabels[aggStatus] ?? '';
-        final product = order.product;
-        final productDesc = product.type;
-        final qty = '${product.quantity} шт.';
-        final due = dateFormat.format(order.dueDate);
-        // Вычисляем последний комментарий для заказа. Используется для
-        // отображения причины паузы или проблемы, если такая есть.
-        String? lastComment;
-        String? lastCommentType;
-        int lastTimestamp = 0;
-        for (final task in orderTasks) {
-          for (final c in task.comments) {
-            if (c.timestamp > lastTimestamp) {
-              lastTimestamp = c.timestamp;
-              lastComment = c.text;
-              lastCommentType = c.type;
+      children: byCustomer.entries.expand((entry) {
+        return [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            child: Text(
+              entry.key,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+          ),
+          ...entry.value.map((order) {
+            final displayId = order.assignmentId ?? order.id;
+            final orderTasks = tasksByOrder[order.id] ?? const [];
+            final aggStatus = _computeAggregatedStatus(orderTasks);
+            final color = _statusColors[aggStatus] ?? Colors.grey;
+            final label = _statusLabels[aggStatus] ?? '';
+            final product = order.product;
+            final productDesc = product.type;
+            final qty = '${product.quantity} шт.';
+            final due = dateFormat.format(order.dueDate);
+            String? lastComment;
+            String? lastCommentType;
+            int lastTimestamp = 0;
+            for (final task in orderTasks) {
+              for (final c in task.comments) {
+                if (c.timestamp > lastTimestamp) {
+                  lastTimestamp = c.timestamp;
+                  lastComment = c.text;
+                  lastCommentType = c.type;
+                }
+              }
             }
-          }
-        }
-        return Card(
-          margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
+            return Card(
+              margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Text(
-                        order.customer,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                        ),
-                      ),
-                    ),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: color.withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Text(
-                        label,
-                        style: TextStyle(color: color, fontSize: 12),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  displayId,
-                  style: TextStyle(color: Colors.grey.shade700, fontSize: 12),
-                ),
-                const SizedBox(height: 2),
-                if (productDesc.isNotEmpty)
-                  Text(
-                    productDesc,
-                    style: const TextStyle(fontSize: 14),
-                  ),
-                const SizedBox(height: 8),
-                Row(
-                  children: [
-                    if (qty.isNotEmpty) ...[
-                      const Icon(Icons.layers, size: 16, color: Colors.grey),
-                      const SizedBox(width: 4),
-                      Text(qty),
-                      const SizedBox(width: 16),
-                    ],
-                    const Icon(Icons.calendar_today, size: 16, color: Colors.grey),
-                    const SizedBox(width: 4),
-                    Text('до $due'),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                // Если есть комментарий (причина проблемы или паузы), выводим его
-                if (lastComment != null &&
-                    (aggStatus == _AggregatedStatus.problem ||
-                        aggStatus == _AggregatedStatus.paused))
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 8.0),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+                    Row(
                       children: [
-                        Icon(
-                          lastCommentType == 'problem'
-                              ? Icons.error_outline
-                              : Icons.pause_circle_outline,
-                          size: 16,
-                          color: lastCommentType == 'problem'
-                              ? Colors.redAccent
-                              : Colors.orange,
-                        ),
-                        const SizedBox(width: 4),
                         Expanded(
                           child: Text(
-                            lastComment!,
-                            style: const TextStyle(
-                                fontSize: 12, color: Colors.black87),
+                            displayId,
+                            style: TextStyle(
+                              color: Colors.grey.shade700,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
+                        Container(
+                          padding:
+                              const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: color.withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            label,
+                            style: TextStyle(color: color, fontSize: 12),
                           ),
                         ),
                       ],
                     ),
-                  ),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton(
-                    onPressed: () {
-                      // Открыть страницу подробностей заказа
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => ProductionDetailsScreen(order: order),
+                    const SizedBox(height: 4),
+                    if (productDesc.isNotEmpty)
+                      Text(
+                        productDesc,
+                        style: const TextStyle(fontSize: 14),
+                      ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        if (qty.isNotEmpty) ...[
+                          const Icon(Icons.layers, size: 16, color: Colors.grey),
+                          const SizedBox(width: 4),
+                          Text(qty),
+                          const SizedBox(width: 16),
+                        ],
+                        const Icon(Icons.calendar_today,
+                            size: 16, color: Colors.grey),
+                        const SizedBox(width: 4),
+                        Text('до $due'),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    if (lastComment != null &&
+                        (aggStatus == _AggregatedStatus.problem ||
+                            aggStatus == _AggregatedStatus.paused))
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 8.0),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Icon(
+                              lastCommentType == 'problem'
+                                  ? Icons.error_outline
+                                  : Icons.pause_circle_outline,
+                              size: 16,
+                              color: lastCommentType == 'problem'
+                                  ? Colors.redAccent
+                                  : Colors.orange,
+                            ),
+                            const SizedBox(width: 4),
+                            Expanded(
+                              child: Text(
+                                lastComment!,
+                                style: const TextStyle(
+                                    fontSize: 12, color: Colors.black87),
+                              ),
+                            ),
+                          ],
                         ),
-                      );
-                    },
-                    child: const Text('Подробнее'),
-                  ),
+                      ),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) =>
+                                  ProductionDetailsScreen(order: order),
+                            ),
+                          );
+                        },
+                        child: const Text('Подробнее'),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
-          ),
-        );
-      },
+              ),
+            );
+          }),
+        ];
+      }).toList(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- group order cards by customer
- show full order details except contract and payment
- group production orders by customer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acdb0a516c832281d4dd1c35f4ca01