### PR TITLE
Redirect users to production module home after saving orders

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -22,6 +22,7 @@ import 'order_model.dart';
 import 'product_model.dart';
 import 'material_model.dart';
 import '../products/products_provider.dart';
+import '../production/production_screen.dart';
 import '../production_planning/template_provider.dart';
 import '../production_planning/template_model.dart';
 import '../warehouse/warehouse_provider.dart';
@@ -90,6 +91,14 @@ class _StageRuleOutcome {
 
 class _EditOrderScreenState extends State<EditOrderScreen> {
   static const String _paintInfoParamLabel = 'Информация для красок:';
+
+  Future<void> _goToProductionModuleHome() async {
+    if (!mounted) return;
+    await Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const ProductionScreen()),
+      (route) => route.isFirst,
+    );
+  }
 
   String _trimTrailingFractionZeros(String value) {
     if (!value.contains('.')) return value;
@@ -2541,7 +2550,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     try {
     // Флаг: создаём новый заказ или редактируем
     final bool isCreating = (widget.order == null);
-    final navigator = Navigator.of(context);
     final messenger = ScaffoldMessenger.of(context);
     if (!_formKey.currentState!.validate()) return;
     _selectedCardboard = _cardboardChecked ? 'есть' : 'нет';
@@ -3150,7 +3158,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
     // Списание лишнего выполняется на этапе отгрузки.
 
-    if (mounted) navigator.pop();
+    await _goToProductionModuleHome();
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -15,6 +15,7 @@ import 'order_model.dart';
 import 'product_model.dart';
 import 'material_model.dart';
 import '../products/products_provider.dart';
+import '../production/production_screen.dart';
 
 import '../production_planning/template_provider.dart';
 import '../warehouse/warehouse_provider.dart';
@@ -95,6 +96,14 @@ class _ExtraPaperEntry {
 }
 
 class _EditOrderScreenState extends State<EditOrderScreen> {
+  Future<void> _goToProductionModuleHome() async {
+    if (!mounted) return;
+    await Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const ProductionScreen()),
+      (route) => route.isFirst,
+    );
+  }
+
   Future<void> _pickFormImage() async {
     final picker = ImagePicker();
     final img = await picker.pickImage(source: ImageSource.gallery);
@@ -2265,7 +2274,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 // Независимо от создания/редактирования - синхронизируем список красок
 // c полем product.parameters и таблицей order_paints.
     await _persistPaints(createdOrUpdatedOrder.id);
-    if (mounted) Navigator.of(context).pop();
+    await _goToProductionModuleHome();
   }
 
   @override


### PR DESCRIPTION
### Motivation
- After creating or editing an order the workflow should take the user to the main Production (production assignments) module so staff see production tasks immediately.

### Description
- Added import of `ProductionScreen` and a shared helper `_goToProductionModuleHome()` to `lib/modules/orders/edit_order_screen.dart` to perform a `pushAndRemoveUntil` navigation to the production module home.
- Replaced the previous post-save `pop` behavior in the main orders editor with `await _goToProductionModuleHome()` and removed an unused `navigator` local.
- Applied the same helper import and call in the production-planning order editor variant at `lib/modules/production_planning/form_editor_screen.dart` so both save flows behave identically.
- No other validation or business logic was changed; only post-save navigation was updated.

### Testing
- Attempted to run `dart format lib/modules/orders/edit_order_screen.dart lib/modules/production_planning/form_editor_screen.dart` but `dart` is not installed in this environment so formatting could not be verified automatically.
- Attempted to run `flutter --version` but `flutter` is not installed in this environment so no Flutter runtime checks were executed.
- No automated unit or integration tests were run in this environment; the change is limited to navigation behavior and should be smoke-tested in a local Flutter environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0857d1a24832f93baf6463ec70ac8)