### PR TITLE
Флексопечать: подтверждение красок и улучшенное описание списания

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -2940,10 +2940,16 @@ class _TasksScreenState extends State<TasksScreen>
 
   bool _isInkConfirmationStage(TaskModel task) {
     final stageId = task.stageId.trim().toLowerCase();
-    if (stageId.contains('flexo') ||
-        stageId.contains('флекс') ||
-        stageId.contains('печать') ||
-        stageId.contains('print')) {
+    const flexoStageAliases = {
+      '0571c01c-f086-47e4-81b2-5d8b2ab91218',
+      'w_flexoprint',
+      'w_flexo',
+      'position:print',
+      'print',
+    };
+    if (flexoStageAliases.contains(stageId) ||
+        stageId.contains('flexo') ||
+        stageId.contains('флекс')) {
       return true;
     }
     final personnel = context.read<PersonnelProvider>();
@@ -2959,9 +2965,7 @@ class _TasksScreenState extends State<TasksScreen>
       task.stageId,
     ).toLowerCase();
     return label.contains('флекс') ||
-        label.contains('flexo') ||
-        label.contains('печать') ||
-        label.contains('print');
+        label.contains('flexo');
   }
 
   String _orderDisplayNameForWriteoff(OrderModel order) {
@@ -2974,6 +2978,13 @@ class _TasksScreenState extends State<TasksScreen>
       return customer;
     }
     return 'Без названия';
+  }
+
+  String _orderReferenceForWriteoff(OrderModel order) {
+    final baseName = _orderDisplayNameForWriteoff(order);
+    final orderId = order.id.trim();
+    if (orderId.isEmpty) return baseName;
+    return '$baseName (ID: $orderId)';
   }
 
   bool _looksLikeOrderCode(String value) {
@@ -3217,7 +3228,7 @@ class _TasksScreenState extends State<TasksScreen>
       final stageName = _stageLabel(task).trim().isEmpty
           ? 'Этап'
           : _stageLabel(task).trim();
-      final orderName = _orderDisplayNameForWriteoff(order);
+      final orderRef = _orderReferenceForWriteoff(order);
       for (final row in paints) {
         final paintId = (row['paint_id'] ?? '').toString();
         final paintName =
@@ -3230,7 +3241,7 @@ class _TasksScreenState extends State<TasksScreen>
         }
 
         final reason =
-            'Заказ: $orderName | Списание краски: $paintName | Кол-во: ${qtyKg.toStringAsFixed(3)} кг | Этап: $stageName';
+            'Заказ: $orderRef | Списание краски: $paintName | Кол-во: ${qtyKg.toStringAsFixed(3)} кг | Этап: $stageName';
         await warehouse.registerShipment(
           id: paintId,
           type: 'paint',


### PR DESCRIPTION
### Motivation
- Сделать окно подтверждения и списания красок точным для этапа флексопечать (включая конкретный id этапа) чтобы сотрудник видел список красок и мог указать фактический расход перед завершением этапа.
- Уточнить текст причины списания, чтобы в логах склада и в комментариях было однозначное указание на заказ (включая id).

### Description
- В `lib/modules/tasks/tasks_screen.dart` добавлен набор алиасов `flexoStageAliases` с вашим id `0571c01c-f086-47e4-81b2-5d8b2ab91218` и ключевыми legacy-именами (`w_flexoprint`, `w_flexo`, `position:print`, `print`) и теперь `_isInkConfirmationStage` возвращает true при совпадении с этими алиасами или при наличии `flexo`/`флекс` в id/названии этапа. (файл: `tasks_screen.dart`)
- Ослаблен/изменён fallback по тексту: удалён общий `печать`/`print` из финальной проверки метки, чтобы окно подтверждения применялось более прицельно к флексо-этапам. (файл: `tasks_screen.dart`)
- Добавлена функция ` _orderReferenceForWriteoff(OrderModel)` которая формирует ссылку на заказ в формате `Название (ID: <id>)`, и эта ссылка используется при формировании строки причины списания в `_writeoffInks`, что делает комментарии/записи в журнале склада однозначными. (файл: `tasks_screen.dart`)
- Обновлён текст `reason` при вызове `warehouse.registerShipment(...)` и при записи комментария `taskProvider.addCommentAutoUser(...)` — теперь содержит расширенную ссылку на заказ, краску, количество и этап. (файл: `tasks_screen.dart`)

### Testing
- Проверил изменения через `git diff -- lib/modules/tasks/tasks_screen.dart` и просмотрил патч; обзор показал ожидаемые строки изменений и вставки в `tasks_screen.dart` (успех). 
- Сделан коммит с сообщением `Refine flexo ink confirmation and writeoff order reference` (успех). 
- Попытки прогнать `dart format` и `flutter format` не удались в окружении, так как `dart`/`flutter` недоступны (`/bin/bash: dart: command not found`, `/bin/bash: flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd12fe1afc832fbbdeed7cfd2aad5b)