### PR TITLE
Prevent shift change from marking stage as finished

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4649,22 +4649,11 @@ class _TasksScreenState extends State<TasksScreen>
                             text: qtyText,
                             userIdOverride: widget.employeeId);
 
-                        await taskProvider.addCommentAutoUser(
-                            taskId: task.id,
-                            type: 'user_done',
-                            text: 'done',
-                            userIdOverride: widget.employeeId);
-
                         for (final helperId in helperIds) {
                           await taskProvider.addCommentAutoUser(
                               taskId: task.id,
                               type: 'quantity_share',
                               text: qtyText,
-                              userIdOverride: helperId);
-                          await taskProvider.addCommentAutoUser(
-                              taskId: task.id,
-                              type: 'user_done',
-                              text: 'done',
                               userIdOverride: helperId);
                           await taskProvider.closeOpenTimeEvent(
                             task: task,


### PR DESCRIPTION
### Motivation
- Avoid treating a shift change as a personal "done" action that can close a stage or order; a user pressing "Пересмена" should pause the stage without creating `user_done` comments so the same employee can resume until another employee takes over.

### Description
- Removed automatic `user_done` comment creation for the current user and helpers during the shift-change (пересмена) path while keeping `quantity_share` logging and helper time-event closing; change is in `lib/modules/tasks/tasks_screen.dart`.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but it failed in the environment because `dart` was not found; `flutter test test/stage_sequence_utils_test.dart` also failed because `flutter` was not found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df898791b8832f8da2ea47441ee5b3)