### PR TITLE
Исправления: старт заданий, очередь, отображение склада и длина L

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -4230,7 +4230,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 },
               ),
               const SizedBox(height: 4),
-              if (_stockExtraAutoloaded) _buildStockExtraResults(),
+              if (_stockExtraAutoloaded &&
+                  (_stockExtraFocusNode.hasFocus ||
+                      _stockExtraSearchController.text.trim().isNotEmpty))
+                _buildStockExtraResults(),
             ],
           ),
           const SizedBox.shrink(),

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -509,6 +509,7 @@ class OrdersProvider with ChangeNotifier {
     required String orderId,
     required List<MaterialModel> paperMaterials,
     required String reason,
+    double? lengthL,
   }) async {
     await _ensureAuthed();
 
@@ -538,7 +539,13 @@ class OrdersProvider with ChangeNotifier {
       return 'Заказ не найден в локальном кеше.';
     }
     final prev = _orders[index];
+    final normalizedLength = lengthL != null && lengthL > 0 ? lengthL : null;
+    final nextProduct = ProductModel.fromMap(prev.product.toMap());
+    if (normalizedLength != null) {
+      nextProduct.length = normalizedLength;
+    }
     final updated = prev.copyWith(
+      product: nextProduct,
       paperMaterials: prepared,
       material: prepared.first,
       comments: trimmedReason,

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -86,14 +86,14 @@ TaskStatus _groupStatus(List<TaskModel> tasks) {
   if (tasks.any((t) => t.status == TaskStatus.problem)) {
     return TaskStatus.problem;
   }
+  if (tasks.any((t) => t.status == TaskStatus.completed)) {
+    return TaskStatus.completed;
+  }
   if (tasks.any((t) => t.status == TaskStatus.inProgress)) {
     return TaskStatus.inProgress;
   }
   if (tasks.any((t) => t.status == TaskStatus.paused)) {
     return TaskStatus.paused;
-  }
-  if (tasks.any((t) => t.status == TaskStatus.completed)) {
-    return TaskStatus.completed;
   }
   return TaskStatus.waiting;
 }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -778,6 +778,7 @@ class _TasksScreenState extends State<TasksScreen>
   bool _selectionUpdateScheduled = false;
   String? _lastQueueSyncGroupId;
   String? _lastQueueSyncIdsSignature;
+  final Set<String> _startingTaskIds = <String>{};
   String? get _selectedWorkplaceId => _selection.workplaceId;
   set _selectedWorkplaceId(String? value) {
     final normalized = value?.trim();
@@ -1133,7 +1134,7 @@ class _TasksScreenState extends State<TasksScreen>
                                       decimal: true,
                                     ),
                                     decoration: const InputDecoration(
-                                      labelText: 'Количество (м)',
+                                      labelText: 'Длина L (м)',
                                     ),
                                     validator: (value) {
                                       final normalized =
@@ -1209,10 +1210,12 @@ class _TasksScreenState extends State<TasksScreen>
                             errorText = null;
                           });
                           final nextMaterials = <MaterialModel>[];
+                          double? nextLengthL;
                           for (var i = 0; i < selected.length; i++) {
                             final qty = double.parse(
                               qtyControllers[i].text.trim().replaceAll(',', '.'),
                             );
+                            nextLengthL ??= qty;
                             nextMaterials.add(selected[i].copyWith(quantity: qty));
                           }
 
@@ -1224,6 +1227,7 @@ class _TasksScreenState extends State<TasksScreen>
                             orderId: latest.id,
                             paperMaterials: nextMaterials,
                             reason: reasonController.text,
+                            lengthL: nextLengthL,
                           );
                           if (!mounted) return;
                           if (error != null) {
@@ -1665,20 +1669,20 @@ class _TasksScreenState extends State<TasksScreen>
     final stageTasksAll = _selectedWorkplaceId == null
         ? const <TaskModel>[]
         : taskProvider.tasks.where((t) => t.stageId == _selectedWorkplaceId).toList();
-    final stageOrderIds =
-        stageTasksAll.map((task) => task.orderId).toSet().toList();
+    final stageQueueIds =
+        stageTasksAll.map((task) => task.id.trim()).where((id) => id.isNotEmpty).toSet().toList();
 
     _scheduleQueueSyncIfNeeded(
       queue: queue,
       groupId: queueGroupId,
-      ids: _selectedWorkplaceId == null ? orderIds : stageOrderIds,
+      ids: _selectedWorkplaceId == null ? orderIds : stageQueueIds,
     );
 
     final sectionedTasks = tasksForWorkplace.toList();
     sectionedTasks.sort((a, b) =>
         queue
-            .priorityOf(a.orderId, groupId: queueGroupId)
-            .compareTo(queue.priorityOf(b.orderId, groupId: queueGroupId)));
+            .priorityOf(a.id, groupId: queueGroupId)
+            .compareTo(queue.priorityOf(b.id, groupId: queueGroupId)));
     final currentTask = _selectedTask != null
         ? taskProvider.tasks.firstWhere(
             (t) => t.id == _selectedTask!.id,
@@ -3470,8 +3474,8 @@ class _TasksScreenState extends State<TasksScreen>
     final queueGroupId = _selectedWorkplaceId!.trim();
     final queued = _tasksForWorkplace(taskProvider)
       ..sort((a, b) => queue
-          .priorityOf(a.orderId, groupId: queueGroupId)
-          .compareTo(queue.priorityOf(b.orderId, groupId: queueGroupId)));
+          .priorityOf(a.id, groupId: queueGroupId)
+          .compareTo(queue.priorityOf(b.id, groupId: queueGroupId)));
 
     final index = queued.indexWhere((t) => t.id == task.id);
     if (index <= 0) return true;
@@ -3672,6 +3676,7 @@ class _TasksScreenState extends State<TasksScreen>
                             task.comments.any((c) => c.type == 'shift_resume');
                     final bool canStartButtonRow = isMyRow &&
                         canStart &&
+                        !_startingTaskIds.contains(task.id) &&
                         !requiresSetupBeforeStart &&
                         !stageStartedBeforeShiftResume &&
                         // Для отдельных исполнителей разрешаем возобновлять этап
@@ -3769,136 +3774,137 @@ class _TasksScreenState extends State<TasksScreen>
                     final personnel = context.read<PersonnelProvider>();
 
                     Future<void> onStart() async {
-                      final taskProvider = context.read<TaskProvider>();
-                      final personnelProvider = personnel;
-                      // Sequential stage guard
-                      if (!_isFirstPendingStage(
-                          taskProvider, personnelProvider, task,
-                          groupResolver: _stageGroupKey)) {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                              content: Text(
-                                  'Сначала выполните предыдущий этап заказа')));
+                      if (_startingTaskIds.contains(task.id)) return;
+                      setState(() => _startingTaskIds.add(task.id));
+                      try {
+                        final taskProvider = context.read<TaskProvider>();
+                        final personnelProvider = personnel;
+                        // Sequential stage guard
+                        if (!_isFirstPendingStage(
+                            taskProvider, personnelProvider, task,
+                            groupResolver: _stageGroupKey)) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                                content: Text(
+                                    'Сначала выполните предыдущий этап заказа')));
+                          }
+                          return;
                         }
-                        return;
-                      }
 
-
-                      if (!_isUnlockedByWorkplaceQueue(
-                        task,
-                        taskProvider,
-                        context.read<ProductionQueueProvider>(),
-                        stage,
-                      )) {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                              content: Text(
-                                  'Сначала начните предыдущие задания в очереди')));
+                        if (!_isUnlockedByWorkplaceQueue(
+                          task,
+                          taskProvider,
+                          context.read<ProductionQueueProvider>(),
+                          stage,
+                        )) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                                content: Text(
+                                    'Сначала начните предыдущие задания в очереди')));
+                          }
+                          return;
                         }
-                        return;
-                      }
 
-
-                      if (_hasBlockingActiveOrder(taskProvider, task)) {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                              content: Text('Сначала завершите текущий активный заказ')));
+                        if (_hasBlockingActiveOrder(taskProvider, task)) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                                content:
+                                    Text('Сначала завершите текущий активный заказ')));
+                          }
+                          return;
                         }
-                        return;
-                      }
 
-                      if (_isStageGroupLocked(tp, task)) {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                              content: Text('Уже выполняется альтернативный этап')));
+                        if (_isStageGroupLocked(tp, task)) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                                content: Text('Уже выполняется альтернативный этап')));
+                          }
+                          return;
                         }
-                        return;
-                      }
 
-                      if (_hasMachineForStage(stage) &&
-                          !_hasPendingSetupForStage(task) &&
-                          !_isSetupCompletedForStage(task) &&
-                          !_hasProductionStartedForStage(task)) {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                              content: Text(
-                                  'Сначала начните наладку, затем запускайте этап')));
+                        if (_hasMachineForStage(stage) &&
+                            !_hasPendingSetupForStage(task) &&
+                            !_isSetupCompletedForStage(task) &&
+                            !_hasProductionStartedForStage(task)) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                                content: Text(
+                                    'Сначала начните наладку, затем запускайте этап')));
+                          }
+                          return;
                         }
-                        return;
-                      }
 
-                      final bool setupInProgressForCurrentUser =
-                          _isSetupInProgressForUser(task, widget.employeeId) &&
-                              !_hasProductionStartedForStage(task);
+                        final bool setupInProgressForCurrentUser =
+                            _isSetupInProgressForUser(task, widget.employeeId) &&
+                                !_hasProductionStartedForStage(task);
 
-                      ExecutionMode? selectedMode = stageExecMode;
-                      final alreadyAssigned =
-                          task.assignees.contains(widget.employeeId);
-                      if (explicitStageMode == null) {
-                        await taskProvider.addComment(
-                              taskId: task.id,
-                              type: 'exec_mode_stage',
-                              text: _executionModeCode(stageExecMode),
-                              userId: widget.employeeId,
-                            );
-                      }
-
-                      if (!alreadyAssigned) {
-                        final newAssignees = List<String>.from(task.assignees)
-                          ..add(widget.employeeId);
-                        await taskProvider.updateAssignees(task.id, newAssignees);
-                      }
-
-                      if (selectedMode != null &&
-                          _needsExecModeRecord(
-                              task, widget.employeeId, selectedMode)) {
-                        await taskProvider.addComment(
-                              taskId: task.id,
-                              type: 'exec_mode',
-                              text: _executionModeCode(selectedMode),
-                              userId: widget.employeeId,
-                            );
-                      }
-                      // Обновляем статус задачи. Не сбрасываем startedAt, если этап уже
-                      // находится в работе – используем существующее значение. В
-                      // состоянии паузы или проблемы возобновляем работу с тем же
-                      // startedAt, чтобы таймер продолжал считаться корректно.
-                      // Всегда обновляем статус: переводим этап в работу и
-                      // сохраняем начальное время. Если этап ещё не начинался,
-                      // фиксируем текущий момент; иначе используем существующий
-                      // startedAt, чтобы не обнулять таймер.
-                      if (_hasMachineForStage(stage) &&
-                          !_isSetupCompletedForUser(
-                              task, widget.employeeId) &&
-                          !setupInProgressForCurrentUser) {
-                        await _finishSetup(task, provider);
-                      }
-                      final startedAtTs = task.startedAt ??
-                          DateTime.now().millisecondsSinceEpoch;
-                      await taskProvider.updateStatus(
-                            task.id,
-                            TaskStatus.inProgress,
-                            startedAt: startedAtTs,
+                        final ExecutionMode? selectedMode = stageExecMode;
+                        final alreadyAssigned =
+                            task.assignees.contains(widget.employeeId);
+                        if (explicitStageMode == null) {
+                          await taskProvider.addComment(
+                            taskId: task.id,
+                            type: 'exec_mode_stage',
+                            text: _executionModeCode(stageExecMode),
+                            userId: widget.employeeId,
                           );
-                      await taskProvider.addCommentAutoUser(
+                        }
+
+                        if (!alreadyAssigned) {
+                          final newAssignees = List<String>.from(task.assignees)
+                            ..add(widget.employeeId);
+                          await taskProvider.updateAssignees(task.id, newAssignees);
+                        }
+
+                        if (selectedMode != null &&
+                            _needsExecModeRecord(
+                                task, widget.employeeId, selectedMode)) {
+                          await taskProvider.addComment(
+                            taskId: task.id,
+                            type: 'exec_mode',
+                            text: _executionModeCode(selectedMode),
+                            userId: widget.employeeId,
+                          );
+                        }
+
+                        if (_hasMachineForStage(stage) &&
+                            !_isSetupCompletedForUser(task, widget.employeeId) &&
+                            !setupInProgressForCurrentUser) {
+                          await _finishSetup(task, provider);
+                        }
+                        final startedAtTs =
+                            task.startedAt ?? DateTime.now().millisecondsSinceEpoch;
+                        await taskProvider.updateStatus(
+                          task.id,
+                          TaskStatus.inProgress,
+                          startedAt: startedAtTs,
+                        );
+                        await taskProvider.addCommentAutoUser(
                           taskId: task.id,
                           type: 'start',
                           text: 'Начал(а) этап',
-                          userIdOverride: widget.employeeId);
-                      if (setupInProgressForCurrentUser) {
-                        // Бизнес-правило: после "Наладка" -> "Пауза/Проблема"
-                        // продолжение возвращает именно в наладку.
-                        await taskProvider.addCommentAutoUser(
+                          userIdOverride: widget.employeeId,
+                        );
+                        if (setupInProgressForCurrentUser) {
+                          await taskProvider.addCommentAutoUser(
                             taskId: task.id,
                             type: 'setup_resume',
                             text: 'Продолжил(а) наладку',
-                            userIdOverride: widget.employeeId);
-                        await recordTimeEventForUser(
-                          TaskTimeType.setup,
-                          note: 'setup_resume',
-                        );
-                      } else {
-                        await recordTimeEventForUser(TaskTimeType.production);
+                            userIdOverride: widget.employeeId,
+                          );
+                          await recordTimeEventForUser(
+                            TaskTimeType.setup,
+                            note: 'setup_resume',
+                          );
+                        } else {
+                          await recordTimeEventForUser(TaskTimeType.production);
+                        }
+                      } finally {
+                        if (mounted) {
+                          setState(() => _startingTaskIds.remove(task.id));
+                        } else {
+                          _startingTaskIds.remove(task.id);
+                        }
                       }
                     }
 


### PR DESCRIPTION
### Motivation
- Устранить несколько UX/логических проблем в модуле производства: видимый «зависший» блок выбора бумаги в форме заказа, некорректное отображение статуса группы этапов, двойной клик для старта этапа, некорректное поведение очереди по этапам и неверная семантика изменения бумаги (нужно менять длину L, а не «количество»).

### Description
- Скрытие блока результатов для поля "Лишнее на складе" до тех пор, пока поле не в фокусе или в нём есть текст (файл `lib/modules/orders/edit_order_screen.dart`, проверка `_stockExtraFocusNode`/`_stockExtraSearchController`).
- Исправлен алгоритм агрегации статуса группы этапов в `lib/modules/production/production_screen.dart` так, чтобы наличие завершённого этапа переводило группу в `TaskStatus.completed` вместо отображения как в процессе.
- Устранён эффект «нужно нажать 2 раза, чтобы начать»: добавлен guard `_startingTaskIds` и во время выполнения асинхронного старта кнопка `Начать` блокируется для данного `task.id` (файл `lib/modules/tasks/tasks_screen.dart`).
- Переведена локальная очередь рабочего места с `orderId` на `task.id` — синхронизация и сортировка очереди теперь используют `task.id`, чтобы перестановка одного этапа не перемещала все этапы заказа (файлы `lib/modules/tasks/tasks_screen.dart` и `lib/modules/production/production_queue_provider.dart`).
- Изменён поток правки бумаги при завершении этапа: поле переименовано в `Длина L (м)`, при сохранении передаётся параметр `lengthL` в `OrdersProvider.updateOrderPapersFromWorkspace`, который при наличии обновляет `product.length` и затем запускает пересчёт резерва (файлы `lib/modules/tasks/tasks_screen.dart` и `lib/modules/orders/orders_provider.dart`).

### Testing
- Выполнена проверка кода `git diff --check`, ошибок не обнаружено.
- Попытки запустить `dart format` и `flutter --version` не удались в среде сборки, так как `dart`/`flutter` не установлены, поэтому автоматическое форматирование и запуск Flutter-тестов не выполнялись.
- В данной среде не запускались встроенные unit/widget тесты из `test/` по причине отсутствия Flutter SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de234a2b2c832fb1e5e90b05740ba8)