### PR TITLE
Fix async login action and missing provider import

### DIFF
--- a/lib/admin_panel.dart
+++ b/lib/admin_panel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'modules/products/products_screen.dart';
 import 'modules/production_planning/production_planning_screen.dart';

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -271,7 +271,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   child: const Text('Отмена'),
                 ),
                 ElevatedButton(
-                  onPressed: () {
+                  onPressed: () async {
                     final password = controller.text.trim();
                     if (password == user.password) {
                       // Запоминаем пользователя в AuthHelper


### PR DESCRIPTION
## Summary
- Allow login dialog to await analytics logging by making button handler async
- Import Provider package so Admin panel can use `context.read`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acedafd7b48322903313e7cbbe8387