### PR TITLE
Adjust paper layout for extra rolls in slitter form

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3874,47 +3874,22 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                     ),
                   ),
                   const SizedBox(height: 4),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextFormField(
-                          initialValue: _extraPaperMaterials[i].quantity > 0
-                              ? _formatDecimal(_extraPaperMaterials[i].quantity)
-                              : '',
-                          decoration: const InputDecoration(
-                            labelText: 'Метраж, м',
-                            border: OutlineInputBorder(),
-                          ),
-                          keyboardType: const TextInputType.numberWithOptions(
-                              decimal: true),
-                          onChanged: (value) {
-                            final parsed =
-                                double.tryParse(value.replaceAll(',', '.'));
-                            setState(() {
-                              _extraPaperMaterials[i] =
-                                  _extraPaperMaterials[i].copyWith(
-                                quantity: parsed == null || parsed < 0 ? 0 : parsed,
-                                unit: 'м',
-                              );
-                            });
-                          },
-                        ),
-                      ),
-                      IconButton(
-                        tooltip: 'Удалить бумагу',
-                        onPressed: () {
-                          setState(() {
-                            _extraPaperMaterials.removeAt(i);
-                            if (_activePaperSlotIndex > _extraPaperMaterials.length) {
-                              _activePaperSlotIndex = _extraPaperMaterials.isEmpty
-                                  ? 0
-                                  : _extraPaperMaterials.length;
-                            }
-                          });
-                        },
-                        icon: const Icon(Icons.delete_outline),
-                      ),
-                    ],
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: IconButton(
+                      tooltip: 'Удалить бумагу',
+                      onPressed: () {
+                        setState(() {
+                          _extraPaperMaterials.removeAt(i);
+                          if (_activePaperSlotIndex > _extraPaperMaterials.length) {
+                            _activePaperSlotIndex = _extraPaperMaterials.isEmpty
+                                ? 0
+                                : _extraPaperMaterials.length;
+                          }
+                        });
+                      },
+                      icon: const Icon(Icons.delete_outline),
+                    ),
                   ),
                   const SizedBox(height: 4),
                   TextFormField(
@@ -4411,17 +4386,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             );
           },
         ),
-        _buildExtraPaperSelectors(),
-        if (_extraPaperMaterials.length < 2)
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton.icon(
-              onPressed: _addExtraPaperSlot,
-              icon: const Icon(Icons.add),
-              label: Text('Добавить бумагу №${_extraPaperMaterials.length + 2}'),
-            ),
-          ),
-        const SizedBox(height: 3),
         TextFormField(
           initialValue: product.widthB != null ? _formatDecimal(product.widthB!) : '',
           decoration: const InputDecoration(
@@ -4491,6 +4455,17 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             ),
           ],
         ),
+        const SizedBox(height: 3),
+        _buildExtraPaperSelectors(),
+        if (_extraPaperMaterials.length < 2)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: _addExtraPaperSlot,
+              icon: const Icon(Icons.add),
+              label: Text('Добавить бумагу №${_extraPaperMaterials.length + 2}'),
+            ),
+          ),
         const SizedBox(height: 3),
       ],
     );


### PR DESCRIPTION
### Motivation
- The extra paper (бумага №2/№3) UI needed to match the desired layout where the primary paper's width/quantity/length remain grouped with the first material selection and the extra slots do not duplicate the primary "Метраж, м" input.

### Description
- Removed the per-extra-paper `Метраж, м` input from each `_extraPaperMaterials` card and preserved width/quantity/length and read-only material/format/grammage fields in `lib/modules/orders/edit_order_screen.dart`.
- Replaced the combined row (metrage + delete) with a right-aligned single delete `IconButton` inside each extra paper card so deletion remains available but layout is simplified.
- Moved the primary paper dimension inputs (`Ширина b`, `Количество`, `Длина L`) so they remain adjacent to the first paper material selection and are not split by the extra paper section.

### Testing
- Attempted to run `dart format lib/modules/orders/edit_order_screen.dart`, but `dart` is not available in this environment so formatting could not be executed and reported as failed.
- Verified the change via `git diff -- lib/modules/orders/edit_order_screen.dart` to ensure the intended structural modifications are present and consistent.
- Committed the updated file locally with `git commit` after applying the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8c9a791c832fb9403e753100ca80)