### PR TITLE
Fix order edit/view consistency and production queue behavior

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -89,6 +89,8 @@ class _StageRuleOutcome {
 }
 
 class _EditOrderScreenState extends State<EditOrderScreen> {
+  static const String _paintInfoParamLabel = 'Информация для красок:';
+
   String _trimTrailingFractionZeros(String value) {
     if (!value.contains('.')) return value;
     return value
@@ -2084,10 +2086,15 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (_paintsRestored) return;
     final template = widget.order ?? widget.initialOrder;
     final params = template?.product.parameters ?? '';
-    if (params.isEmpty || !params.contains('Краска:')) {
+    if (params.isEmpty) {
       _paintsRestored = true;
       return;
     }
+    final infoMatch = RegExp(
+      r'Информация для красок:\s*([^;]+)',
+      caseSensitive: false,
+    ).firstMatch(params);
+    final infoFromParams = (infoMatch?.group(1) ?? '').trim();
     final paintTmcList = warehouse.getTmcByType('Краска');
     final reg = RegExp(
         r'Краска:\s*(.+?)\s+([0-9]+(?:[.,][0-9]+)?)\s*(кг|г)(?:\s*\(([^)]+)\))?',
@@ -2095,7 +2102,18 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         caseSensitive: false);
     final matches = reg.allMatches(params).toList();
     if (matches.isEmpty) {
-      _paintsRestored = true;
+      if (infoFromParams.isNotEmpty) {
+        setState(() {
+          _paintInfo = infoFromParams;
+          _paintInfoController.value = TextEditingValue(
+            text: infoFromParams,
+            selection: TextSelection.collapsed(offset: infoFromParams.length),
+          );
+          _paintsRestored = true;
+        });
+      } else {
+        _paintsRestored = true;
+      }
       return;
     }
     final restored = <_PaintEntry>[];
@@ -2123,7 +2141,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       }
     }
     if (restored.isNotEmpty) {
-      final sharedInfo = _deriveSharedPaintInfo(restored);
+      final sharedInfo = infoFromParams.isNotEmpty
+          ? infoFromParams
+          : _deriveSharedPaintInfo(restored);
       setState(() {
         _paints
           ..clear()
@@ -2148,7 +2168,11 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   /// Сохраняет список красок в таблицу order_paints и синхронизирует product.parameters.
   Future<void> _persistPaints(String orderId) async {
     // 1) Всегда чистим строки "Краска: ..." в product.parameters
-    final cleanRe = RegExp(r'(?:^|;\s*)Краска:\s*.+?(?=(?:;\s*Краска:|$))');
+    final cleanRe = RegExp(
+      r'(?:^|;\s*)(?:Краска:\s*.+?(?=(?:;\s*Краска:|;\s*Информация для красок:|$))|'
+      r'Информация для красок:\s*.+?(?=(?:;\s*Краска:|;\s*Информация для красок:|$)))',
+      caseSensitive: false,
+    );
     var clean = _product.parameters.replaceAll(cleanRe, '').trim();
     if (clean.endsWith(';')) {
       clean = clean.substring(0, clean.length - 1).trim();
@@ -2180,6 +2204,11 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       _product.parameters = clean.isEmpty ? joined : '$clean; $joined';
     } else {
       _product.parameters = clean;
+    }
+    if (sharedInfo.isNotEmpty) {
+      _product.parameters = _product.parameters.isEmpty
+          ? '$_paintInfoParamLabel $sharedInfo'
+          : '${_product.parameters}; $_paintInfoParamLabel $sharedInfo';
     }
 
     // 4) Перезаписываем таблицу order_paints
@@ -2503,7 +2532,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       return true;
     }
 
-    final bool canLaunchProductionNow = hasEnoughPaperForLaunch();
+    final bool hasStageQueueSelected =
+        _stageTemplateId != null && _stageTemplateId!.trim().isNotEmpty;
+    final bool canLaunchProductionNow =
+        hasStageQueueSelected && hasEnoughPaperForLaunch();
     final bool wasAlreadyLaunched = widget.order?.assignmentCreated ?? false;
     final bool stageQueueChangedForLaunchedOrder = wasAlreadyLaunched &&
         ((_stageTemplateId ?? '') != (widget.order?.stageTemplateId ?? '') ||
@@ -2523,17 +2555,21 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     }
     final String nextOrderStatus = wasAlreadyLaunched
         ? widget.order!.status
-        : (canLaunchProductionNow
+        : (!hasStageQueueSelected
+            ? OrderStatus.draft.name
+            : (canLaunchProductionNow
             ? OrderStatus.ready_to_start.name
-            : OrderStatus.waiting_materials.name);
+            : OrderStatus.waiting_materials.name));
     final bool nextHasMaterialShortage = wasAlreadyLaunched
         ? widget.order!.hasMaterialShortage
-        : !canLaunchProductionNow;
+        : (hasStageQueueSelected ? !canLaunchProductionNow : false);
     final String shortageMessage = wasAlreadyLaunched
         ? widget.order!.materialShortageMessage
-        : (canLaunchProductionNow
+        : (!hasStageQueueSelected
             ? ''
-            : 'Недостаточно материала на складе. Пополните склад и запустите заказ вручную.');
+            : (canLaunchProductionNow
+            ? ''
+            : 'Недостаточно материала на складе. Пополните склад и запустите заказ вручную.'));
     late OrderModel createdOrUpdatedOrder;
     bool resetForRelaunchAfterEdit = false;
     if (widget.order == null) {
@@ -3006,6 +3042,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         const SnackBar(
           content: Text(
             'Заказ обновлён и снят с производства. Для продолжения запустите его повторно.',
+          ),
+        ),
+      );
+    } else if (!createdOrUpdatedOrder.assignmentCreated && !hasStageQueueSelected) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Заказ сохранён в черновиках: выберите очередь этапов для подготовки к запуску.',
           ),
         ),
       );
@@ -4240,7 +4284,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         ),
         const SizedBox(height: 3),
         TextFormField(
-          initialValue: product.widthB?.toString() ?? '',
+          initialValue: product.widthB != null ? _formatDecimal(product.widthB!) : '',
           decoration: const InputDecoration(
             labelText: 'Ширина b',
             border: OutlineInputBorder(),
@@ -4273,7 +4317,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             const SizedBox(width: 8),
             Expanded(
               child: TextFormField(
-                initialValue: product.length?.toString() ?? '',
+                initialValue: product.length != null ? _formatDecimal(product.length!) : '',
                 decoration: InputDecoration(
                   labelText: 'Длина L',
                   border: const OutlineInputBorder(),
@@ -4614,7 +4658,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   Widget _buildMakereadyFields() {
     return _buildFieldGrid([
       TextFormField(
-        initialValue: _makeready > 0 ? '$_makeready' : '',
+        initialValue: _makeready > 0 ? _formatDecimal(_makeready) : '',
         decoration: const InputDecoration(
           labelText: 'Приладка',
           border: OutlineInputBorder(),
@@ -4626,7 +4670,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         },
       ),
       TextFormField(
-        initialValue: _val > 0 ? '$_val' : '',
+        initialValue: _val > 0 ? _formatDecimal(_val) : '',
         decoration: const InputDecoration(
           labelText: 'ВАЛ',
           border: OutlineInputBorder(),

--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -130,8 +130,8 @@ class OrderDetailsCard extends StatelessWidget {
   Widget _buildDimensionsValue({bool compact = false}) {
     final p = order.product;
     final dimensions = <({String label, String value})>[
-      if (p.height != null) (label: 'Д', value: _fmtNum(p.height)),
-      if (p.width != null) (label: 'Ш', value: _fmtNum(p.width)),
+      if (p.width != null) (label: 'Д', value: _fmtNum(p.width)),
+      if (p.height != null) (label: 'Ш', value: _fmtNum(p.height)),
       if (p.depth != null) (label: 'Г', value: _fmtNum(p.depth)),
     ];
 
@@ -304,6 +304,13 @@ class OrderDetailsCard extends StatelessWidget {
         .where((v) => v.isNotEmpty)
         .toSet()
         .join(', ');
+    final paintInfoFromParams = RegExp(
+      r'Информация для красок:\s*([^;]+)',
+      caseSensitive: false,
+    ).firstMatch(p.parameters);
+    final fallbackPaintInfo = (paintInfoFromParams?.group(1) ?? '').trim();
+    final paintInfoValue =
+        paintInfo.isNotEmpty ? paintInfo : fallbackPaintInfo;
     final paintsWidget = paints.isEmpty
         ? const Text('—')
         : Column(
@@ -460,8 +467,8 @@ class OrderDetailsCard extends StatelessWidget {
                           alignEnd: false,
                           compact: true,
                         ),
-                        if (paintInfo.isNotEmpty)
-                          _buildInfoRow('Комментарий', paintInfo, compact: true),
+                        if (paintInfoValue.isNotEmpty)
+                          _buildInfoRow('Комментарий', paintInfoValue, compact: true),
                       ],
                     ),
                   ),

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -628,6 +628,34 @@ class _ProductionTab extends StatelessWidget {
   final _ProductionSort sort;
   final String? productTypeFilter;
 
+  List<String> _normalizeLabelParts(Iterable<String> raw) {
+    final normalized = <String>[];
+    final seen = <String>{};
+    for (final value in raw) {
+      for (final part in value.split(RegExp(r'[/,]'))) {
+        final trimmed = part.trim();
+        final key = trimmed.toLowerCase();
+        if (trimmed.isEmpty || !seen.add(key)) continue;
+        normalized.add(trimmed);
+      }
+    }
+    if (normalized.length >= 4 && normalized.length.isEven) {
+      final half = normalized.length ~/ 2;
+      var mirrored = true;
+      for (var i = 0; i < half; i++) {
+        if (normalized[i].toLowerCase() !=
+            normalized[normalized.length - 1 - i].toLowerCase()) {
+          mirrored = false;
+          break;
+        }
+      }
+      if (mirrored) {
+        normalized.removeRange(half, normalized.length);
+      }
+    }
+    return normalized;
+  }
+
   Map<String, _StageGroupInfo> _stageGroupsForOrder(
     OrderModel order,
     List<TaskModel> orderTasks,
@@ -655,21 +683,18 @@ class _ProductionTab extends StatelessWidget {
 
       final key = groupKeyForIds(ids);
       if (groups.containsKey(key)) return;
-      final labels = <String>{};
+      final labels = <String>[];
       final explicit = explicitLabel?.trim();
       if (explicit != null && explicit.isNotEmpty) {
-        for (final chunk in explicit.split('/')) {
-          final normalized = chunk.trim();
-          if (normalized.isNotEmpty) {
-            labels.add(normalized);
-          }
-        }
+        labels.addAll(_normalizeLabelParts([explicit]));
       }
       for (final id in ids) {
         final resolved = _stageLabel(id, taskProvider, personnelProvider, order.id).trim();
-        if (resolved.isNotEmpty) labels.add(resolved);
+        if (resolved.isNotEmpty) {
+          labels.addAll(_normalizeLabelParts([resolved]));
+        }
       }
-      final label = labels.join(' / ');
+      final label = _normalizeLabelParts(labels).join(' / ');
       final normalizedLabelKey =
           (label.isEmpty ? key : label).trim().toLowerCase();
       if (normalizedLabelKey.isNotEmpty &&
@@ -870,6 +895,19 @@ class _ProductionTab extends StatelessWidget {
     return true;
   }
 
+  bool _isOrderLockedInCurrentWorkplace(
+    OrderModel order,
+    _OrderGroupingData grouping,
+  ) {
+    final group = grouping.stageGroups.values.firstWhere(
+      (entry) => entry.stageIds.contains(tab.id),
+      orElse: () => const _StageGroupInfo(key: '', stageIds: [], label: ''),
+    );
+    if (group.stageIds.isEmpty) return false;
+    final tasksForGroup = grouping.tasksByGroup[group.key] ?? const <TaskModel>[];
+    return tasksForGroup.any((task) => task.status == TaskStatus.inProgress);
+  }
+
   List<OrderModel> _sortOrders(List<OrderModel> source) {
     if (source.length < 2) return source;
     final sorted = List<OrderModel>.from(source);
@@ -993,6 +1031,29 @@ class _ProductionTab extends StatelessWidget {
                 itemCount: ordered.length,
                 onReorder: (oldIndex, newIndex) {
                   if (newIndex > oldIndex) newIndex -= 1;
+                  if (oldIndex < 0 ||
+                      oldIndex >= ordered.length ||
+                      newIndex < 0 ||
+                      newIndex >= ordered.length) {
+                    return;
+                  }
+                  final movedOrder = ordered[oldIndex];
+                  final movedGrouping = groupingByOrder[movedOrder.id];
+                  final movedLocked = movedGrouping != null &&
+                      _isOrderLockedInCurrentWorkplace(
+                        movedOrder,
+                        movedGrouping,
+                      );
+                  if (movedLocked) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text(
+                          'Нельзя менять очередь: этот этап уже выполняется.',
+                        ),
+                      ),
+                    );
+                    return;
+                  }
                   final updated = List.of(ordered);
                   final item = updated.removeAt(oldIndex);
                   updated.insert(newIndex, item);

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1663,7 +1663,7 @@ class _TasksScreenState extends State<TasksScreen>
         ? const <TaskModel>[]
         : taskProvider.tasks.where((t) => t.stageId == _selectedWorkplaceId).toList();
     final stageQueueIds =
-        stageTasksAll.map((task) => task.id.trim()).where((id) => id.isNotEmpty).toSet().toList();
+        stageTasksAll.map((task) => task.orderId.trim()).where((id) => id.isNotEmpty).toSet().toList();
 
     _scheduleQueueSyncIfNeeded(
       queue: queue,
@@ -1674,8 +1674,8 @@ class _TasksScreenState extends State<TasksScreen>
     final sectionedTasks = tasksForWorkplace.toList();
     sectionedTasks.sort((a, b) =>
         queue
-            .priorityOf(a.id, groupId: queueGroupId)
-            .compareTo(queue.priorityOf(b.id, groupId: queueGroupId)));
+            .priorityOf(a.orderId, groupId: queueGroupId)
+            .compareTo(queue.priorityOf(b.orderId, groupId: queueGroupId)));
     final currentTask = _selectedTask != null
         ? taskProvider.tasks.firstWhere(
             (t) => t.id == _selectedTask!.id,
@@ -3486,8 +3486,8 @@ class _TasksScreenState extends State<TasksScreen>
     final queueGroupId = _selectedWorkplaceId!.trim();
     final queued = _tasksForWorkplace(taskProvider)
       ..sort((a, b) => queue
-          .priorityOf(a.id, groupId: queueGroupId)
-          .compareTo(queue.priorityOf(b.id, groupId: queueGroupId)));
+          .priorityOf(a.orderId, groupId: queueGroupId)
+          .compareTo(queue.priorityOf(b.orderId, groupId: queueGroupId)));
 
     final index = queued.indexWhere((t) => t.id == task.id);
     if (index <= 0) return true;


### PR DESCRIPTION
### Motivation
- Устранить потерю данных и некорректное отображение при редактировании/просмотре заказа (комментарии к краскам, поля размеров и числовые форматы). 
- Обеспечить корректную подготовку заказа к запуску: не переводить в `ready_to_start`, если не выбрана очередь этапов. 
- Вернуть согласованное поведение очереди между списком заданий и модулем управления производством и запретить перестановку, когда этап уже выполняется.

### Description
- Сохранение/восстановление информации для красок: добавлен отдельный маркер `Информация для красок:` в `product.parameters`, улучшен парсинг и восстановление при загрузке заказа и обновлена очистка параметров перед записи в `order_paints` (файл `lib/modules/orders/edit_order_screen.dart`).
- Форматирование числовых полей: использован внутренний форматтер `_formatDecimal(...)` для полей `Ширина b`, `Длина L`, `Приладка` и `ВАЛ`, чтобы убрать лишние `.0` в отображении и при инициализации контроллеров (файл `lib/modules/orders/edit_order_screen.dart`).
- Исправление мест swap длина/ширина в просмотре заказа: метки теперь берут значения из правильных полей (`Д` ← `product.width`, `Ш` ← `product.height`) (файл `lib/modules/orders/order_details_card.dart`).
- Логика статуса при сохранении заказа: если не выбрана очередь этапов (`stageTemplateId` пустой), заказ сохраняется как `draft` и показывается уведомление пользователю; раньше он мог переводиться в `ready_to_start` (файл `lib/modules/orders/edit_order_screen.dart`).
- Нормализация подписи этапов: добавлена логика разбиения/дедупликации меток и вырезания зеркальных дубликатов (A,B,C,C,B,A → A,B,C) чтобы избежать дублирования вида `a,b,b,a` или `a,b,a` (файл `lib/modules/production/production_screen.dart`).
- Защита от перестановки в очереди: при перетаскивании в `ReorderableListView` теперь проверяется, выполняется ли этап заказа в текущем рабочем месте, и в таком случае операция блокируется с `SnackBar` (файл `lib/modules/production/production_screen.dart`).
- Синхронизация очереди в рабочем пространстве: в `TasksScreen` очередь и сортировка по рабочему месту теперь используют `orderId` вместо `task.id`, чтобы совпадало с поведением `ProductionQueueProvider` (файл `lib/modules/tasks/tasks_screen.dart`).

### Testing
- Выполнена проверка изменённого кода и диффа с помощью `git diff` и `git status`, и изменения зафиксированы в коммите через `git commit` (успех). 
- Выполнены базовые инспекции фрагментов: `git log -1 --oneline` и просмотр `git diff` для всех трёх файлов (успех). 
- Попытки автоматического форматирования с `dart format` и `flutter format` не выполнились из-за отсутствия `dart`/`flutter` в окружении (неуспех), поэтому форматирование не было автоматически применено. 
- Юнит/интеграционные тесты проекта не запускались в этом окружении; изменения покрывают логику сохранения/отображения и очередей и требуют регрессионной проверки в CI/локально с доступным SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3623b854832f8f979c9c81bebc09)