### PR TITLE
Prevent duplicate order creation on repeated save taps

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -558,6 +558,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   bool _stockExtraAutoloaded = false;
   bool _launchedNoStartedStages = false;
   bool _launchedWithStartedStages = false;
+  bool _isSavingOrder = false;
 
   Future<void> _loadCategoriesForProduct() async {
     setState(() => _catsLoading = true);
@@ -2497,6 +2498,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   }
 
   Future<void> _saveOrder() async {
+    if (_isSavingOrder) return;
+    setState(() => _isSavingOrder = true);
+    try {
     // Флаг: создаём новый заказ или редактируем
     final bool isCreating = (widget.order == null);
     final navigator = Navigator.of(context);
@@ -3109,6 +3113,17 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     // Списание лишнего выполняется на этапе отгрузки.
 
     if (mounted) navigator.pop();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Не удалось сохранить заказ: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSavingOrder = false);
+      }
+    }
   }
 
   String _formatDecimal(double value, {int fractionDigits = 2}) {
@@ -3478,7 +3493,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed:
+              _isSavingOrder ? null : () => Navigator.of(context).pop(),
         ),
         title: Text(isEditing
             ? 'Редактирование заказа ${(widget.order!.assignmentId ?? widget.order!.id)}'
@@ -3492,9 +3508,15 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
               ),
-              onPressed: _saveOrder,
-              icon: const Icon(Icons.save_outlined, size: 18),
-              label: const Text('Сохранить'),
+              onPressed: _isSavingOrder ? null : _saveOrder,
+              icon: _isSavingOrder
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.save_outlined, size: 18),
+              label: Text(_isSavingOrder ? 'Сохранение…' : 'Сохранить'),
             ),
           ),
           if (isEditing)


### PR DESCRIPTION
### Motivation
- При повторных нажатиях кнопки «Сохранить» пока выполняется запрос создаются дубли заказов, поэтому нужно сделать операцию сохранения идемпотентной со стороны UI и заблокировать повторные действия до завершения запроса.

### Description
- Добавлено булево поле `_isSavingOrder` и ранний выход в начале `_saveOrder`, чтобы предотвратить повторный запуск операции сохранения, если она уже выполняется.
- Обёрнул основную логику `_saveOrder` в `try/catch/finally`, при ошибке показываю `SnackBar` с текстом ошибки и в `finally` всегда сбрасываю флаг сохранения, чтобы экран не оставался в заблокированном состоянии.
- На время сохранения отключил навигацию назад и кнопку «Сохранить», а сама кнопка теперь показывает индикатор загрузки и текст `Сохранение…` вместо обычного состояния.
- Файл изменён: `lib/modules/orders/edit_order_screen.dart`.

### Testing
- Запущена попытка форматирования `dart format lib/modules/orders/edit_order_screen.dart`, но в окружении отсутствует CLI (`dart: command not found`).
- Запущена попытка проверить `flutter --version`, но в окружении отсутствует Flutter CLI (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e082274894832fa8d774ee4eaac09f)