### PR TITLE
Improve warehouse tab perceived load time

### DIFF
--- a/lib/modules/warehouse/type_table_tabs_screen.dart
+++ b/lib/modules/warehouse/type_table_tabs_screen.dart
@@ -404,27 +404,47 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
   Future<void> _loadAll() async {
     if (!mounted) return;
     final provider = Provider.of<WarehouseProvider>(context, listen: false);
+    final typeKey = _normalizeType(widget.type);
+
+    void applySnapshot({
+      required List<TmcModel> items,
+      WarehouseLogsBundle? bundle,
+    }) {
+      final writeoffs =
+          bundle == null ? _writeoffs : _mapBundleLogs(bundle.writeoffs);
+      final inventories =
+          bundle == null ? _inventories : _mapBundleLogs(bundle.inventories);
+      final arrivals = bundle == null ? _arrivals : _mapBundleLogs(bundle.arrivals);
+
+      if (!mounted) return;
+      setState(() {
+        _items = items;
+        _writeoffs = writeoffs;
+        _inventories = inventories;
+        _arrivals = arrivals;
+      });
+      _notifyThresholds();
+      _resort();
+    }
+
+    // 1) Мгновенно показываем то, что уже есть в памяти.
+    final cachedItems = provider.getTmcByType(widget.type);
+    final cachedBundle = provider.logsBundle(typeKey);
+    applySnapshot(items: cachedItems, bundle: cachedBundle);
+
+    // 2) Затем обновляем данные из БД и перерисовываем экран.
     try {
       await provider.fetchTmc();
     } catch (_) {}
 
-    final items = provider.getTmcByType(widget.type);
-    final typeKey = _normalizeType(widget.type);
-    final bundle = await provider.fetchLogsBundle(typeKey, forceRefresh: true);
-
-    final writeoffs = _mapBundleLogs(bundle.writeoffs);
-    final inventories = _mapBundleLogs(bundle.inventories);
-    final arrivals = _mapBundleLogs(bundle.arrivals);
-
-    if (!mounted) return;
-    setState(() {
-      _items = items;
-      _writeoffs = writeoffs;
-      _inventories = inventories;
-      _arrivals = arrivals;
-    });
-    _notifyThresholds();
-    _resort();
+    final freshItems = provider.getTmcByType(widget.type);
+    WarehouseLogsBundle? freshBundle;
+    try {
+      freshBundle = await provider.fetchLogsBundle(typeKey, forceRefresh: true);
+    } catch (_) {
+      freshBundle = provider.logsBundle(typeKey);
+    }
+    applySnapshot(items: freshItems, bundle: freshBundle);
   }
 
   List<_LogRow> _mapBundleLogs(List<WarehouseLogEntry> entries) {


### PR DESCRIPTION
### Motivation
- Opening warehouse category screens (e.g. "Бумага") could feel slow because the UI waited for fresh DB/log fetch before rendering, producing a noticeable 10–20s delay for users. 

### Description
- Reworked `TypeTableTabsScreen._loadAll` in `lib/modules/warehouse/type_table_tabs_screen.dart` to apply an immediate in-memory snapshot using `provider.getTmcByType` and `provider.logsBundle` so the screen displays cached data instantly. 
- Added a local `applySnapshot` helper that updates `_items`, `_writeoffs`, `_inventories`, and `_arrivals` and calls `_notifyThresholds()` and `_resort()` to centralize UI updates. 
- Kept the background refresh behavior by calling `provider.fetchTmc()` and then `provider.fetchLogsBundle(..., forceRefresh: true)` and falling back to the cached bundle if the forced fetch fails. 

### Testing
- Attempted to run `dart format lib/modules/warehouse/type_table_tabs_screen.dart`, but it failed because `dart` is not available in this environment. 
- No other automated tests (unit/integration) were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de0cdc7ee4832fb5e068bac8f8de64)