### PR TITLE
Add logout buttons and refresh orders/tasks

### DIFF
--- a/lib/modules/manager/manager_workspace_screen.dart
+++ b/lib/modules/manager/manager_workspace_screen.dart
@@ -5,6 +5,9 @@ import '../orders/orders_screen.dart';
 import '../chat/chat_tab.dart';
 import '../personnel/personnel_provider.dart';
 import '../personnel/employee_model.dart';
+import '../analytics/analytics_provider.dart';
+import '../../utils/auth_helper.dart';
+import '../../login_screen.dart';
 
 class ManagerWorkspaceScreen extends StatelessWidget {
   final String employeeId;
@@ -40,6 +43,28 @@ class ManagerWorkspaceScreen extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           title: Text(fio.isEmpty ? 'Менеджер' : '$fio • Менеджер'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.logout),
+              tooltip: 'Выйти',
+              onPressed: () async {
+                final analytics = context.read<AnalyticsProvider>();
+                await analytics.logEvent(
+                  orderId: '',
+                  stageId: '',
+                  userId: emp.id,
+                  action: 'logout',
+                  category: 'manager',
+                );
+                AuthHelper.clear();
+                if (!context.mounted) return;
+                Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (_) => const LoginScreen()),
+                  (route) => false,
+                );
+              },
+            ),
+          ],
           bottom: const TabBar(
             tabs: [
               Tab(text: 'Заказы', icon: Icon(Icons.assignment)),

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -14,6 +14,7 @@ import '../products/products_provider.dart';
 import '../production_planning/template_provider.dart';
 import '../warehouse/warehouse_provider.dart';
 import '../warehouse/tmc_model.dart';
+import '../tasks/task_provider.dart';
 /// Экран редактирования или создания заказа.
 /// Если [order] передан, экран открывается для редактирования существующего заказа.
 class EditOrderScreen extends StatefulWidget {
@@ -375,6 +376,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         assignmentCreated: true,
       );
       await provider.updateOrder(withAssignment);
+      await provider.refresh();
+      await context.read<TaskProvider>().refresh();
       createdOrUpdatedOrder = withAssignment;
     }
   }
@@ -450,6 +453,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         assignmentCreated: true,
       );
       await provider.updateOrder(orderWithAssignment);
+      await provider.refresh();
+      await context.read<TaskProvider>().refresh();
     }
   }
 

--- a/lib/modules/warehouse_manager/warehouse_manager_workspace_screen.dart
+++ b/lib/modules/warehouse_manager/warehouse_manager_workspace_screen.dart
@@ -5,6 +5,9 @@ import '../warehouse/warehouse_screen.dart';
 import '../chat/chat_tab.dart';
 import '../personnel/personnel_provider.dart';
 import '../personnel/employee_model.dart';
+import '../analytics/analytics_provider.dart';
+import '../../utils/auth_helper.dart';
+import '../../login_screen.dart';
 
 class WarehouseManagerWorkspaceScreen extends StatelessWidget {
   final String employeeId;
@@ -41,6 +44,28 @@ class WarehouseManagerWorkspaceScreen extends StatelessWidget {
         appBar: AppBar(
           title: Text(
               fio.isEmpty ? 'Заведующий складом' : '$fio • Заведующий складом'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.logout),
+              tooltip: 'Выйти',
+              onPressed: () async {
+                final analytics = context.read<AnalyticsProvider>();
+                await analytics.logEvent(
+                  orderId: '',
+                  stageId: '',
+                  userId: emp.id,
+                  action: 'logout',
+                  category: 'warehouse',
+                );
+                AuthHelper.clear();
+                if (!context.mounted) return;
+                Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (_) => const LoginScreen()),
+                  (route) => false,
+                );
+              },
+            ),
+          ],
           bottom: const TabBar(
             tabs: [
               Tab(text: 'Склад', icon: Icon(Icons.warehouse)),


### PR DESCRIPTION
## Summary
- add logout actions for manager and warehouse roles with analytics
- refresh orders and tasks providers after creating assignments
- introduce provider refresh methods for realtime UI updates

## Testing
- `dart format lib/modules/manager/manager_workspace_screen.dart lib/modules/warehouse_manager/warehouse_manager_workspace_screen.dart lib/modules/tasks/task_provider.dart lib/modules/orders/orders_provider.dart lib/modules/orders/edit_order_screen.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*
- `dart analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0c5eb11c8322940cc4f0cb8496a9