### PR TITLE
Require flexo ink confirmation dialog before finalizing task

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3061,44 +3061,54 @@ class _TasksScreenState extends State<TasksScreen>
               ),
               const SizedBox(height: 12),
               Flexible(
-                child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: mutable.length,
-                  itemBuilder: (context, index) {
-                    final row = mutable[index];
-                    final name = (row['paint_name'] ?? row['name'] ?? 'Краска')
-                        .toString();
-                    final orderedQty = (row['qty_kg'] as num?)?.toDouble() ?? 0;
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: Row(
-                        children: [
-                          Expanded(flex: 3, child: Text(name)),
-                          Expanded(
-                            flex: 2,
-                            child: Text(
-                              'По заказу: ${orderedQty.toStringAsFixed(3)} кг',
-                              textAlign: TextAlign.end,
+                child: mutable.isEmpty
+                    ? const Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'В заказе не указаны краски. При необходимости вернитесь и добавьте их в заказ.',
+                        ),
+                      )
+                    : ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: mutable.length,
+                        itemBuilder: (context, index) {
+                          final row = mutable[index];
+                          final name =
+                              (row['paint_name'] ?? row['name'] ?? 'Краска')
+                                  .toString();
+                          final orderedQty =
+                              (row['qty_kg'] as num?)?.toDouble() ?? 0;
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: Row(
+                              children: [
+                                Expanded(flex: 3, child: Text(name)),
+                                Expanded(
+                                  flex: 2,
+                                  child: Text(
+                                    'По заказу: ${orderedQty.toStringAsFixed(3)} кг',
+                                    textAlign: TextAlign.end,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  flex: 2,
+                                  child: TextField(
+                                    controller: ctrls[index],
+                                    keyboardType:
+                                        const TextInputType.numberWithOptions(
+                                            decimal: true),
+                                    decoration: const InputDecoration(
+                                      labelText: 'Факт, кг',
+                                      border: OutlineInputBorder(),
+                                    ),
+                                  ),
+                                ),
+                              ],
                             ),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            flex: 2,
-                            child: TextField(
-                              controller: ctrls[index],
-                              keyboardType: const TextInputType.numberWithOptions(
-                                  decimal: true),
-                              decoration: const InputDecoration(
-                                labelText: 'Факт, кг',
-                                border: OutlineInputBorder(),
-                              ),
-                            ),
-                          ),
-                        ],
+                          );
+                        },
                       ),
-                    );
-                  },
-                ),
               ),
             ],
           ),
@@ -3291,37 +3301,45 @@ class _TasksScreenState extends State<TasksScreen>
     List<Map<String, dynamic>> paints = const <Map<String, dynamic>>[];
     _QuantityInput? qtyInput;
     if (_isInkConfirmationStage(task)) {
-      final initialPaints = await OrdersRepository().getPaints(task.orderId);
-      if (initialPaints.isNotEmpty) {
-        var mutablePaints = initialPaints;
-        while (true) {
-          final dialogResult = await _showInkAdjustDialog(
-            mutablePaints,
-            unitLabel,
-            allowPaperEdit: true,
+      List<Map<String, dynamic>> initialPaints = const <Map<String, dynamic>>[];
+      try {
+        initialPaints = await OrdersRepository().getPaints(task.orderId);
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Не удалось загрузить краски заказа: $e')),
           );
-          if (dialogResult == null) return;
-          if (dialogResult.quantityInput.openPaperEditor) {
-            final order = _orderById(task.orderId);
-            if (order == null) {
-              if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text('Не удалось найти заказ для редактирования бумаги.'),
-                  ),
-                );
-              }
-              return;
-            }
-            await _openPaperEditDialog(order);
-            continue;
-          }
-          mutablePaints = dialogResult.paints;
-          await _validateInkAvailability(mutablePaints);
-          paints = mutablePaints;
-          qtyInput = dialogResult.quantityInput;
-          break;
         }
+        return;
+      }
+      var mutablePaints = initialPaints;
+      while (true) {
+        final dialogResult = await _showInkAdjustDialog(
+          mutablePaints,
+          unitLabel,
+          allowPaperEdit: true,
+        );
+        if (dialogResult == null) return;
+        if (dialogResult.quantityInput.openPaperEditor) {
+          final order = _orderById(task.orderId);
+          if (order == null) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Не удалось найти заказ для редактирования бумаги.'),
+                ),
+              );
+            }
+            return;
+          }
+          await _openPaperEditDialog(order);
+          continue;
+        }
+        mutablePaints = dialogResult.paints;
+        await _validateInkAvailability(mutablePaints);
+        paints = mutablePaints;
+        qtyInput = dialogResult.quantityInput;
+        break;
       }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure operators at the флексопечать stage must confirm/correct ink usage before finalizing the task so actual paint consumption is recorded and written off to the warehouse with an order reference.

### Description
- Always open the ink-adjustment dialog for flexo stages detected by `_isInkConfirmationStage` (includes `0571c01c-f086-47e4-81b2-5d8b2ab91218`, `w_flexoprint`, `w_flexo`, `position:print`, `print`) prior to finalizing the task by changing `_finalizeTask` flow in `lib/modules/tasks/tasks_screen.dart`.
- Add an explicit empty-state message in the dialog when the order has no paints so the operator sees that paints are not specified and can act accordingly by editing the order first.
- Guard loading of order paints with `try/catch` and show a `SnackBar` on failure to load paints to avoid proceeding with incomplete data.
- Preserve existing behavior: factual per-paint corrections, stock validation (`_validateInkAvailability`), write-off via `WarehouseProvider.registerShipment`, `ink_writeoff` task comments and `OrdersRepository.applyPaintUsage` remain intact and are invoked after confirmation.

### Testing
- Attempted `dart format lib/modules/tasks/tasks_screen.dart` but `dart` was not available in the container PATH, so formatting was not run. (failed)
- Attempted `flutter --version` but `flutter` was not available in the container PATH, so no build/run validation was performed. (failed)
- Local changes were staged and committed with message `Require flexo ink confirmation dialog before finalizing task` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd15249754832fac86fafc352b1178)