### PR TITLE
Prefill paper edit dialog with order length (L) instead of product quantity

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1021,16 +1021,9 @@ class _TasksScreenState extends State<TasksScreen>
 
     double initialPaperQty(MaterialModel item) {
       final fromCurrent = item.quantity > 0 ? item.quantity : 0.0;
-      final orderQty =
-          latest.product.quantity > 0 ? latest.product.quantity.toDouble() : 0.0;
-      if (fromCurrent <= 0) return orderQty;
-
       final orderLength = (latest.product.length ?? 0).toDouble();
-      final looksAutoLength =
-          orderLength > 0 && (fromCurrent - orderLength).abs() < 0.0001;
-      if (looksAutoLength && orderQty > 0) {
-        return orderQty;
-      }
+      if (fromCurrent > 0) return fromCurrent;
+      if (orderLength > 0) return orderLength;
       return fromCurrent;
     }
 


### PR DESCRIPTION
### Motivation
- Operators replacing paper after a stage must see and edit the paper length `L` in meters, not the number of product copies, to avoid confusion during paper substitution. 
- Existing logic could fill the `Длина L (м)` field with the order `quantity` instead of a length value, which is misleading for this dialog.

### Description
- Changed the initial value logic in the "Изменение бумаги в заказе" dialog to prefer the paper's current length when present and otherwise use the order length `product.length`. 
- Removed the previous fallback that could substitute the order `quantity` for the length. 
- Modified file `lib/modules/tasks/tasks_screen.dart` where `initialPaperQty` is computed to implement the new behavior.

### Testing
- Attempted to run formatter via `dart format /workspace/app/lib/modules/tasks/tasks_screen.dart`, but it failed because `dart` is not available in the environment. (failed)
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de37a51b7c832fb6ea721b43a4a372)