### PR TITLE
Fix unmatched brace in tasks_screen.dart

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5786,3 +5786,4 @@ Duration _setupElapsedTotal(TaskModel task) {
           doneList.map((c) => c.timestamp).reduce((a, b) => a > b ? a : b));
   return end.difference(start);
 }
+}


### PR DESCRIPTION
### Motivation
- Resolve Dart parser error `Can't find '}' to match '{'` that caused Windows Flutter build failures by ensuring the `_TasksScreenState` class is properly closed.

### Description
- Add a missing closing brace `}` at the end of `lib/modules/tasks/tasks_screen.dart` to correctly terminate the `_TasksScreenState` scope.

### Testing
- Ran a brace-balance check using a small Python script (`python - <<'PY' ... PY`) which reported `remaining 0`, and attempted `dart analyze` and `flutter analyze` checks but both CLIs were unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0d7190b8832f83dc20ea296b189f)