### PR TITLE
Уточнить выбор бумаги по формату/грамажу и синхронизацию резерва

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -518,15 +518,14 @@ class OrdersProvider with ChangeNotifier {
       return 'Укажите причину изменения бумаги.';
     }
 
-    final prepared = paperMaterials
-        .where((paper) => (paper.id ?? '').trim().isNotEmpty)
-        .map((paper) {
-          final double qty = paper.quantity > 0
-              ? paper.quantity
-              : (paper.weight != null && paper.weight! > 0 ? paper.weight! : 0.0);
-          return paper.copyWith(quantity: qty);
-        })
-        .toList(growable: false);
+    final prepared = <MaterialModel>[];
+    for (final paper in paperMaterials) {
+      final normalizedPaper = await _normalizePaperForReservation(paper);
+      if ((normalizedPaper.id ?? '').trim().isEmpty) {
+        continue;
+      }
+      prepared.add(normalizedPaper);
+    }
     if (prepared.isEmpty) {
       return 'Добавьте хотя бы один тип бумаги.';
     }
@@ -1222,6 +1221,47 @@ class OrdersProvider with ChangeNotifier {
     return 0;
   }
 
+  Future<MaterialModel> _normalizePaperForReservation(MaterialModel paper) async {
+    final double qty = paper.quantity > 0
+        ? paper.quantity
+        : (paper.weight != null && paper.weight! > 0 ? paper.weight! : 0.0);
+    final normalized = paper.copyWith(quantity: qty);
+    final currentId = (normalized.id ?? '').trim();
+    if (currentId.isNotEmpty) {
+      return normalized;
+    }
+    final resolvedId = await _resolvePaperIdByAttributes(normalized);
+    if (resolvedId == null) {
+      return normalized;
+    }
+    return normalized.copyWith(id: resolvedId);
+  }
+
+  Future<String?> _resolvePaperIdByAttributes(MaterialModel paper) async {
+    final name = paper.name.trim();
+    final format = (paper.format ?? '').trim();
+    final grammage = (paper.grammage ?? '').trim();
+    if (name.isEmpty || format.isEmpty || grammage.isEmpty) {
+      return null;
+    }
+    try {
+      final row = await _supabase
+          .from('papers')
+          .select('id')
+          .eq('description', name)
+          .eq('format', format)
+          .eq('grammage', grammage)
+          .maybeSingle();
+      if (row is Map) {
+        final id = (row['id'] ?? '').toString().trim();
+        return id.isEmpty ? null : id;
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
   Future<String?> _syncPaperReservationsForOrder(OrderModel order) async {
     final papers = _resolveOrderPapers(order)
         .where((paper) => (paper.id ?? '').trim().isNotEmpty)
@@ -1473,11 +1513,18 @@ class OrdersProvider with ChangeNotifier {
     required OrderModel previous,
     required OrderModel updated,
   }) {
+    bool textChanged(String? a, String? b) {
+      return (a ?? '').trim().toLowerCase() != (b ?? '').trim().toLowerCase();
+    }
+
     final before = _resolveOrderPapers(previous);
     final after = _resolveOrderPapers(updated);
     if (before.length != after.length) return true;
     for (var i = 0; i < before.length; i++) {
       if (before[i].id != after[i].id ||
+          textChanged(before[i].name, after[i].name) ||
+          textChanged(before[i].format, after[i].format) ||
+          textChanged(before[i].grammage, after[i].grammage) ||
           (before[i].quantity - after[i].quantity).abs() > 0.0001) {
         return true;
       }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1028,9 +1028,46 @@ class _TasksScreenState extends State<TasksScreen>
 
     final papers = warehouse.allTmc.where(isPaperType).toList();
     papers.sort(
-      (a, b) => a.description.toLowerCase().compareTo(b.description.toLowerCase()),
+      (a, b) {
+        final byName =
+            a.description.toLowerCase().compareTo(b.description.toLowerCase());
+        if (byName != 0) return byName;
+        final byFormat =
+            (a.format ?? '').toLowerCase().compareTo((b.format ?? '').toLowerCase());
+        if (byFormat != 0) return byFormat;
+        return (a.grammage ?? '')
+            .toLowerCase()
+            .compareTo((b.grammage ?? '').toLowerCase());
+      },
     );
     return papers;
+  }
+
+  String _paperLabel(TmcModel paper) {
+    final details = <String>[
+      if ((paper.format ?? '').trim().isNotEmpty) 'Формат: ${paper.format}',
+      if ((paper.grammage ?? '').trim().isNotEmpty) 'Грамаж: ${paper.grammage}',
+    ];
+    if (details.isEmpty) return paper.description;
+    return '${paper.description} (${details.join(', ')})';
+  }
+
+  bool _matchPaperSearch(TmcModel paper, String query) {
+    final normalized = query.trim().toLowerCase();
+    if (normalized.isEmpty) return true;
+    final searchable = [
+      paper.description,
+      paper.format ?? '',
+      paper.grammage ?? '',
+      paper.id,
+    ].join(' ').toLowerCase();
+    final tokens = normalized
+        .split(RegExp(r'[\s,;]+'))
+        .where((token) => token.isNotEmpty);
+    for (final token in tokens) {
+      if (!searchable.contains(token)) return false;
+    }
+    return true;
   }
 
   Future<void> _openPaperEditDialog(OrderModel baseOrder) async {
@@ -1081,9 +1118,22 @@ class _TasksScreenState extends State<TasksScreen>
         }(),
     ];
     final reasonController = TextEditingController();
+    final paperSearchController = TextEditingController();
     final formKey = GlobalKey<FormState>();
     String? errorText;
     bool saving = false;
+    String paperSearch = '';
+
+    List<TmcModel> papersForPicker() {
+      final selectedIds = selected
+          .map((item) => (item.id ?? '').trim())
+          .where((id) => id.isNotEmpty)
+          .toSet();
+      return papers.where((paper) {
+        if (selectedIds.contains(paper.id)) return true;
+        return _matchPaperSearch(paper, paperSearch);
+      }).toList(growable: false);
+    }
 
     Future<void> addSlot(StateSetter setDialogState) async {
       if (selected.length >= 3) return;
@@ -1133,10 +1183,10 @@ class _TasksScreenState extends State<TasksScreen>
                                       labelText: 'Бумага №${i + 1}',
                                     ),
                                     items: [
-                                      for (final paper in papers)
+                                      for (final paper in papersForPicker())
                                         DropdownMenuItem<String>(
                                           value: paper.id,
-                                          child: Text(paper.description),
+                                          child: Text(_paperLabel(paper)),
                                         ),
                                     ],
                                     validator: (value) =>
@@ -1200,12 +1250,39 @@ class _TasksScreenState extends State<TasksScreen>
                           ),
                         Align(
                           alignment: Alignment.centerLeft,
-                          child: TextButton.icon(
-                            onPressed: selected.length >= 3 || saving
-                                ? null
-                                : () => addSlot(setDialogState),
-                            icon: const Icon(Icons.add),
-                            label: const Text('Добавить бумагу'),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              TextField(
+                                controller: paperSearchController,
+                                decoration: InputDecoration(
+                                  labelText: 'Поиск бумаги',
+                                  hintText: 'Наименование, формат, грамаж',
+                                  prefixIcon: const Icon(Icons.search),
+                                  suffixIcon: paperSearch.isEmpty
+                                      ? null
+                                      : IconButton(
+                                          onPressed: () {
+                                            setDialogState(() {
+                                              paperSearch = '';
+                                              paperSearchController.clear();
+                                            });
+                                          },
+                                          icon: const Icon(Icons.clear),
+                                        ),
+                                ),
+                                onChanged: (value) =>
+                                    setDialogState(() => paperSearch = value),
+                              ),
+                              const SizedBox(height: 8),
+                              TextButton.icon(
+                                onPressed: selected.length >= 3 || saving
+                                    ? null
+                                    : () => addSlot(setDialogState),
+                                icon: const Icon(Icons.add),
+                                label: const Text('Добавить бумагу'),
+                              ),
+                            ],
                           ),
                         ),
                         const SizedBox(height: 8),
@@ -1293,6 +1370,7 @@ class _TasksScreenState extends State<TasksScreen>
     for (final controller in qtyControllers) {
       controller.dispose();
     }
+    paperSearchController.dispose();
     reasonController.dispose();
   }
 


### PR DESCRIPTION
### Motivation
- Была проблема: при изменении бумаги в заказе позиции с одинаковым `description` могли отличаться по `format`/`grammage`, и резерв на складе мог попасть не на ту карточку; это нужно исправить чтобы резерв всегда соотносился с конкретной номенклатурой бумаги. 
- Также важно упростить подбор бумаги в рабочем пространстве: поиск и отображение должны учитывать формат и грамаж, чтобы сотрудник не выбрал «не ту» бумагу.

### Description
- В `lib/modules/tasks/tasks_screen.dart` уточнена сортировка бумажных TMC (наименование → формат → грамаж), добавлен человекочитаемый label `_paperLabel`, реализован токенизированный поиск `_matchPaperSearch`, в диалоге редактирования бумаги добавлено поле поиска и фильтрация списка с сохранением уже выбранных позиций, и добавлено корректное освобождение `paperSearchController`.
- В `lib/modules/orders/orders_provider.dart` при сохранении состава бумаги материалы нормализуются через `_normalizePaperForReservation`, и при отсутствии `id` пытается быть найден `id` по сочетанию `description + format + grammage` через `_resolvePaperIdByAttributes` (по таблице `papers`).
- Детектор изменений состава бумаги `_hasPaperCompositionChanged` усилен: теперь учитывает изменения `name`, `format` и `grammage` (сравнение трим/без учета регистра), чтобы правки формата/грамажа всегда считались изменением и инициировали пересчёт резерва.
- Логика синхронизации резерва (`_syncPaperReservationsForOrder`) осталась, но получает нормализованные `paper.id`, что гарантирует перемещение резерва между корректными карточками склада.

### Testing
- Запустил `git diff --check`, проблем не обнаружено.
- Пытался применить автоматическое форматирование через `dart format` и `flutter format`, но исполняемые файлы отсутствуют в окружении, поэтому форматирование не выполнено. 
- Автоматических unit/integration тестов в этой итерации не запускал (внесены только функциональные изменения и UI-улучшения).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df45c58c0c832fb3bc9db64ef7eb63)