### PR TITLE
Use documents table across remaining modules

### DIFF
--- a/lib/admin_panel.dart
+++ b/lib/admin_panel.dart
@@ -53,15 +53,15 @@ class _AdminPanelScreenState extends State<AdminPanelScreen> {
         final String? email = user.email as String?;
         final String? uid = user.id as String?;
 
-        // Ищем по login = email ИЛИ по id = uid
         final rows = await client
-            .from('employees')
-            .select('firstName, lastName, patronymic, login, id')
-            .or('login.eq.${email ?? ''},id.eq.${uid ?? ''}')
+            .from('documents')
+            .select('id, data')
+            .eq('collection', 'employees')
+            .or('data->>login.eq.${email ?? ''},data->>userId.eq.${uid ?? ''}')
             .limit(1);
 
         if (rows is List && rows.isNotEmpty) {
-          final r = Map<String, dynamic>.from(rows.first);
+          final r = Map<String, dynamic>.from(rows.first['data'] ?? {});
           final last = (r['lastName'] ?? '').toString().trim();
           final first = (r['firstName'] ?? '').toString().trim();
           final patr = (r['patronymic'] ?? '').toString().trim();

--- a/lib/data/employee_repository.dart
+++ b/lib/data/employee_repository.dart
@@ -1,6 +1,6 @@
-import 'package:supabase_flutter/supabase_flutter.dart';
+import '../services/doc_db.dart';
 
-final _supabase = Supabase.instance.client;
+final _docDb = DocDB();
 
 class EmployeeRepository {
   Future<void> addEmployee({
@@ -12,30 +12,33 @@ class EmployeeRepository {
     bool isTechLeader = false,
     List<String> positionIds = const [],
   }) async {
-    await _supabase.from('employees').insert({
-      'user_id': userId,
-      'first_name': firstName,
-      'last_name': lastName,
+    await _docDb.insert('employees', {
+      'userId': userId,
+      'firstName': firstName,
+      'lastName': lastName,
       'patronymic': patronymic,
       'iin': iin,
-      'is_tech_leader': isTechLeader,
-      'position_ids': positionIds,
+      'isTechLeader': isTechLeader,
+      'positionIds': positionIds,
     });
   }
 
   Future<List<Map<String, dynamic>>> fetchEmployees() async {
-    final rows = await _supabase
-        .from('employees')
-        .select()
-        .order('created_at', ascending: false);
-    return List<Map<String, dynamic>>.from(rows);
+    final rows = await _docDb.list('employees');
+    return rows
+        .map((row) {
+          final data = Map<String, dynamic>.from(row['data'] ?? {});
+          data['id'] = row['id'];
+          return data;
+        })
+        .toList();
   }
 
   Future<void> updateEmployee(String id, Map<String, dynamic> patch) async {
-    await _supabase.from('employees').update(patch).eq('id', id);
+    await _docDb.patchById(id, patch);
   }
 
   Future<void> deleteEmployee(String id) async {
-    await _supabase.from('employees').delete().eq('id', id);
+    await _docDb.deleteById(id);
   }
 }

--- a/lib/modules/personnel/add_employee_screen.dart
+++ b/lib/modules/personnel/add_employee_screen.dart
@@ -4,6 +4,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:uuid/uuid.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:file_picker/file_picker.dart';
+import '../../services/doc_db.dart';
 
 class AddEmployeeScreen extends StatefulWidget {
   const AddEmployeeScreen({super.key});
@@ -124,23 +125,33 @@ class _AddEmployeeScreenState extends State<AddEmployeeScreen> {
       final id = const Uuid().v4();
 
       final filePath = 'employee_photos/$id.jpg';
-      await client.storage.from('employee_photos').upload(filePath, _selectedImage!);
-      final photoUrl = client.storage.from('employee_photos').getPublicUrl(filePath);
+      await client.storage
+          .from('employee_photos')
+          .upload(filePath, _selectedImage!);
+      final photoUrl =
+          client.storage.from('employee_photos').getPublicUrl(filePath);
 
-      await client.from('employees').insert({
-        'id': id,
-        'lastName': lastName,
-        'firstName': firstName,
-        'patronymic': patronymic,
-        'iin': iin,
-        'photoUrl': photoUrl,
-        'positionIds': _positionIds,
-        'isFired': false,
-        'comments': comments,
-        'login': login,
-        'password': password,
+      final docDb = DocDB();
+      await docDb.insert(
+        'employees',
+        {
+          'lastName': lastName,
+          'firstName': firstName,
+          'patronymic': patronymic,
+          'iin': iin,
+          'photoUrl': photoUrl,
+          'positionIds': _positionIds,
+          'isFired': false,
+          'comments': comments,
+          'login': login,
+          'password': password,
+        },
+        explicitId: id,
+      );
+      await docDb.insert('workspaces', {
+        'employee_id': id,
+        'tasks': [],
       });
-      await client.from('workspaces').insert({'employee_id': id, 'tasks': []});
 
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Сотрудник успешно добавлен')),

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import '../../services/doc_db.dart';
 
 import '../orders/order_model.dart';
 import '../tasks/task_model.dart';
@@ -66,16 +66,13 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
   Future<void> _loadPlan() async {
     
     try {
-      final data = await Supabase.instance.client
-          .from('production_plans')
-          .select()
-          .eq('order_id', widget.order.id)
-          .maybeSingle();
+      final rows =
+          await DocDB().whereEq('production_plans', 'order_id', widget.order.id);
       List<PlannedStage> stages = [];
-      if (data != null) {
+      if (rows.isNotEmpty) {
+        final data = Map<String, dynamic>.from(rows.first['data'] ?? {});
         final value = data['stages'];
         stages = decodePlannedStages(value);
-      
       }
       if (mounted) {
         setState(() {
@@ -84,7 +81,6 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
         });
       }
     } catch (_) {
-      // В случае ошибки загрузки просто выставляем пустой список
       if (mounted) {
         setState(() {
           _plannedStages = [];

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -2,9 +2,11 @@
 import 'dart:io' show File;
 import 'package:file_picker/file_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'doc_db.dart';
 
 /// Единый клиент Supabase
 final supabase = Supabase.instance.client;
+final DocDB _docDb = DocDB();
 
 /// Имя приватного бакета
 const String kOrderBucket = 'order-attachments';
@@ -125,20 +127,17 @@ Future<Map<String, dynamic>> linkOrderPdf({
   _ensureAuthed();
 
   final userId = supabase.auth.currentUser!.id;
-  final rows = await supabase
-      .from('order_files')
-      .upsert({
-        'order_id': orderId,
-        'object_path': objectPath, // должен быть UNIQUE
-        'filename': fileName,
-        'mime_type': 'application/pdf',
-        'size_bytes': sizeBytes,
-        'created_by': userId,
-      }, onConflict: 'object_path')
-      .select()
-      .single();
-
-  return (rows as Map<String, dynamic>);
+  final row = await _docDb.insert('order_files', {
+    'orderId': orderId,
+    'objectPath': objectPath,
+    'filename': fileName,
+    'mimeType': 'application/pdf',
+    'sizeBytes': sizeBytes,
+    'createdBy': userId,
+  });
+  final data = Map<String, dynamic>.from(row['data'] ?? {});
+  data['id'] = row['id'];
+  return data;
 }
 
 /// Приватная подписанная ссылка
@@ -155,16 +154,21 @@ Future<String> getSignedUrl(String objectPath,
 Future<void> deleteOrderFile(String objectPath) async {
   _ensureAuthed();
   await supabase.storage.from(kOrderBucket).remove([objectPath]);
-  await supabase.from('order_files').delete().eq('object_path', objectPath);
+  final rows = await _docDb.whereEq('order_files', 'objectPath', objectPath);
+  for (final r in rows) {
+    await _docDb.deleteById(r['id'] as String);
+  }
 }
 
 /// Список файлов заказа по метаданным
 Future<List<Map<String, dynamic>>> listOrderFiles(String orderId) async {
   _ensureAuthed();
-  final res = await supabase
-      .from('order_files')
-      .select()
-      .eq('order_id', orderId)
-      .order('created_at', ascending: false);
-  return (res as List).cast<Map<String, dynamic>>();
+  final res = await _docDb.whereEq('order_files', 'orderId', orderId);
+  return res
+      .map((row) {
+        final data = Map<String, dynamic>.from(row['data'] ?? {});
+        data['id'] = row['id'];
+        return data;
+      })
+      .toList();
 }


### PR DESCRIPTION
## Summary
- migrate employee data access to universal `documents` store
- route analytics logging through `documents` collection
- switch chat, planning, and file metadata modules to store in `documents`

## Testing
- `dart format lib/admin_panel.dart lib/data/employee_repository.dart lib/modules/analytics/analytics_provider.dart lib/modules/chat/chat_provider.dart lib/modules/orders/edit_order_screen.dart lib/modules/personnel/add_employee_screen.dart lib/modules/production/production_details_screen.dart lib/modules/production_planning/form_editor_screen.dart lib/services/storage_service.dart` *(command failed: dart not found)*
- `dart analyze` *(command failed: dart not found)*
- `dart test` *(command failed: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eacda08c8322bbcca3bfa492e763