### PR TITLE
Бобинорезка: дублируемые поля для нескольких бумаг и перенос «Лишнее на складе» наверх

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1980,14 +1980,15 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (_activePaperSlotIndex > 0) {
       final extraIndex = _activePaperSlotIndex - 1;
       if (extraIndex >= 0 && extraIndex < _extraPaperMaterials.length) {
+        final currentExtra = _extraPaperMaterials[extraIndex];
         setState(() {
-          _extraPaperMaterials[extraIndex] = MaterialModel(
+          _extraPaperMaterials[extraIndex] = currentExtra.copyWith(
             id: paper.id,
             name: paper.description,
             format: paper.format ?? '',
             grammage: paper.grammage ?? '',
-            quantity: _extraPaperMaterials[extraIndex].quantity > 0
-                ? _extraPaperMaterials[extraIndex].quantity
+            quantity: currentExtra.quantity > 0
+                ? currentExtra.quantity
                 : (_product.length ?? 0).toDouble(),
             unit: 'м',
           );
@@ -2036,9 +2037,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     for (final paper in _extraPaperMaterials) {
       final id = (paper.id ?? '').trim();
       if (id.isEmpty) continue;
+      final extraLength = _paperExtraDouble(paper, 'lengthL');
+      final resolvedQty =
+          extraLength != null && extraLength > 0 ? extraLength : fallbackQty;
       selected.add(
         paper.copyWith(
-          quantity: paper.quantity > 0 ? paper.quantity : fallbackQty,
+          quantity: paper.quantity > 0 ? paper.quantity : resolvedQty,
           unit: 'м',
         ),
       );
@@ -2058,10 +2062,33 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           name: '',
           quantity: (_product.length ?? 0).toDouble(),
           unit: 'м',
+          extra: <String, dynamic>{
+            if (_product.widthB != null) 'widthB': _product.widthB,
+            if ((_product.blQuantity ?? '').trim().isNotEmpty)
+              'blQuantity': _product.blQuantity!.trim(),
+            if (_product.length != null) 'lengthL': _product.length,
+          },
         ),
       );
       _activePaperSlotIndex = _extraPaperMaterials.length;
     });
+  }
+
+  double? _paperExtraDouble(MaterialModel paper, String key) {
+    final value = paper.extra?[key];
+    if (value is num) return value.toDouble();
+    if (value is String) {
+      final normalized = value.trim().replaceAll(',', '.');
+      if (normalized.isEmpty) return null;
+      return double.tryParse(normalized);
+    }
+    return null;
+  }
+
+  String? _paperExtraString(MaterialModel paper, String key) {
+    final value = paper.extra?[key];
+    final text = value?.toString().trim() ?? '';
+    return text.isEmpty ? null : text;
   }
 
   void _addPaintFromTmc(TmcModel paint) {
@@ -2702,6 +2729,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           handle: createdOrUpdatedOrder.handle,
           cardboard: createdOrUpdatedOrder.cardboard,
           material: createdOrUpdatedOrder.material,
+          paperMaterials: createdOrUpdatedOrder.paperMaterials,
           makeready: createdOrUpdatedOrder.makeready,
           val: createdOrUpdatedOrder.val,
           pdfUrl: createdOrUpdatedOrder.pdfUrl,
@@ -3888,6 +3916,112 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                       ),
                     ],
                   ),
+                  const SizedBox(height: 4),
+                  TextFormField(
+                    initialValue: _paperExtraDouble(
+                              _extraPaperMaterials[i],
+                              'widthB',
+                            ) !=
+                            null
+                        ? _formatDecimal(
+                            _paperExtraDouble(_extraPaperMaterials[i], 'widthB')!)
+                        : '',
+                    decoration: const InputDecoration(
+                      labelText: 'Ширина b',
+                      border: OutlineInputBorder(),
+                    ),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    onChanged: (value) {
+                      final parsed = double.tryParse(value.replaceAll(',', '.'));
+                      setState(() {
+                        final nextExtra = Map<String, dynamic>.from(
+                          _extraPaperMaterials[i].extra ?? const {},
+                        );
+                        if (parsed == null) {
+                          nextExtra.remove('widthB');
+                        } else {
+                          nextExtra['widthB'] = parsed;
+                        }
+                        _extraPaperMaterials[i] = _extraPaperMaterials[i].copyWith(
+                          extra: nextExtra.isEmpty ? null : nextExtra,
+                        );
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          initialValue:
+                              _paperExtraString(_extraPaperMaterials[i], 'blQuantity') ??
+                                  '',
+                          decoration: const InputDecoration(
+                            labelText: 'Количество',
+                            border: OutlineInputBorder(),
+                          ),
+                          onChanged: (value) {
+                            final trimmed = value.trim();
+                            setState(() {
+                              final nextExtra = Map<String, dynamic>.from(
+                                _extraPaperMaterials[i].extra ?? const {},
+                              );
+                              if (trimmed.isEmpty) {
+                                nextExtra.remove('blQuantity');
+                              } else {
+                                nextExtra['blQuantity'] = trimmed;
+                              }
+                              _extraPaperMaterials[i] =
+                                  _extraPaperMaterials[i].copyWith(
+                                extra: nextExtra.isEmpty ? null : nextExtra,
+                              );
+                            });
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: TextFormField(
+                          initialValue: _paperExtraDouble(
+                                    _extraPaperMaterials[i],
+                                    'lengthL',
+                                  ) !=
+                                  null
+                              ? _formatDecimal(_paperExtraDouble(
+                                  _extraPaperMaterials[i], 'lengthL')!)
+                              : '',
+                          decoration: const InputDecoration(
+                            labelText: 'Длина L',
+                            border: OutlineInputBorder(),
+                          ),
+                          keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true),
+                          onChanged: (value) {
+                            final parsed =
+                                double.tryParse(value.replaceAll(',', '.'));
+                            setState(() {
+                              final nextExtra = Map<String, dynamic>.from(
+                                _extraPaperMaterials[i].extra ?? const {},
+                              );
+                              if (parsed == null) {
+                                nextExtra.remove('lengthL');
+                              } else {
+                                nextExtra['lengthL'] = parsed;
+                              }
+                              _extraPaperMaterials[i] =
+                                  _extraPaperMaterials[i].copyWith(
+                                quantity: parsed != null && parsed > 0
+                                    ? parsed
+                                    : _extraPaperMaterials[i].quantity,
+                                extra: nextExtra.isEmpty ? null : nextExtra,
+                              );
+                            });
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),
@@ -3900,9 +4034,107 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   /// Дополнительные параметры продукта: материал, складские остатки и вложения
   Widget _buildProductMaterialAndExtras(ProductModel product) {
+    final stockExtraWidget = _buildStockExtraLayout(
+      Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _stockExtraSearchController,
+            focusNode: _stockExtraFocusNode,
+            onTap: () {
+              if (_stockExtraAutoloaded) return;
+              setState(() => _stockExtraAutoloaded = true);
+              _updateStockExtra(includeAllResults: true);
+            },
+            decoration: InputDecoration(
+              labelText: 'Лишнее на складе',
+              border: const OutlineInputBorder(),
+              suffixIcon: _loadingStockExtra
+                  ? const Padding(
+                      padding: EdgeInsets.all(12),
+                      child: SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : (_stockExtraSearchController.text.isEmpty
+                      ? null
+                      : IconButton(
+                          icon: const Icon(Icons.clear),
+                          onPressed: () {
+                            _stockExtraSearchController.clear();
+                            _onStockExtraSearchChanged('');
+                          },
+                        )),
+            ),
+            onChanged: _onStockExtraSearchChanged,
+          ),
+          const SizedBox(height: 3),
+          Text(
+            _stockExtra != null
+                ? 'Доступно: ${_stockExtra!.toStringAsFixed(2)}'
+                : 'Доступно: —',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 4),
+          TextField(
+            controller: _stockExtraQtyController,
+            decoration: InputDecoration(
+              labelText: 'Количество для списания',
+              border: const OutlineInputBorder(),
+              helperText: _selectedStockExtraRow != null
+                  ? null
+                  : 'Сначала выберите позицию из списка',
+            ),
+            enabled: _selectedStockExtraRow != null,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            onChanged: (value) {
+              final normalized = value.replaceAll(',', '.');
+              final parsed = double.tryParse(normalized);
+              double? nextValue = parsed != null && parsed >= 0 ? parsed : null;
+              if (nextValue != null && _stockExtra != null) {
+                final double available = _stockExtra!;
+                if (available >= 0 && nextValue > available) {
+                  nextValue = available;
+                  final text = _formatDecimal(available);
+                  _stockExtraQtyController.value = TextEditingValue(
+                    text: text,
+                    selection: TextSelection.collapsed(offset: text.length),
+                  );
+                }
+              }
+              setState(() {
+                _stockExtraQtyTouched = true;
+                _stockExtraSelectedQty = nextValue;
+                _product.leftover =
+                    _stockExtraSelectedQty != null && _stockExtraSelectedQty! > 0
+                        ? _stockExtraSelectedQty
+                        : null;
+                if (_writeOffStockExtra &&
+                    (_stockExtraSelectedQty == null ||
+                        _stockExtraSelectedQty! <= 0)) {
+                  _writeOffStockExtra = false;
+                }
+              });
+            },
+          ),
+          const SizedBox(height: 4),
+          if (_stockExtraAutoloaded &&
+              (_stockExtraFocusNode.hasFocus ||
+                  _stockExtraSearchController.text.trim().isNotEmpty))
+            _buildStockExtraResults(),
+        ],
+      ),
+      const SizedBox.shrink(),
+    );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        stockExtraWidget,
+        const SizedBox(height: 3),
         Builder(
           builder: (context) {
             final papers = _paperItems();
@@ -4189,104 +4421,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               label: Text('Добавить бумагу №${_extraPaperMaterials.length + 2}'),
             ),
           ),
-        const SizedBox(height: 3),
-        _buildStockExtraLayout(
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: _stockExtraSearchController,
-                focusNode: _stockExtraFocusNode,
-                onTap: () {
-                  if (_stockExtraAutoloaded) return;
-                  setState(() => _stockExtraAutoloaded = true);
-                  _updateStockExtra(includeAllResults: true);
-                },
-                decoration: InputDecoration(
-                  labelText: 'Лишнее на складе',
-                  border: const OutlineInputBorder(),
-                  suffixIcon: _loadingStockExtra
-                      ? const Padding(
-                          padding: EdgeInsets.all(12),
-                          child: SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          ),
-                        )
-                      : (_stockExtraSearchController.text.isEmpty
-                          ? null
-                          : IconButton(
-                              icon: const Icon(Icons.clear),
-                              onPressed: () {
-                                _stockExtraSearchController.clear();
-                                _onStockExtraSearchChanged('');
-                              },
-                            )),
-                ),
-                onChanged: _onStockExtraSearchChanged,
-              ),
-              const SizedBox(height: 3),
-              Text(
-                _stockExtra != null
-                    ? 'Доступно: ${_stockExtra!.toStringAsFixed(2)}'
-                    : 'Доступно: —',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-              const SizedBox(height: 4),
-              TextField(
-                controller: _stockExtraQtyController,
-                decoration: InputDecoration(
-                  labelText: 'Количество для списания',
-                  border: const OutlineInputBorder(),
-                  helperText: _selectedStockExtraRow != null
-                      ? null
-                      : 'Сначала выберите позицию из списка',
-                ),
-                enabled: _selectedStockExtraRow != null,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
-                onChanged: (value) {
-                  final normalized = value.replaceAll(',', '.');
-                  final parsed = double.tryParse(normalized);
-                  double? nextValue =
-                      parsed != null && parsed >= 0 ? parsed : null;
-                  if (nextValue != null && _stockExtra != null) {
-                    final double available = _stockExtra!;
-                    if (available >= 0 && nextValue > available) {
-                      nextValue = available;
-                      final text = _formatDecimal(available);
-                      _stockExtraQtyController.value = TextEditingValue(
-                        text: text,
-                        selection: TextSelection.collapsed(offset: text.length),
-                      );
-                    }
-                  }
-                  setState(() {
-                    _stockExtraQtyTouched = true;
-                    _stockExtraSelectedQty = nextValue;
-                    _product.leftover = _stockExtraSelectedQty != null &&
-                            _stockExtraSelectedQty! > 0
-                        ? _stockExtraSelectedQty
-                        : null;
-                    if (_writeOffStockExtra &&
-                        (_stockExtraSelectedQty == null ||
-                            _stockExtraSelectedQty! <= 0)) {
-                      _writeOffStockExtra = false;
-                    }
-                  });
-                },
-              ),
-              const SizedBox(height: 4),
-              if (_stockExtraAutoloaded &&
-                  (_stockExtraFocusNode.hasFocus ||
-                      _stockExtraSearchController.text.trim().isNotEmpty))
-                _buildStockExtraResults(),
-            ],
-          ),
-          const SizedBox.shrink(),
-        ),
         const SizedBox(height: 3),
         TextFormField(
           initialValue: product.widthB != null ? _formatDecimal(product.widthB!) : '',

--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -259,46 +259,58 @@ class OrderDetailsCard extends StatelessWidget {
     );
   }
 
-  String _additionalDimensions() {
-    final p = order.product;
-    if (p.widthB == null) return '';
-    return _fmtNum(p.widthB);
-  }
-
-  String _lengthValue() {
-    final p = order.product;
-    if (p.length != null) return _fmtNum(p.length);
-    return '';
-  }
-
-  String _materialSummary() {
-    final materials = order.paperMaterials.isNotEmpty
-        ? order.paperMaterials
-        : <MaterialModel>[
-            if (order.material != null) order.material!,
-          ];
-    if (materials.isEmpty) return '—';
-    final lines = <String>[];
-    for (var i = 0; i < materials.length; i++) {
-      final m = materials[i];
-      final parts = <String>[];
-      if (m.name.isNotEmpty) parts.add(m.name);
-      if (m.format != null && m.format!.isNotEmpty) parts.add('(${m.format})Ф');
-      if (m.grammage != null && m.grammage!.isNotEmpty) {
-        parts.add('(${m.grammage})Гр');
-      }
-      
-      if (parts.isNotEmpty) lines.add('Бумага №${i + 1}: ${parts.join(' ')}');
+  double? _paperExtraDouble(MaterialModel material, String key) {
+    final value = material.extra?[key];
+    if (value is num) return value.toDouble();
+    if (value is String) {
+      final normalized = value.trim().replaceAll(',', '.');
+      if (normalized.isEmpty) return null;
+      return double.tryParse(normalized);
     }
-    return lines.isEmpty ? '—' : lines.join('\n');
+    return null;
+  }
+
+  String? _paperExtraString(MaterialModel material, String key) {
+    final value = material.extra?[key];
+    final text = value?.toString().trim() ?? '';
+    return text.isEmpty ? null : text;
+  }
+
+  String _paperWidthValue(MaterialModel material, int index) {
+    if (index == 0) {
+      final value = order.product.widthB;
+      return value == null ? '' : _fmtNum(value);
+    }
+    final value = _paperExtraDouble(material, 'widthB');
+    return value == null ? '' : _fmtNum(value);
+  }
+
+  String _paperLengthValue(MaterialModel material, int index) {
+    if (index == 0) {
+      final value = order.product.length;
+      return value == null ? '' : _fmtNum(value);
+    }
+    final value = _paperExtraDouble(material, 'lengthL');
+    return value == null ? '' : _fmtNum(value);
+  }
+
+  String _paperQuantityValue(MaterialModel material, int index) {
+    if (index == 0) {
+      final value = order.product.blQuantity?.trim() ?? '';
+      return value;
+    }
+    return _paperExtraString(material, 'blQuantity') ?? '';
   }
 
   @override
   Widget build(BuildContext context) {
     final o = order;
     final p = o.product;
-    final widthBValue = _additionalDimensions();
-    final lengthValue = _lengthValue();
+    final materials = o.paperMaterials.isNotEmpty
+        ? o.paperMaterials
+        : <MaterialModel>[
+            if (o.material != null) o.material!,
+          ];
     final paintInfo = paints
         .map((e) => (e['info'] ?? '').toString().trim())
         .where((v) => v.isNotEmpty)
@@ -482,11 +494,63 @@ class OrderDetailsCard extends StatelessWidget {
                     accentColor: const Color(0xFF7A4CF0),
                     child: Column(
                       children: [
-                        _buildInfoRow('Материал', _materialSummary(), compact: true),
-                        if (widthBValue.isNotEmpty)
-                          _buildInfoRow('Ширина B', widthBValue, compact: true),
-                        if (lengthValue.isNotEmpty)
-                          _buildInfoRow('Длина L', lengthValue, compact: true),
+                        if (materials.isEmpty)
+                          _buildInfoRow('Материал', '—', compact: true)
+                        else
+                          ...materials.asMap().entries.expand((entry) {
+                            final index = entry.key;
+                            final material = entry.value;
+                            final parts = <String>[];
+                            if (material.name.isNotEmpty) parts.add(material.name);
+                            if (material.format != null &&
+                                material.format!.isNotEmpty) {
+                              parts.add('(${material.format})Ф');
+                            }
+                            if (material.grammage != null &&
+                                material.grammage!.isNotEmpty) {
+                              parts.add('(${material.grammage})Гр');
+                            }
+                            final materialLine =
+                                parts.isEmpty ? '—' : parts.join(' ');
+                            final rows = <Widget>[
+                              _buildInfoRow(
+                                'Бумага №${index + 1}',
+                                materialLine,
+                                compact: true,
+                              ),
+                            ];
+                            final widthValue = _paperWidthValue(material, index);
+                            if (widthValue.isNotEmpty) {
+                              rows.add(
+                                _buildInfoRow(
+                                  'Ширина B №${index + 1}',
+                                  widthValue,
+                                  compact: true,
+                                ),
+                              );
+                            }
+                            final qtyValue = _paperQuantityValue(material, index);
+                            if (qtyValue.isNotEmpty) {
+                              rows.add(
+                                _buildInfoRow(
+                                  'Количество №${index + 1}',
+                                  qtyValue,
+                                  compact: true,
+                                ),
+                              );
+                            }
+                            final lenValue = _paperLengthValue(material, index);
+                            if (lenValue.isNotEmpty) {
+                              rows.add(
+                                _buildInfoRow(
+                                  'Длина L №${index + 1}',
+                                  lenValue,
+                                  compact: true,
+                                ),
+                              );
+                            }
+                            return rows;
+                          }),
                         _buildInfoRow('Приладка',
                             o.makeready > 0 ? _fmtNum(o.makeready) : '—',
                             compact: true),


### PR DESCRIPTION
### Motivation
- В форме создания/редактирования заказа нужен рабочий блок «Бобинорезка», где `Материал`, `Формат`, `Грамаж`, `Ширина b`, `Количество`, `Длина L` рассматриваются как единый блок и должны дублироваться для второй/третьей бумаги. 
- Поля дополнительной бумаги не должны теряться при сохранении или при смене выбранного материала, и данные должны правильно учитываться при резерве/проверке наличия на складе.

### Description
- Перенёс виджет поиска/выбора «Лишнее на складе» в начало блока «Бобинорезка» в `lib/modules/orders/edit_order_screen.dart`, чтобы он отображался первым. 
- Добавил в UI для дополнительных слотов бумаги (№2/№3) дублируемые поля `Ширина b`, `Количество`, `Длина L` и связал их с хранилищем в `MaterialModel.extra`. 
- Сохраняю пользовательские доп. поля при смене выбранной бумаги в слоте (использую `copyWith` и сохраняю `extra`), чтобы введённые bobbin-параметры не терялись. 
- В логике сохранения/сборки списка бумаги (`_collectSelectedPapers`) добавлен fallback количества на основе per-paper `lengthL` из `MaterialModel.extra`, и при присвоении читаемого номера заказа теперь передаётся `paperMaterials`, чтобы состав бумаги не терялся. 
- Обновил карточку деталей заказа `lib/modules/orders/order_details_card.dart` для показа по каждой бумаге отдельно: строка `Бумага №N`, а также отдельные строки `Ширина B №N`, `Количество №N`, `Длина L №N`. 
- Добавлены вспомогательные функции `_paperExtraDouble` и `_paperExtraString` для безопасного чтения полей из `MaterialModel.extra`.

### Testing
- Попытка прогнать автоформатирование: `dart format lib/modules/orders/edit_order_screen.dart lib/modules/orders/order_details_card.dart` завершилась неудачно из‑за отсутствия `dart` в окружении (ошибка: `dart: command not found`).
- Других автоматических тестов/анализов в CI не выполнял(ась) в этом окружении; локально рекомендуется запустить `dart format` и `flutter analyze`/`flutter test` после получения SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df82a5bc30832fa2b493fd0bd26131)