### PR TITLE
Показывать `assignment_id` в подписи заказа для резерва бумаги

### DIFF
--- a/lib/modules/warehouse/warehouse_provider.dart
+++ b/lib/modules/warehouse/warehouse_provider.dart
@@ -181,11 +181,13 @@ class WarehouseProvider with ChangeNotifier {
               : <String, dynamic>{};
 
           final primaryLabel = _firstNotEmpty([
+            row['assignment_id'],
             row['title'],
             row['name'],
             row['order_name'],
             row['product_name'],
             data['title'],
+            data['assignment_id'],
             data['name'],
             data['order_name'],
             data['product_name'],


### PR DESCRIPTION
### Motivation
- В UI деталей резерва бумаги вместо реального идентификатора/названия заказа иногда отображалась `Форма №...`, потому что `assignment_id` не учитывался в приоритете при формировании метки заказа.

### Description
- Добавлено использование `assignment_id` из корневой записи заказа в приоритете кандидатов для подписи заказа в `paperReserveDetails`.
- Также добавлено использование `data['assignment_id']` для покрытия вложенной структуры заказа; изменение находится в `lib/modules/warehouse/warehouse_provider.dart`.
- В случае отсутствия осмысленной метки поведение с fallback на `new_form_no` или `'Заказ без названия'` сохранено.

### Testing
- Проверены изменённые строки и дифф-файл, и подтверждено, что приоритет меток теперь включает `assignment_id` (локальная проверка содержимого файла прошла успешно).
- Форматирование через `dart format` не было выполнено в этом окружении, потому что `dart` не установлен (`/bin/bash: line 1: dart: command not found`).
- Автоматических unit/integration тестов в рамках этого изменения не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5257a590832f9ac35756f5147f15)