### PR TITLE
Fix paper search controller lifecycle in TasksScreen

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1078,16 +1078,17 @@ class _TasksScreenState extends State<TasksScreen>
   }) async {
     final searchController = TextEditingController();
     var search = '';
-    return showDialog<TmcModel>(
-      context: context,
-      builder: (pickerContext) {
-        return StatefulBuilder(
-          builder: (pickerContext, setPickerState) {
-            final filtered = papers.where((paper) {
-              if (excludedIds.contains(paper.id)) return false;
-              return _matchPaperSearch(paper, search);
-            }).toList(growable: false);
-            return AlertDialog(
+    try {
+      return showDialog<TmcModel>(
+        context: context,
+        builder: (pickerContext) {
+          return StatefulBuilder(
+            builder: (pickerContext, setPickerState) {
+              final filtered = papers.where((paper) {
+                if (excludedIds.contains(paper.id)) return false;
+                return _matchPaperSearch(paper, search);
+              }).toList(growable: false);
+              return AlertDialog(
               title: const Text('Выбор бумаги'),
               content: SizedBox(
                 width: 540,
@@ -1151,8 +1152,11 @@ class _TasksScreenState extends State<TasksScreen>
             );
           },
         );
-      },
-    );
+        },
+      );
+    } finally {
+      searchController.dispose();
+    }
   }
 
   Future<void> _openPaperEditDialog(OrderModel baseOrder) async {
@@ -1454,7 +1458,6 @@ class _TasksScreenState extends State<TasksScreen>
     for (final controller in qtyControllers) {
       controller.dispose();
     }
-    searchController.dispose();
     reasonController.dispose();
   }
 


### PR DESCRIPTION
### Motivation
- The build failed because `_openPaperEditDialog` referenced a `searchController` that is not a member of `_TasksScreenState`, causing an undefined getter error during compilation of the Windows build. 
- The local `searchController` created inside `_pickPaperForSlot` was not reliably disposed in all execution paths, risking resource leaks.

### Description
- Wrap the `showDialog` call in `_pickPaperForSlot` with a `try/finally` and call `searchController.dispose()` from the `finally` block to ensure the local controller is always disposed; change is in `lib/modules/tasks/tasks_screen.dart`. 
- Remove the invalid `searchController.dispose()` call from `_openPaperEditDialog` so the state class no longer references a non-existent controller. 
- Adjust surrounding indentation/structure to keep the dialog builder logic unchanged while fixing the controller lifecycle.

### Testing
- Ran `rg -n "searchController\.dispose\(|paperSearchController" lib/modules/tasks/tasks_screen.dart` to verify there are no stray references to a non-scoped `paperSearchController`, and the check succeeded. 
- Attempted `dart format` and `flutter --version` in this environment but both commands failed because the tools are not installed here (`/bin/bash: dart: command not found` and `/bin/bash: flutter: command not found`). 
- Committed the change locally and the patch contains the intended additions/removals to `lib/modules/tasks/tasks_screen.dart`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4bcd6b6c832faa1c54d8b8564405)