### PR TITLE
Fix: блокировка повторного старта, корректное списание красок и синхронизация статуса этапа

### DIFF
--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -932,6 +932,11 @@ class TaskProvider with ChangeNotifier {
     }
     try {
       await _supabase.from('tasks').update(updates).eq('id', id);
+      await _syncProdPlanStageStatus(
+        orderId: updated.orderId,
+        stageId: updated.stageId,
+        status: status,
+      );
       // if this task just became completed — check last-stage and update actual_qty
       if (status == TaskStatus.completed) {
         final orderId = updated.orderId;
@@ -961,6 +966,59 @@ class TaskProvider with ChangeNotifier {
               .update({'status': OrderStatus.completed.name}).eq('id', orderId);
         }
       } catch (_) {}
+    }
+  }
+
+  Future<void> _syncProdPlanStageStatus({
+    required String orderId,
+    required String stageId,
+    required TaskStatus status,
+  }) async {
+    final normalizedOrderId = orderId.trim();
+    final normalizedStageId = stageId.trim();
+    if (normalizedOrderId.isEmpty || normalizedStageId.isEmpty) return;
+
+    String? mapped;
+    switch (status) {
+      case TaskStatus.waiting:
+        mapped = 'waiting';
+        break;
+      case TaskStatus.inProgress:
+        mapped = 'inProgress';
+        break;
+      case TaskStatus.paused:
+        mapped = 'paused';
+        break;
+      case TaskStatus.problem:
+        mapped = 'problem';
+        break;
+      case TaskStatus.completed:
+        mapped = 'completed';
+        break;
+    }
+
+    try {
+      final plan = await _supabase
+          .from('prod_plans')
+          .select('id')
+          .eq('order_id', normalizedOrderId)
+          .maybeSingle();
+      final planId = plan?['id']?.toString().trim() ?? '';
+      if (planId.isEmpty) return;
+
+      final payload = <String, dynamic>{'status': mapped};
+      if (status == TaskStatus.completed) {
+        payload['completed_at'] = DateTime.now().toIso8601String();
+      } else {
+        payload['completed_at'] = null;
+      }
+      await _supabase
+          .from('prod_plan_stages')
+          .update(payload)
+          .eq('plan_id', planId)
+          .eq('stage_id', normalizedStageId);
+    } catch (e, st) {
+      debugPrint('⚠️ sync prod_plan_stages status failed: $e\n$st');
     }
   }
 

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3171,7 +3171,7 @@ class _TasksScreenState extends State<TasksScreen>
           final paintName =
               (row['paint_name'] ?? row['name'] ?? '').toString().trim();
           if (paintName.isEmpty) return '';
-          return warehouse.getPaintByName(paintName)?.id ?? '';
+          return _resolvePaintIdForWriteoff(warehouse, paintName) ?? '';
         })
         .where((id) => id.isNotEmpty)
         .toSet()
@@ -3195,11 +3195,10 @@ class _TasksScreenState extends State<TasksScreen>
     for (final row in paints) {
       final paintId = (row['paint_id'] ?? '').toString().trim().isNotEmpty
           ? (row['paint_id'] ?? '').toString().trim()
-          : (warehouse
-                  .getPaintByName(
-                    (row['paint_name'] ?? row['name'] ?? '').toString().trim(),
-                  )
-                  ?.id ??
+          : (_resolvePaintIdForWriteoff(
+                  warehouse,
+                  (row['paint_name'] ?? row['name'] ?? '').toString().trim(),
+                ) ??
               '');
       final paintName =
           (row['paint_name'] ?? row['name'] ?? 'Краска').toString();
@@ -3218,6 +3217,29 @@ class _TasksScreenState extends State<TasksScreen>
     }
   }
 
+  String? _resolvePaintIdForWriteoff(
+      WarehouseProvider warehouse, String paintName) {
+    final normalized = paintName.trim().toLowerCase();
+    if (normalized.isEmpty) return null;
+    final exact = warehouse.getPaintByName(normalized);
+    if (exact != null) return exact.id;
+
+    final compactName = normalized.replaceAll(RegExp(r'\\s+'), '');
+    for (final item in warehouse.allTmc) {
+      if (item.type != 'paint') continue;
+      final desc = (item.description ?? '').trim().toLowerCase();
+      if (desc.isEmpty) continue;
+      final compactDesc = desc.replaceAll(RegExp(r'\\s+'), '');
+      if (desc == normalized ||
+          compactDesc == compactName ||
+          desc.contains(normalized) ||
+          normalized.contains(desc)) {
+        return item.id;
+      }
+    }
+    return null;
+  }
+
   Future<bool> _writeoffInks(TaskModel task, List<Map<String, dynamic>> paints) async {
     if (paints.isEmpty) return true;
     final order = _orderById(task.orderId);
@@ -3234,11 +3256,10 @@ class _TasksScreenState extends State<TasksScreen>
       for (final row in paints) {
         final paintId = (row['paint_id'] ?? '').toString().trim().isNotEmpty
             ? (row['paint_id'] ?? '').toString().trim()
-            : (warehouse
-                    .getPaintByName(
-                      (row['paint_name'] ?? row['name'] ?? '').toString().trim(),
-                    )
-                    ?.id ??
+            : (_resolvePaintIdForWriteoff(
+                    warehouse,
+                    (row['paint_name'] ?? row['name'] ?? '').toString().trim(),
+                  ) ??
                 '');
         final paintName =
             (row['paint_name'] ?? row['name'] ?? 'Краска').toString();
@@ -3389,8 +3410,30 @@ class _TasksScreenState extends State<TasksScreen>
       orElse: () => task,
     );
     final secs = _elapsed(latest).inSeconds;
-    await tp.updateStatus(task.id, TaskStatus.completed,
-        spentSeconds: secs, startedAt: null);
+    final groupKey = latest.stageGroupKey.trim().isNotEmpty
+        ? latest.stageGroupKey.trim()
+        : latest.stageId;
+    final relatedTasks = tp.tasks.where((candidate) {
+      if (candidate.orderId != latest.orderId) return false;
+      final candidateGroupKey = candidate.stageGroupKey.trim().isNotEmpty
+          ? candidate.stageGroupKey.trim()
+          : candidate.stageId;
+      return candidateGroupKey == groupKey;
+    }).toList(growable: false);
+
+    if (relatedTasks.isEmpty) {
+      await tp.updateStatus(task.id, TaskStatus.completed,
+          spentSeconds: secs, startedAt: null);
+    } else {
+      for (final stageTask in relatedTasks) {
+        await tp.updateStatus(
+          stageTask.id,
+          TaskStatus.completed,
+          spentSeconds: secs,
+          startedAt: null,
+        );
+      }
+    }
 
     if (!mounted) return;
     final note = await _askFinishNote();
@@ -3695,9 +3738,7 @@ class _TasksScreenState extends State<TasksScreen>
                             (stateRowUser == UserRunState.paused) ||
                             (stateRowUser == UserRunState.problem) ||
                             (stateRowUser == UserRunState.finished &&
-                                stageExecMode == ExecutionMode.separate) ||
-                            (stateRowUser == UserRunState.active &&
-                                isSetupActiveForRow));
+                                stageExecMode == ExecutionMode.separate));
                     final bool shouldShowContinueLabel =
                         stateRowUser == UserRunState.finished &&
                             stageExecMode == ExecutionMode.separate;


### PR DESCRIPTION
### Motivation
- Исправить поведение, когда после нажатия «Начать» кнопка снова становилась активной и можно было стартовать этап повторно, чего быть не должно. 
- Устранить ситуацию, когда факт расхода краски не списывался со склада из‑за несовпадения имён краски между заказом и карточками склада. 
- Обеспечить, чтобы после завершения этапа (в частности флексопечати) этап в модуле управления производственными заданиями корректно становился завершённым.

### Description
- Добавлена синхронизация состояния задачи в `prod_plan_stages` через новый метод `TaskProvider._syncProdPlanStageStatus(...)`, который вызывается из `updateStatus` и обновляет `status` и `completed_at` в `prod_plan_stages` при изменениях статуса задачи. (файл: `lib/modules/tasks/task_provider.dart`)
- В диалоге списания красок добавлена функция `_resolvePaintIdForWriteoff(...)`, которая выполняет более гибкое сопоставление имени краски с записями склада и используется в валидации наличия (`_validateInkAvailability`) и при самом списании (`_writeoffInks`). (файл: `lib/modules/tasks/tasks_screen.dart`)
- Изменена логика финализации этапа: при завершении флексопечати теперь закрываются все задачи с тем же `stage_group_key` (группа этапа) для заказа, чтобы этап перестал отображаться как «в процессе» в модулях управления производством. (файл: `lib/modules/tasks/tasks_screen.dart`)
- Усилена защита от повторного старта: условие, которое преждевременно разблокировывало кнопку старта для строки пользователя во время наладки, скорректировано, чтобы исключить возможность нажать `Начать` подряд дважды. (файл: `lib/modules/tasks/tasks_screen.dart`)

### Testing
- `git diff --check` выполнен успешно и не показал проблем. 
- Попытки запустить `dart format` и `flutter --version` не удались в этом окружении, так как `dart`/`flutter` отсутствуют (`/bin/bash: dart: command not found`, `/bin/bash: flutter: command not found`).
- Кодовые изменения локально закоммичены и изменения проверены вручную по логике (обновления вызовов и новых функций) в затронутых файлах.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2c1c4500832fb2a82fe42b79548a)