### PR TITLE
Always write off flexo paint in grams and use order display name in comments

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -2988,10 +2988,7 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   String _orderReferenceForWriteoff(OrderModel order) {
-    final baseName = _orderDisplayNameForWriteoff(order);
-    final orderId = order.id.trim();
-    if (orderId.isEmpty) return baseName;
-    return '$baseName (ID: $orderId)';
+    return _orderDisplayNameForWriteoff(order);
   }
 
   bool _looksLikeOrderCode(String value) {
@@ -3002,6 +2999,13 @@ class _TasksScreenState extends State<TasksScreen>
       return true;
     }
     if (RegExp(r'^(заказ\s*)?#?\d+$').hasMatch(normalized)) {
+      return true;
+    }
+    if (RegExp(r'^зк[-\\s]?\\d{4}(?:[.\\-/]\\d{1,2}){1,2}[-\\s]?\\d+$')
+        .hasMatch(normalized)) {
+      return true;
+    }
+    if (RegExp(r'^ord[-\\s]?\\d{4}[-\\s]?\\d+$').hasMatch(normalized)) {
       return true;
     }
     return false;
@@ -3182,7 +3186,8 @@ class _TasksScreenState extends State<TasksScreen>
     if (rows is List) {
       for (final raw in rows.whereType<Map>()) {
         final map = Map<String, dynamic>.from(raw);
-        stockById[(map['id'] ?? '').toString()] =
+        final id = (map['id'] ?? '').toString();
+        stockById[id] =
             (map['quantity'] as num?)?.toDouble() ?? 0;
       }
     }
@@ -3203,10 +3208,11 @@ class _TasksScreenState extends State<TasksScreen>
       if (paintId.isEmpty) {
         throw Exception('Для краски «$paintName» не указан складской идентификатор.');
       }
+      final qtyForStock = qtyKg * 1000;
       final current = stockById[paintId] ?? 0;
-      if (qtyKg > current) {
+      if (qtyForStock > current) {
         throw Exception(
-          'Недостаточно краски «$paintName» на складе: доступно ${current.toStringAsFixed(3)} кг, требуется ${qtyKg.toStringAsFixed(3)} кг.',
+          'Недостаточно краски «$paintName» на складе: доступно ${current.toStringAsFixed(0)} г, требуется ${qtyForStock.toStringAsFixed(0)} г.',
         );
       }
     }
@@ -3245,10 +3251,11 @@ class _TasksScreenState extends State<TasksScreen>
 
         final reason =
             'Заказ: $orderRef | Списание краски: $paintName | Кол-во: ${(qtyKg * 1000).toStringAsFixed(0)} г | Этап: $stageName';
+        final qtyForStock = qtyKg * 1000;
         await warehouse.registerShipment(
           id: paintId,
           type: 'paint',
-          qty: qtyKg,
+          qty: qtyForStock,
           reason: reason,
         );
         await taskProvider.addCommentAutoUser(


### PR DESCRIPTION
### Motivation
- Operators always enter paint consumption in grams, but previous logic could re-interpret `300 г` as `0.30` due to unit-based conversions from stock metadata. 
- Comments for ink writeoffs should show a human-readable order name instead of an ID or code for easier operator reference.

### Description
- Stop reading `unit` from `paints` and remove unit-based conversion helpers, so all comparisons and shipments use grams computed as `qty_kg * 1000`.
- Update validation to compare stock against `qty_kg * 1000` and change the shortage error text to display values in grams.
- Ensure `warehouse.registerShipment` is called with the quantity in grams and update stored usage records to use grams.
- Use `_orderDisplayNameForWriteoff` directly from `_orderReferenceForWriteoff` and extend `_looksLikeOrderCode` to exclude `ЗК-...` and `ORD-...` patterns from display names.

### Testing
- Ran `git diff -- lib/modules/tasks/tasks_screen.dart` to inspect changes and it succeeded.
- Ran `git status --short` to verify workspace state and it succeeded.
- Attempted `dart format lib/modules/tasks/tasks_screen.dart` but it failed in this environment because `dart` is not installed, so formatting and Dart/Flutter tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2616ff44832f8b0304952902f729)