### PR TITLE
Harden paper edit flow in workspace dialog

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1043,6 +1043,15 @@ class _TasksScreenState extends State<TasksScreen>
     return papers;
   }
 
+  Future<List<TmcModel>> _workspacePaperItemsFresh() async {
+    final warehouse = context.read<WarehouseProvider>();
+    // На первом открытии диалога склад может быть ещё не загружен:
+    // выполняем принудительное обновление, чтобы избежать ложного
+    // "бумага не найдена" и корректно открыть выбор с первого раза.
+    await warehouse.fetchTmc();
+    return _workspacePaperItems();
+  }
+
   bool _matchPaperSearch(TmcModel paper, String query) {
     final normalized = query.trim().toLowerCase();
     if (normalized.isEmpty) return true;
@@ -1082,6 +1091,51 @@ class _TasksScreenState extends State<TasksScreen>
   String _paperGrammageText(String? grammage) {
     final value = (grammage ?? '').trim();
     return value.isEmpty ? '—' : value;
+  }
+
+  String? _validatePaperRow({
+    required MaterialModel selected,
+    required String editedFormat,
+    required String editedGrammage,
+    required double qty,
+    required List<TmcModel> papers,
+  }) {
+    final selectedId = (selected.id ?? '').trim();
+    final matchedById = selectedId.isEmpty
+        ? null
+        : papers.cast<TmcModel?>().firstWhere(
+              (paper) => paper?.id == selectedId,
+              orElse: () => null,
+            );
+    final matchedByName = papers.cast<TmcModel?>().firstWhere(
+          (paper) => paper?.description.trim().toLowerCase() ==
+              selected.name.trim().toLowerCase(),
+          orElse: () => null,
+        );
+    final matchedPaper = matchedById ?? matchedByName;
+    if (matchedPaper == null) {
+      return 'Выбранная бумага «${selected.name}» отсутствует на складе.';
+    }
+
+    final normalizedEditedFormat = editedFormat.trim();
+    final normalizedEditedGrammage = editedGrammage.trim();
+    final paperFormat = (matchedPaper.format ?? '').trim();
+    final paperGrammage = (matchedPaper.grammage ?? '').trim();
+
+    if (paperFormat.isNotEmpty &&
+        normalizedEditedFormat.toLowerCase() != paperFormat.toLowerCase()) {
+      return 'Формат для «${matchedPaper.description}» должен быть "$paperFormat".';
+    }
+    if (paperGrammage.isNotEmpty &&
+        normalizedEditedGrammage.toLowerCase() != paperGrammage.toLowerCase()) {
+      return 'Грамаж для «${matchedPaper.description}» должен быть "$paperGrammage".';
+    }
+    if (qty > matchedPaper.quantity) {
+      return 'Недостаточно бумаги «${matchedPaper.description}»: '
+          'доступно ${matchedPaper.quantity.toStringAsFixed(2)} ${matchedPaper.unit}.';
+    }
+
+    return null;
   }
 
   Future<TmcModel?> _pickPaperForSlot({
@@ -1179,7 +1233,7 @@ class _TasksScreenState extends State<TasksScreen>
         : <MaterialModel>[
             if (latest.material != null) latest.material!,
           ];
-    final papers = _workspacePaperItems();
+    final papers = await _workspacePaperItemsFresh();
     if (!mounted) return;
     if (papers.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -1452,6 +1506,20 @@ class _TasksScreenState extends State<TasksScreen>
                                 formatControllers[i].text.trim();
                             final editedGrammage =
                                 grammageControllers[i].text.trim();
+                            final rowValidationError = _validatePaperRow(
+                              selected: selected[i],
+                              editedFormat: editedFormat,
+                              editedGrammage: editedGrammage,
+                              qty: qty,
+                              papers: papers,
+                            );
+                            if (rowValidationError != null) {
+                              setDialogState(() {
+                                saving = false;
+                                errorText = rowValidationError;
+                              });
+                              return;
+                            }
                             nextLengthL ??= qty;
                             nextMaterials.add(
                               selected[i].copyWith(


### PR DESCRIPTION
### Motivation
- Усилить валидацию при правке состава бумаги, чтобы проверять наличие выбранной бумаги и соответствие введённых `Формат`/`Грамаж` реальной складской записи и доступного количества. 
- Устранить баг, при котором при первом открытии диалога бумаги список мог быть пустым из‑за ещё не загруженного склада. 
- Блокировать отправку некорректных данных в бекенд и показывать понятные ошибки пользователю в диалоге.

### Description
- Добавлена асинхронная загрузка свежего списка бумаги через `Future<List<TmcModel>> _workspacePaperItemsFresh()` которая выполняет `await warehouse.fetchTmc()` перед построением списка бумаги. 
- Добавлена функция валидации строки бумаги `String? _validatePaperRow({...})`, которая проверяет существование бумаги (по `id` или названию), совпадение `format` и `grammage` с записью склада и что запрошенное `qty` не превышает `matchedPaper.quantity`. 
- Интегрирована валидация в диалог правки: `_openPaperEditDialog` теперь использует `await _workspacePaperItemsFresh()` и вызывает `_validatePaperRow` для каждой строки перед вызовом `orders.updateOrderPapersFromWorkspace`, при ошибке устанавливает `errorText` и отменяет сохранение.

### Testing
- Попытки статической проверки `flutter analyze` и `dart analyze` в этой среде завершились неудачей из‑за отсутствия бинарей (`flutter` и `dart` не найдены). 
- Изменения локально применены в `lib/modules/tasks/tasks_screen.dart` and no unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4faf69f4832f9b7d7922a1b0882f)