### PR TITLE
Fix Dart syntax error in _showInkAdjustDialog signature

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3008,7 +3008,7 @@ class _TasksScreenState extends State<TasksScreen>
     List<Map<String, dynamic>> paints,
     String? unit, {
     bool allowPaperEdit = false,
-  ) async {
+  }) async {
     final mutable = paints
         .map((row) => Map<String, dynamic>.from(row))
         .toList(growable: true);


### PR DESCRIPTION
### Motivation
- Fix a Dart parse/build error caused by a missing closing brace in the named-parameter block of `_showInkAdjustDialog`, which produced `Can't find '}' to match '{'` during analysis/compile.

### Description
- Close the named-parameter block in the `_showInkAdjustDialog` signature by changing the trailing `) async {` to `}) async {` in `lib/modules/tasks/tasks_screen.dart` so braces are balanced.

### Testing
- Ran a Python-based syntax check that strips strings and verifies bracket pairing, which reports the function signature now balanced (success).
- Attempted `flutter analyze`, but the environment lacks the Flutter/Dart SDK so analysis could not be executed (failure due to missing SDK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0d7190b8832f83dc20ea296b189f)