### PR TITLE
Немедленное обновление статуса наличия материалов после правки заказа

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -482,6 +482,7 @@ class OrdersProvider with ChangeNotifier {
           throw Exception(reserveError);
         }
       }
+      await _applyImmediateMaterialAvailabilityState(updated);
       final paperHistory = _describePaperChanges(
         previous: prev,
         updated: updated,
@@ -569,6 +570,7 @@ class OrdersProvider with ChangeNotifier {
       if (reserveError != null) {
         throw Exception(reserveError);
       }
+      await _applyImmediateMaterialAvailabilityState(updated);
       final paperHistory = _describePaperChanges(
         previous: prev,
         updated: updated,
@@ -1190,6 +1192,40 @@ class OrdersProvider with ChangeNotifier {
       orderId: updated.id,
       orderLabel: _buildOrderLabelForWriteoff(updated),
     );
+  }
+
+  Future<void> _applyImmediateMaterialAvailabilityState(OrderModel order) async {
+    final hasEnough = await _hasEnoughMaterialForLaunch(order);
+    final shortageMessage = hasEnough ? '' : await _materialShortageMessage(order);
+    final nextStatus = hasEnough
+        ? (order.statusEnum == OrderStatus.waiting_materials
+            ? OrderStatus.ready_to_start
+            : order.statusEnum)
+        : OrderStatus.waiting_materials;
+
+    if (order.statusEnum == nextStatus &&
+        order.hasMaterialShortage == !hasEnough &&
+        order.materialShortageMessage == shortageMessage) {
+      return;
+    }
+
+    final updatePayload = <String, dynamic>{
+      'status': nextStatus.name,
+      'has_material_shortage': !hasEnough,
+      'material_shortage_message': shortageMessage,
+    };
+
+    await _supabase.from('orders').update(updatePayload).eq('id', order.id);
+
+    final index = _orders.indexWhere((o) => o.id == order.id);
+    if (index != -1) {
+      _orders[index] = _orders[index].copyWith(
+        status: nextStatus.name,
+        hasMaterialShortage: !hasEnough,
+        materialShortageMessage: shortageMessage,
+      );
+      notifyListeners();
+    }
   }
 
   String _buildOrderLabelForWriteoff(OrderModel order) {


### PR DESCRIPTION
### Motivation
- При редактировании заказа (в том числе изменения длины бумаги) нужно сразу переводить заказ в `waiting_materials` при нехватке или обратно в `ready_to_start`, не ожидая отложенной проверки остатков.

### Description
- Добавлена немедленная пересчётная логика в `OrdersProvider.updateOrder` после сохранения, вызывающая новый метод `_applyImmediateMaterialAvailabilityState` для синхронного обновления статуса и флагов недостатка материалов.
- Аналогичный вызов добавлен в `updateOrderPapersFromWorkspace` сразу после синхронизации резерва бумаги, чтобы рабочее пространство также сразу получало корректный статус.
- Введён приватный метод `Future<void> _applyImmediateMaterialAvailabilityState(OrderModel order)` который вычисляет `hasEnough`, формирует `material_shortage_message`, выбирает `nextStatus` и выполняет `UPDATE` в таблице `orders`, а также обновляет локальный кеш `_orders` и вызывает `notifyListeners()`; изменения внесены в `lib/modules/orders/orders_provider.dart`.

### Testing
- Попытки запустить форматирование файла через `dart format` и `flutter format` завершились неудачей из‑за отсутствия CLI в окружении (`dart: command not found`, `flutter: command not found`).
- Автоматические unit/integration тесты в этом окружении не запускались, поэтому поведение проверено только через статический обзор и локальный запуск в репозитории не производился.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7b21e808832fa25f0619e953219d)