### PR TITLE
Fix duplicate start activation and flexo stage finalization/write-off

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3221,7 +3221,6 @@ class _TasksScreenState extends State<TasksScreen>
   Future<bool> _writeoffInks(TaskModel task, List<Map<String, dynamic>> paints) async {
     if (paints.isEmpty) return true;
     final order = _orderById(task.orderId);
-    if (order == null) return true;
     final repo = OrdersRepository();
 
     try {
@@ -3230,7 +3229,9 @@ class _TasksScreenState extends State<TasksScreen>
       final stageName = _stageLabel(task).trim().isEmpty
           ? 'Этап'
           : _stageLabel(task).trim();
-      final orderRef = _orderReferenceForWriteoff(order);
+      final orderRef = order != null
+          ? _orderReferenceForWriteoff(order)
+          : task.orderId;
       for (final row in paints) {
         final paintId = (row['paint_id'] ?? '').toString().trim().isNotEmpty
             ? (row['paint_id'] ?? '').toString().trim()
@@ -3691,11 +3692,10 @@ class _TasksScreenState extends State<TasksScreen>
                         // "Завершить задание").
                         // Для совместного режима после user_done повторный запуск
                         // через эту строку недоступен.
-                        (((stateRowUser == UserRunState.idle)) ||
+                        ((((stateRowUser == UserRunState.idle) &&
+                                !userParticipatedInStage)) ||
                             (stateRowUser == UserRunState.paused) ||
                             (stateRowUser == UserRunState.problem) ||
-                            (stateRowUser == UserRunState.finished &&
-                                stageExecMode == ExecutionMode.separate) ||
                             (stateRowUser == UserRunState.active &&
                                 isSetupActiveForRow));
                     final bool shouldShowContinueLabel =
@@ -4043,7 +4043,8 @@ class _TasksScreenState extends State<TasksScreen>
                         (t) => t.id == task.id,
                         orElse: () => task,
                       );
-                      if (!_anyUserActive(latestTask)) {
+                      if (!_anyUserActive(latestTask,
+                          exceptUserId: currentRowUserId)) {
                         final _secs = _elapsed(latestTask).inSeconds;
                         final shouldCloseStage = jointGroup != null || separateAllDone;
                         if (_isInkConfirmationStage(task)) {


### PR DESCRIPTION
### Motivation
- Prevent accidental double-starts where the `Начать` button becomes re-enabled a few seconds after a start due to transient state recalculation. 
- Ensure ink quantities entered at flexo finalization are actually written off from warehouse stock. 
- Fix flexo stage remaining `in progress` by avoiding race conditions when the finishing user closes their own time event.

### Description
- Tightened per-row start eligibility in `lib/modules/tasks/tasks_screen.dart` so an `idle` row cannot re-start if the user already participated in the stage (removed the unconditional `idle` allow and require `!userParticipatedInStage`).
- When finishing a row, changed the active-user check to ignore the currently finishing user by calling `_anyUserActive(latestTask, exceptUserId: currentRowUserId)` to avoid blocking finalization due to transient state.
- Made `_writeoffInks` robust when the `OrderModel` is not present by removing an early return and using a fallback order reference (`task.orderId`) for write-off comments so ink shipments still register and per-paint `qty_kg` updates are applied.

### Testing
- Verified file changes with `git diff` and created a commit successfully. (succeeded)
- Attempted to run `dart format` but the environment lacks the `dart` CLI (`/bin/bash: dart: command not found`). (could not run)
- Attempted to check Flutter SDK with `flutter --version` but the environment lacks `flutter` (`/bin/bash: flutter: command not found`). (could not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2c1c4500832fb2a82fe42b79548a)