### PR TITLE
Переход после сохранения заказа: вернуть в модуль «Заказы»

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -22,7 +22,7 @@ import 'order_model.dart';
 import 'product_model.dart';
 import 'material_model.dart';
 import '../products/products_provider.dart';
-import '../production/production_screen.dart';
+import 'orders_screen.dart';
 import '../production_planning/template_provider.dart';
 import '../production_planning/template_model.dart';
 import '../warehouse/warehouse_provider.dart';
@@ -92,10 +92,10 @@ class _StageRuleOutcome {
 class _EditOrderScreenState extends State<EditOrderScreen> {
   static const String _paintInfoParamLabel = 'Информация для красок:';
 
-  Future<void> _goToProductionModuleHome() async {
+  Future<void> _goToOrdersModuleHome() async {
     if (!mounted) return;
     await Navigator.of(context).pushAndRemoveUntil(
-      MaterialPageRoute(builder: (_) => const ProductionScreen()),
+      MaterialPageRoute(builder: (_) => const OrdersScreen()),
       (route) => route.isFirst,
     );
   }
@@ -3158,7 +3158,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
     // Списание лишнего выполняется на этапе отгрузки.
 
-    await _goToProductionModuleHome();
+    await _goToOrdersModuleHome();
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -15,7 +15,7 @@ import 'order_model.dart';
 import 'product_model.dart';
 import 'material_model.dart';
 import '../products/products_provider.dart';
-import '../production/production_screen.dart';
+import '../orders/orders_screen.dart';
 
 import '../production_planning/template_provider.dart';
 import '../warehouse/warehouse_provider.dart';
@@ -96,10 +96,10 @@ class _ExtraPaperEntry {
 }
 
 class _EditOrderScreenState extends State<EditOrderScreen> {
-  Future<void> _goToProductionModuleHome() async {
+  Future<void> _goToOrdersModuleHome() async {
     if (!mounted) return;
     await Navigator.of(context).pushAndRemoveUntil(
-      MaterialPageRoute(builder: (_) => const ProductionScreen()),
+      MaterialPageRoute(builder: (_) => const OrdersScreen()),
       (route) => route.isFirst,
     );
   }
@@ -2274,7 +2274,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 // Независимо от создания/редактирования - синхронизируем список красок
 // c полем product.parameters и таблицей order_paints.
     await _persistPaints(createdOrUpdatedOrder.id);
-    await _goToProductionModuleHome();
+    await _goToOrdersModuleHome();
   }
 
   @override


### PR DESCRIPTION
### Motivation
- При создании или редактировании заказа нужно возвращать пользователя на главный экран модуля «Заказы», а не на экран управления производственными заданиями.

### Description
- Заменён импорт `ProductionScreen` на `OrdersScreen` в `lib/modules/orders/edit_order_screen.dart` и `lib/modules/production_planning/form_editor_screen.dart`.
- Переименован хелпер навигации `_goToProductionModuleHome()` в `_goToOrdersModuleHome()` и изменён маршрут на `OrdersScreen` в обеих реализациях.
- Обновлены вызовы после сохранения заказа на `await _goToOrdersModuleHome()` в обоих файлах.
- Изменения затронули только навигацию после сохранения, логика сохранения заказа не менялась.

### Testing
- Попытка запустить форматтер `dart format lib/modules/orders/edit_order_screen.dart lib/modules/production_planning/form_editor_screen.dart` завершилась неуспешно из‑за отсутствия `dart` в окружении (`/bin/bash: dart: command not found`).
- Проверка состояния репозитория и коммит изменений прошли успешно (`git status` и `git commit` были выполнены).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0879549dc832fae868085029ad525)