### PR TITLE
Fix invalid order-code regex escaping in tasks screen

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3001,11 +3001,11 @@ class _TasksScreenState extends State<TasksScreen>
     if (RegExp(r'^(заказ\s*)?#?\d+$').hasMatch(normalized)) {
       return true;
     }
-    if (RegExp(r'^зк[-\\s]?\\d{4}(?:[.\\-/]\\d{1,2}){1,2}[-\\s]?\\d+$')
+    if (RegExp(r'^зк[-\s]?\d{4}(?:[.\-/]\d{1,2}){1,2}[-\s]?\d+$')
         .hasMatch(normalized)) {
       return true;
     }
-    if (RegExp(r'^ord[-\\s]?\\d{4}[-\\s]?\\d+$').hasMatch(normalized)) {
+    if (RegExp(r'^ord[-\s]?\d{4}[-\s]?\d+$').hasMatch(normalized)) {
       return true;
     }
     return false;


### PR DESCRIPTION
### Motivation
- Prevent `FormatException: Range out of order in character class` in `_looksLikeOrderCode` by fixing malformed raw RegExp literals used to detect order codes.

### Description
- Removed redundant backslashes inside raw regex strings for the `зк...` and `ord...` patterns in `lib/modules/tasks/tasks_screen.dart`, replacing them with valid patterns like `r'^зк[-\s]?\d{4}(?:[.\-/]\d{1,2}){1,2}[-\s]?\d+$'` -> `r'^зк[-\s]?\d{4}(?:[.\-/]\d{1,2}){1,2}[-\s]?\d+$'` (escaped for readability) and `r'^ord[-\s]?\d{4}[-\s]?\d+$'` -> `r'^ord[-\s]?\d{4}[-\s]?\d+$'` so the raw strings no longer contain incorrect `\` sequences that produced invalid character classes.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but `dart` is not available in the container so formatting could not be executed (tool unavailable). 
- Verified the change by inspecting the file diff and the affected lines with a line-numbered file print (`git diff` and `nl -ba lib/modules/tasks/tasks_screen.dart | sed -n '2996,3014p'`), which show the corrected regex literals and no other modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2f1c29d4832f84cc427024e16293)