### PR TITLE
Show only order length in 'Длина L' (order details card)

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -267,12 +267,7 @@ class OrderDetailsCard extends StatelessWidget {
 
   String _lengthValue() {
     final p = order.product;
-    final hasQty = p.blQuantity != null && p.blQuantity!.isNotEmpty;
-    if (p.length != null && hasQty) {
-      return '${p.blQuantity}*${_fmtNum(p.length)}';
-    }
     if (p.length != null) return _fmtNum(p.length);
-    if (hasQty) return p.blQuantity!;
     return '';
   }
 


### PR DESCRIPTION
### Motivation
- Убрать двусмысленное отображение формата `blQuantity*length` под лейблом `Длина L`, чтобы сотрудник при смене бумаги видел именно фактическую длину заказа `L`.

### Description
- Изменена логика в `OrderDetailsCard._lengthValue()` в `lib/modules/orders/order_details_card.dart` — удалена конкатенация `blQuantity*length`, теперь при наличии `product.length` возвращается только ` _fmtNum(p.length)`.

### Testing
- Проверено изменение через просмотр диффа и локальную инспекцию файла `lib/modules/orders/order_details_card.dart` и закоммичено с сообщением `Fix length L display in order details`.
- Выполнена команда `git status --short` успешно, попытка запустить `dart format` не удалась из-за отсутствия `dart` в окружении (`/bin/bash: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de35980d5c832f8e9419af244b7ce8)