### PR TITLE
Resolve paint_id from warehouse by paint name when missing

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3155,8 +3155,16 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   Future<void> _validateInkAvailability(List<Map<String, dynamic>> paints) async {
+    final warehouse = context.read<WarehouseProvider>();
     final ids = paints
-        .map((row) => (row['paint_id'] ?? '').toString())
+        .map((row) {
+          final directId = (row['paint_id'] ?? '').toString().trim();
+          if (directId.isNotEmpty) return directId;
+          final paintName =
+              (row['paint_name'] ?? row['name'] ?? '').toString().trim();
+          if (paintName.isEmpty) return '';
+          return warehouse.getPaintByName(paintName)?.id ?? '';
+        })
         .where((id) => id.isNotEmpty)
         .toSet()
         .toList(growable: false);
@@ -3176,7 +3184,14 @@ class _TasksScreenState extends State<TasksScreen>
     }
 
     for (final row in paints) {
-      final paintId = (row['paint_id'] ?? '').toString();
+      final paintId = (row['paint_id'] ?? '').toString().trim().isNotEmpty
+          ? (row['paint_id'] ?? '').toString().trim()
+          : (warehouse
+                  .getPaintByName(
+                    (row['paint_name'] ?? row['name'] ?? '').toString().trim(),
+                  )
+                  ?.id ??
+              '');
       final paintName =
           (row['paint_name'] ?? row['name'] ?? 'Краска').toString();
       final qtyKg = (row['qty_kg'] as num?)?.toDouble() ?? 0;
@@ -3207,7 +3222,14 @@ class _TasksScreenState extends State<TasksScreen>
           : _stageLabel(task).trim();
       final orderRef = _orderReferenceForWriteoff(order);
       for (final row in paints) {
-        final paintId = (row['paint_id'] ?? '').toString();
+        final paintId = (row['paint_id'] ?? '').toString().trim().isNotEmpty
+            ? (row['paint_id'] ?? '').toString().trim()
+            : (warehouse
+                    .getPaintByName(
+                      (row['paint_name'] ?? row['name'] ?? '').toString().trim(),
+                    )
+                    ?.id ??
+                '');
         final paintName =
             (row['paint_name'] ?? row['name'] ?? 'Краска').toString();
         final qtyKg = (row['qty_kg'] as num?)?.toDouble() ?? 0;


### PR DESCRIPTION
### Motivation
- Prevent write-off failures for orders that have paints saved without a `paint_id` by resolving the warehouse item from the paint name before validation and shipment registration.

### Description
- In `_validateInkAvailability` use `WarehouseProvider.getPaintByName(...)` as a fallback when `paint_id` is empty while building the list of paint IDs to query and when checking each paint row.
- In `_writeoffInks` apply the same `paint_id` fallback so `registerShipment` receives a resolved warehouse `id` even if `order_paints.paint_id` is not set.
- Changed file: `lib/modules/tasks/tasks_screen.dart` (adds name→id lookup in both validation and write-off paths).

### Testing
- Ran content checks with `rg` to verify updated logic is present and relevant error messages are addressed, and those checks succeeded.
- Attempted to run `dart format` but it failed because `dart` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1483e844832fa040a48bde07367e)