### PR TITLE
Fix nullable map access in paper ID lookup

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1252,7 +1252,10 @@ class OrdersProvider with ChangeNotifier {
           .eq('format', format)
           .eq('grammage', grammage)
           .maybeSingle();
-      final id = (row?['id'] ?? '').toString().trim();
+      if (row == null) {
+        return null;
+      }
+      final id = (row['id'] ?? '').toString().trim();
       return id.isEmpty ? null : id;
     } catch (_) {
       return null;


### PR DESCRIPTION
### Motivation
- Устранить null-safety ошибку в `_resolvePaperIdByAttributes`, где оператор `[]` вызывался у nullable `Map<String, dynamic>?`, что приводило к ошибке сборки.

### Description
- В `lib/modules/orders/orders_provider.dart` добавлена явная проверка `if (row == null) return null;` перед чтением `row['id']`, сохраняя прежнее поведение — возвращать `null`, если запись не найдена или `id` пустой.

### Testing
- Попытки статического анализа через `dart analyze lib/modules/orders/orders_provider.dart` и проверки окружения через `flutter --version` не завершились в этой среде, так как `dart`/`flutter` не установлены (команды вернули "command not found").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4820a3b4832fa13416e4a54c2919)