### PR TITLE
Fix duplicate quantity prompt on flexo finalization and hide extra finalize button

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3285,11 +3285,14 @@ class _TasksScreenState extends State<TasksScreen>
     }
   }
 
-  Future<void> _finalizeTask(TaskModel task) async {
+  Future<void> _finalizeTask(
+    TaskModel task, {
+    _QuantityInput? initialQtyInput,
+  }) async {
     final unitLabel =
         _workplaceUnit(context.read<PersonnelProvider>(), task.stageId);
     List<Map<String, dynamic>> paints = const <Map<String, dynamic>>[];
-    _QuantityInput? qtyInput;
+    _QuantityInput? qtyInput = initialQtyInput;
     if (_isInkConfirmationStage(task)) {
       List<Map<String, dynamic>> initialPaints = const <Map<String, dynamic>>[];
       try {
@@ -4031,7 +4034,7 @@ class _TasksScreenState extends State<TasksScreen>
                         final _secs = _elapsed(latestTask).inSeconds;
                         final shouldCloseStage = jointGroup != null || separateAllDone;
                         if (_isInkConfirmationStage(task)) {
-                          await _finalizeTask(task);
+                          await _finalizeTask(task, initialQtyInput: qtyInput);
                           return;
                         }
                         final nextStatus =
@@ -4669,7 +4672,8 @@ class _TasksScreenState extends State<TasksScreen>
                     style: TextStyle(color: Colors.red.shade700, fontSize: 14),
                   ),
                 ),
-              if (task.assignees.isNotEmpty)
+              if (task.assignees.isNotEmpty &&
+                  stageMode == ExecutionMode.separate)
                 Align(
                   alignment: Alignment.centerRight,
                   child: ElevatedButton.icon(


### PR DESCRIPTION
### Motivation
- Исправить ситуацию, когда при завершении этапа «Флексопечать/Печать» после ввода расхода красок пользователь снова получает окно ввода количества бумаги/экземпляров. 
- Убрать лишнюю нижнюю кнопку `Завершить задание` для режимов «Одиночная или совместная работа», оставив её только для отдельного (`ExecutionMode.separate`) режима.

### Description
- Изменён сигнатур `_finalizeTask` так, чтобы он принимал опциональный аргумент `initialQtyInput` типа `_QuantityInput?` и инициализировал внутреннюю переменную `qtyInput` из этого значения. 
- При ветке завершения из `onFinish` (row-level finish) передаётся уже введённое количество в вызов `_finalizeTask` через `initialQtyInput`, чтобы избежать повторного запроса количества. 
- Скрыта нижняя кнопка `Завершить задание`, если `stageMode != ExecutionMode.separate`, чтобы не показывать дополнительную кнопку для «Одиночная или совместная работа». 
- Изменён файл: `lib/modules/tasks/tasks_screen.dart`.

### Testing
- Выполнена командная проверка `git -C /workspace/app status --short` и подготовка коммита прошли успешно. 
- Команда `git -C /workspace/app commit` завершилась успешно и зафиксировала изменения. 
- Попытка запустить `dart format lib/modules/tasks/tasks_screen.dart` не удалась, так как в окружении отсутствует `dart`/`flutter` CLI (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1956c17c832f9fdf4d2ee00bced4)