### PR TITLE
fix: persist workplaces in documents

### DIFF
--- a/lib/modules/personnel/workplaces_screen.dart
+++ b/lib/modules/personnel/workplaces_screen.dart
@@ -148,12 +148,19 @@ class WorkplacesScreen extends StatelessWidget {
     );
     if (ok == true && nameC.text.trim().isNotEmpty) {
       final int? maxWorkers = int.tryParse(maxWorkersC.text.trim());
-      context.read<PersonnelProvider>().addWorkplace(
-        name: nameC.text.trim(),
-        positionIds: selectedPositions.toList(),
-        hasMachine: hasMachine,
-        maxConcurrentWorkers: maxWorkers ?? 1,
-      );
+      try {
+        await context.read<PersonnelProvider>().addWorkplace(
+          name: nameC.text.trim(),
+          positionIds: selectedPositions.toList(),
+          hasMachine: hasMachine,
+          maxConcurrentWorkers: maxWorkers ?? 1,
+        );
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text('Ошибка сохранения: $e')));
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure `addWorkplace` persists to Supabase documents and rolls back on failure
- await saving new workplaces from UI and show an error if it fails
- explicitly type local caches to resolve a compilation error

## Testing
- `dart test` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c70f19a3588322b571d1945444c7c1