### PR TITLE
Persist paint info in `orders.product` when no paints are selected

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -2219,6 +2219,11 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       if (rows.isNotEmpty) {
         await _sb.from('order_paints').insert(rows);
       }
+      // Сохраняем актуальные product.parameters даже когда красок нет:
+      // в этом случае "Информация для красок" должна оставаться в заказе.
+      await _sb.from('orders').update({
+        'product': _product.toMap(),
+      }).eq('id', orderId);
     } catch (e) {
       // не блокируем сохранение заказа, просто сообщим в консоль
       debugPrint('❌ persist paints error: ' + e.toString());


### PR DESCRIPTION
### Motivation
- Исправить потерю текста из поля «Информация для красок» при сохранении заказа, когда пользователем заполнено только общее примечание, но не выбраны отдельные позиции краски.

### Description
- В `lib/modules/orders/edit_order_screen.dart` в методе `_persistPaints` добавлено обновление записи в таблице `orders` через `_sb.from('orders').update({'product': _product.toMap()}).eq('id', orderId);`, чтобы `product.parameters` (включая `Информация для красок`) всегда сохранялся даже при пустом списке `order_paints`.

### Testing
- Выполнены команды: `git status --short` (успешно) и `git commit` (успешно); попытка запустить `dart format lib/modules/orders/edit_order_screen.dart` не удалась из-за отсутствия бинарника `dart` в окружении (ошибка).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3b41bacc832f8b045842189c3626)