### PR TITLE
Align ink writeoff comments with paper writeoff wording

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3225,12 +3225,11 @@ class _TasksScreenState extends State<TasksScreen>
     try {
       final warehouse = context.read<WarehouseProvider>();
       final taskProvider = context.read<TaskProvider>();
-      final stageName = _stageLabel(task).trim().isEmpty
-          ? 'Этап'
-          : _stageLabel(task).trim();
       final order = _orderById(task.orderId);
-      final orderRef =
+      final normalizedOrderLabel =
           order != null ? _orderReferenceForWriteoff(order) : task.orderId;
+      final humanReadableReason =
+          'Списание после завершения заказа $normalizedOrderLabel';
       for (final row in paints) {
         final paintId = (row['paint_id'] ?? '').toString().trim().isNotEmpty
             ? (row['paint_id'] ?? '').toString().trim()
@@ -3249,19 +3248,17 @@ class _TasksScreenState extends State<TasksScreen>
               'Для краски «$paintName» не удалось определить складскую позицию.');
         }
 
-        final reason =
-            'Заказ: $orderRef | Списание краски: $paintName | Кол-во: ${(qtyKg * 1000).toStringAsFixed(0)} г | Этап: $stageName';
         final qtyForStock = qtyKg * 1000;
         await warehouse.registerShipment(
           id: paintId,
           type: 'paint',
           qty: qtyForStock,
-          reason: reason,
+          reason: humanReadableReason,
         );
         await taskProvider.addCommentAutoUser(
           taskId: task.id,
           type: 'ink_writeoff',
-          text: reason,
+          text: humanReadableReason,
           userIdOverride: widget.employeeId,
         );
       }


### PR DESCRIPTION
### Motivation
- Align ink writeoff comments with the human-readable wording used for paper writeoffs so warehouse shipments and task comments match printed documents.

### Description
- Replace the per-paint verbose reason with a single `humanReadableReason = 'Списание после завершения заказа $normalizedOrderLabel'` computed from the resolved order label.
- Compute `normalizedOrderLabel` as `order != null ? _orderReferenceForWriteoff(order) : task.orderId` and reuse it for all paints in the task.
- Use `humanReadableReason` for both `warehouse.registerShipment` and `taskProvider.addCommentAutoUser` calls.
- Remove the previous `stageName` and the old per-paint `reason` construction.

### Testing
- Attempted formatting check with `dart format lib/modules/tasks/tasks_screen.dart`, which failed due to missing `dart` binary in the environment.
- No automated unit or integration tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de33c1fe00832f8bd274dcbd3b3a02)