### PR TITLE
Fix workplace persistence to documents

### DIFF
--- a/test/personnel_provider_workplace_test.dart
+++ b/test/personnel_provider_workplace_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/personnel/personnel_provider.dart';
+import 'package:sheet_clone/services/doc_db.dart';
+
+class FakeDocDB extends DocDB {
+  bool insertCalled = false;
+  String? capturedCollection;
+  Map<String, dynamic>? capturedData;
+
+  @override
+  Future<Map<String, dynamic>> insert(String collection, Map<String, dynamic> data, {String? explicitId}) async {
+    insertCalled = true;
+    capturedCollection = collection;
+    capturedData = data;
+    return {'id': explicitId ?? '1', 'collection': collection, 'data': data};
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> list(String collection) async => [];
+}
+
+void main() {
+  test('addWorkplace saves to documents', () async {
+    final fakeDb = FakeDocDB();
+    final provider = PersonnelProvider(docDb: fakeDb, bootstrap: false);
+    await provider.addWorkplace(name: 'Test place', positionIds: ['p1']);
+
+    expect(fakeDb.insertCalled, isTrue);
+    expect(fakeDb.capturedCollection, 'workplaces');
+    expect(fakeDb.capturedData?['name'], 'Test place');
+    expect(provider.workplaces.any((w) => w.name == 'Test place'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- allow injecting DocDB and optional bootstrap in PersonnelProvider
- await document insert when adding workplaces to persist properly
- add regression test verifying workplace save

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c70f19a3588322b571d1945444c7c1