### PR TITLE
Fix duplicate workplaces in production stage labels

### DIFF
--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -130,16 +130,29 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
     List<String> stageIds,
     PersonnelProvider personnel,
   ) {
-    final names = _plannedStageNames(planned);
-    if (names.isNotEmpty) {
-      return names.join(' / ');
+    final normalized = <String>[];
+    final seen = <String>{};
+
+    void addParts(Iterable<String> values) {
+      for (final value in values) {
+        for (final rawPart in value.split(RegExp(r'[/,]'))) {
+          final cleaned = rawPart.trim().replaceAll(RegExp(r'^\(+|\)+$'), '');
+          if (cleaned.isEmpty) continue;
+          final key = cleaned.toLowerCase();
+          if (!seen.add(key)) continue;
+          normalized.add(cleaned);
+        }
+      }
     }
+
+    addParts(_plannedStageNames(planned));
+    if (normalized.isNotEmpty) {
+      return normalized.join(' / ');
+    }
+
     if (stageIds.isEmpty) return planned.stageName;
-    final resolved = stageIds
-        .map((id) => _resolveStageName(id, personnel))
-        .where((name) => name.trim().isNotEmpty)
-        .toList();
-    return resolved.isEmpty ? planned.stageName : resolved.toSet().join(' / ');
+    addParts(stageIds.map((id) => _resolveStageName(id, personnel)));
+    return normalized.isEmpty ? planned.stageName : normalized.join(' / ');
   }
 
   Future<void> _skipStageForTesting(List<TaskModel> stageTasks) async {


### PR DESCRIPTION
### Motivation
- Stage labels in order production details could show duplicated workplace names when a stage includes multiple workplaces, producing outputs like `( место A, место B, место A)`, which must be avoided.

### Description
- Updated label generation in `lib/modules/production/production_details_screen.dart` by changing `_plannedStageLabel` to normalize, split and deduplicate parts before joining them for display.
- Splitting now occurs on `/` and `,`, and outer parentheses are stripped from parts to avoid format differences causing duplicates.
- Deduplication is case-insensitive and preserves the first-seen order, while keeping the existing fallback to `planned.stageName` when no normalized names are found.
- The change is limited to label construction logic and does not alter task or stage data sources.

### Testing
- Ran `git -C /workspace/app status --short` to confirm the change was staged and committed (succeeded).
- Attempted `dart format lib/modules/production/production_details_screen.dart` but the environment lacks the `dart` binary (failed).
- Attempted `flutter --version` to check Flutter tooling but the environment lacks the `flutter` binary (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3ddf9fe4832f8e053724cfea6c2f)