### PR TITLE
Use customer order name in flexo paint writeoff comments

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3346,13 +3346,13 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   String _orderDisplayNameForWriteoff(OrderModel order) {
-    final productName = order.product.type.trim();
-    if (productName.isNotEmpty && !_looksLikeOrderCode(productName)) {
-      return productName;
-    }
     final customer = order.customer.trim();
     if (customer.isNotEmpty && !_looksLikeOrderCode(customer)) {
       return customer;
+    }
+    final productName = order.product.type.trim();
+    if (productName.isNotEmpty && !_looksLikeOrderCode(productName)) {
+      return productName;
     }
     return 'Без названия';
   }


### PR DESCRIPTION
### Motivation
- Paint writeoff comments created after flexo completion must show the order name entered in the "Заказчик" field (`order.customer`) instead of product type, order id or stage identifiers.

### Description
- Change `_orderDisplayNameForWriteoff` in `lib/modules/tasks/tasks_screen.dart` to prefer `order.customer` first and fall back to `order.product.type` only when the customer name is empty or looks like an order code.

### Testing
- Inspected the code diff to confirm only `_orderDisplayNameForWriteoff` priority was changed and the file was updated; attempted to run `dart format` but `dart` is not available in the current environment, and no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5400c100832f84434f03cee24a13)