### PR TITLE
Fix flexo start/button behavior, ink write-off and stage completion propagation

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3220,8 +3220,6 @@ class _TasksScreenState extends State<TasksScreen>
 
   Future<bool> _writeoffInks(TaskModel task, List<Map<String, dynamic>> paints) async {
     if (paints.isEmpty) return true;
-    final order = _orderById(task.orderId);
-    if (order == null) return true;
     final repo = OrdersRepository();
 
     try {
@@ -3230,7 +3228,9 @@ class _TasksScreenState extends State<TasksScreen>
       final stageName = _stageLabel(task).trim().isEmpty
           ? 'Этап'
           : _stageLabel(task).trim();
-      final orderRef = _orderReferenceForWriteoff(order);
+      final order = _orderById(task.orderId);
+      final orderRef =
+          order != null ? _orderReferenceForWriteoff(order) : task.orderId;
       for (final row in paints) {
         final paintId = (row['paint_id'] ?? '').toString().trim().isNotEmpty
             ? (row['paint_id'] ?? '').toString().trim()
@@ -3391,6 +3391,21 @@ class _TasksScreenState extends State<TasksScreen>
     final secs = _elapsed(latest).inSeconds;
     await tp.updateStatus(task.id, TaskStatus.completed,
         spentSeconds: secs, startedAt: null);
+    final sameStageTasks = tp.tasks
+        .where((t) =>
+            t.id != task.id &&
+            t.orderId == task.orderId &&
+            t.stageId == task.stageId &&
+            t.status != TaskStatus.completed)
+        .toList(growable: false);
+    for (final related in sameStageTasks) {
+      await tp.updateStatus(
+        related.id,
+        TaskStatus.completed,
+        spentSeconds: related.spentSeconds,
+        startedAt: null,
+      );
+    }
 
     if (!mounted) return;
     final note = await _askFinishNote();
@@ -3681,11 +3696,14 @@ class _TasksScreenState extends State<TasksScreen>
                     final bool stageStartedBeforeShiftResume =
                         _hasProductionStartedForStage(task) &&
                             task.comments.any((c) => c.type == 'shift_resume');
+                    final bool hasOpenStartIntentForRowUser =
+                        _hasOpenStartIntentForUser(task, currentRowUserId);
                     final bool canStartButtonRow = isMyRow &&
                         canStart &&
                         !_startingTaskIds.contains(task.id) &&
                         !requiresSetupBeforeStart &&
                         !stageStartedBeforeShiftResume &&
+                        !hasOpenStartIntentForRowUser &&
                         // Для отдельных исполнителей разрешаем возобновлять этап
                         // после личного завершения (до финальной кнопки
                         // "Завершить задание").
@@ -4963,6 +4981,25 @@ class _TasksScreenState extends State<TasksScreen>
         ? 0
         : dones.map((c) => c.timestamp).reduce((a, b) => a > b ? a : b);
     return lastStartTs > lastDoneTs;
+  }
+
+  bool _hasOpenStartIntentForUser(TaskModel task, String userId) {
+    final events = task.comments
+        .where((c) =>
+            c.userId == userId &&
+            (c.type == 'start' ||
+                c.type == 'resume' ||
+                c.type == 'setup_resume' ||
+                c.type == 'pause' ||
+                c.type == 'problem' ||
+                c.type == 'user_done'))
+        .toList()
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    if (events.isEmpty) return false;
+    final lastType = events.last.type;
+    return lastType == 'start' ||
+        lastType == 'resume' ||
+        lastType == 'setup_resume';
   }
 
   bool _hasPendingSetupForStage(TaskModel task) {


### PR DESCRIPTION
### Motivation
- Users reported that after finishing a stage by pressing `Начать`/`▶ Начать` the start button could become active again a few seconds later, allowing immediate duplicate starts.  
- During flexo finalization entered paint quantities were not always written off from warehouse stock when the local order model was missing.  
- Finalizing the flexo stage left other task rows for the same `orderId+stageId` marked as still `inProgress`, so production modules showed the stage as unfinished.

### Description
- Added a guard function `bool _hasOpenStartIntentForUser(TaskModel task, String userId)` in `lib/modules/tasks/tasks_screen.dart` to detect an existing open start/resume intent from the user.  
- Integrated the guard into the row-level start enablement (`canStart` logic) to block pressing `Начать` again while a start/resume is already in effect.  
- Changed `_writeoffInks` to avoid an early `return` when `_orderById` is `null` and to use `task.orderId` as a fallback `orderRef` so paint write-off still runs and registers a shipment even if the local order object is unavailable.  
- In `_finalizeTask` added propagation that marks other non-completed tasks with the same `orderId` and `stageId` as `TaskStatus.completed` to keep stage state consistent across related task rows.

### Testing
- Attempted to run formatting with `dart format lib/modules/tasks/tasks_screen.dart`, but the `dart` binary was not available in the environment (failed).  
- Attempted to query Flutter with `flutter --version`, but the `flutter` binary was not available in the environment (failed).  
- No automated unit or integration tests were executed in this environment due to missing Dart/Flutter toolchain, so runtime verification is still required on a dev workstation or CI with Flutter installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2c1c4500832fb2a82fe42b79548a)