### PR TITLE
Fix nullable map access in paper id lookup

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1245,17 +1245,15 @@ class OrdersProvider with ChangeNotifier {
       return null;
     }
     try {
-      final row = await _supabase
+      final Map<String, dynamic>? row = await _supabase
           .from('papers')
           .select('id')
           .eq('description', name)
           .eq('format', format)
           .eq('grammage', grammage)
           .maybeSingle();
-      if (row is Map) {
-        final id = (row['id'] ?? '').toString().trim();
-        return id.isEmpty ? null : id;
-      }
+      final id = (row?['id'] ?? '').toString().trim();
+      return id.isEmpty ? null : id;
     } catch (_) {
       return null;
     }


### PR DESCRIPTION
### Motivation
- Fix a null-safety error in `_resolvePaperIdByAttributes` that caused a Windows build failure: "Operator '[]' cannot be called on 'Map<String, dynamic>?'."

### Description
- In `lib/modules/orders/orders_provider.dart` typed the `maybeSingle()` result as `Map<String, dynamic>?` and replaced unsafe `row['id']` access with null-safe `row?['id']`, trimming and returning `null` when the id is empty inside `_resolvePaperIdByAttributes`.

### Testing
- Attempted to run `dart analyze lib/modules/orders/orders_provider.dart`, but analysis could not be executed because `dart` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df47482620832fb72be516db524828)