### PR TITLE
Показывать имя заказчика в резервах бумаги вместо ID

### DIFF
--- a/lib/modules/warehouse/paper_table.dart
+++ b/lib/modules/warehouse/paper_table.dart
@@ -198,7 +198,6 @@ class _PaperTableState extends State<PaperTable> {
               : ListView(
                   shrinkWrap: true,
                   children: details.map((row) {
-                    final orderId = (row['order_id'] ?? '').toString();
                     final orderName = (row['order_name'] ?? '').toString().trim();
                     final hasOrderName = orderName.isNotEmpty &&
                         orderName.toLowerCase() != 'null' &&
@@ -208,14 +207,7 @@ class _PaperTableState extends State<PaperTable> {
                     final qty = (row['qty'] as num?)?.toDouble() ??
                         double.tryParse('${row['qty']}') ??
                         0;
-                    final normalizedOrderId = orderId.trim().isEmpty
-                        ? 'Без номера'
-                        : orderId.trim();
-                    final orderLabel = hasOrderName
-                        ? orderName
-                        : (normalizedOrderId == 'Без номера'
-                            ? 'Заказ без названия'
-                            : 'Заказ без названия ($normalizedOrderId)');
+                    final orderLabel = hasOrderName ? orderName : 'Заказ без названия';
                     return ListTile(
                       dense: true,
                       title: Text(orderLabel),

--- a/lib/modules/warehouse/type_table_screen.dart
+++ b/lib/modules/warehouse/type_table_screen.dart
@@ -498,7 +498,6 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
               : ListView(
                   shrinkWrap: true,
                   children: details.map((row) {
-                    final orderId = (row['order_id'] ?? '').toString();
                     final orderName = (row['order_name'] ?? '').toString().trim();
                     final hasOrderName = orderName.isNotEmpty &&
                         orderName.toLowerCase() != 'null' &&
@@ -508,14 +507,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                     final qty = (row['qty'] as num?)?.toDouble() ??
                         double.tryParse('${row['qty']}') ??
                         0;
-                    final normalizedOrderId = orderId.trim().isEmpty
-                        ? 'Без номера'
-                        : orderId.trim();
-                    final orderLabel = hasOrderName
-                        ? orderName
-                        : (normalizedOrderId == 'Без номера'
-                            ? 'Заказ без названия'
-                            : 'Заказ без названия ($normalizedOrderId)');
+                    final orderLabel = hasOrderName ? orderName : 'Заказ без названия';
                     return Container(
                       margin: const EdgeInsets.only(bottom: 8),
                       padding: const EdgeInsets.symmetric(

--- a/lib/modules/warehouse/type_table_tabs_screen.dart
+++ b/lib/modules/warehouse/type_table_tabs_screen.dart
@@ -555,7 +555,6 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
               : ListView(
                   shrinkWrap: true,
                   children: details.map((row) {
-                    final orderId = (row['order_id'] ?? '').toString();
                     final orderName = (row['order_name'] ?? '').toString().trim();
                     final hasOrderName = orderName.isNotEmpty &&
                         orderName.toLowerCase() != 'null' &&
@@ -565,14 +564,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                     final qty = (row['qty'] as num?)?.toDouble() ??
                         double.tryParse('${row['qty']}') ??
                         0;
-                    final normalizedOrderId = orderId.trim().isEmpty
-                        ? 'Без номера'
-                        : orderId.trim();
-                    final orderLabel = hasOrderName
-                        ? orderName
-                        : (normalizedOrderId == 'Без номера'
-                            ? 'Заказ без названия'
-                            : 'Заказ без названия ($normalizedOrderId)');
+                    final orderLabel = hasOrderName ? orderName : 'Заказ без названия';
                     return Container(
                       margin: const EdgeInsets.only(bottom: 8),
                       padding: const EdgeInsets.symmetric(

--- a/lib/modules/warehouse/warehouse_provider.dart
+++ b/lib/modules/warehouse/warehouse_provider.dart
@@ -181,11 +181,13 @@ class WarehouseProvider with ChangeNotifier {
               : <String, dynamic>{};
 
           final primaryLabel = _firstNotEmpty([
-            row['assignment_id'],
+            row['customer'],
             row['title'],
             row['name'],
             row['order_name'],
             row['product_name'],
+            row['assignment_id'],
+            data['customer'],
             data['title'],
             data['assignment_id'],
             data['name'],


### PR DESCRIPTION
### Motivation
- В резервах бумаги нужно показывать читаемое название заказа (имя/название/заказчик), а не технический `order_id`, чтобы сотрудники сразу видели, за чей заказ отложен материал.

### Description
- Обновлена логика формирования метки заказа в `warehouse_provider.dart` — теперь в приоритете используется `orders.customer` и `data.customer`, затем прочие человекочитаемые поля, и только после этого технические fallback-поля; результат записывается в `order_name` для отображения.
- Упрощён UI в диалогах резерва в `paper_table.dart`, `type_table_screen.dart` и `type_table_tabs_screen.dart` — убран fallback с подстановкой `order_id` в скобках, и вместо этого выводится либо человекочитаемое имя, либо нейтральное `Заказ без названия`.
- Код адаптирован так, чтобы резервные записи отображали только понятную пользователю строку имени/названия заказа без добавления технических идентификаторов.

### Testing
- Проверена разница по затронутым файлам и подтверждён ожидаемый заменённый текст в диалогах и в провайдере (diff verification — успешно). 
- Статический прогон локальных проверок файлов показал изменения в `lib/modules/warehouse/warehouse_provider.dart`, `lib/modules/warehouse/paper_table.dart`, `lib/modules/warehouse/type_table_screen.dart` и `lib/modules/warehouse/type_table_tabs_screen.dart` (verification OK). 
- Попытка запустить `dart format` в среде завершилась неудачей из‑за отсутствия Dart SDK в этом окружении (format — failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5552c3a4832f82bf786fd8062c5b)