### PR TITLE
Fix undefined paperSearchController in TasksScreen

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1454,7 +1454,7 @@ class _TasksScreenState extends State<TasksScreen>
     for (final controller in qtyControllers) {
       controller.dispose();
     }
-    paperSearchController.dispose();
+    searchController.dispose();
     reasonController.dispose();
   }
 


### PR DESCRIPTION
### Motivation
- Fix build failure caused by a reference to a non-existent `paperSearchController` in `_TasksScreenState`.

### Description
- Replace `paperSearchController.dispose()` with `searchController.dispose()` in `lib/modules/tasks/tasks_screen.dart` to dispose the actually-declared controller.

### Testing
- Attempted to run `flutter analyze lib/modules/tasks/tasks_screen.dart`, but `flutter` is not installed in this environment so static analysis could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4b02c268832fb33a106072f097e7)