### PR TITLE
Fix order edit persistence when clearing nullable fields

### DIFF
--- a/lib/modules/orders/order_model.dart
+++ b/lib/modules/orders/order_model.dart
@@ -205,41 +205,49 @@ class OrderModel {
   set statusEnum(OrderStatus s) => status = s.name;
 
   /// В БД пишем snake_case.
-  Map<String, dynamic> toMap() => {
+  ///
+  /// [includeNulls] нужен для UPDATE-сценариев, когда необходимо явно
+  /// сбросить значение колонки в `null` (например, при удалении очереди этапов).
+  Map<String, dynamic> toMap({bool includeNulls = false}) => {
         'id': id,
         'manager': manager,
         'customer': customer,
         'order_date': orderDate.toIso8601String(),
-        if (dueDate != null) 'due_date': dueDate!.toIso8601String(),
+        if (includeNulls || dueDate != null)
+          'due_date': dueDate?.toIso8601String(),
         'product': product.toMap(),
         'additional_params':
             additionalParams, // массив строк; БД примет и объект
         'handle': handle,
         'cardboard': cardboard,
-        if (material != null) 'material': material!.toMap(),
-        if (paperMaterials.isNotEmpty)
-          'material_list': paperMaterials.map((m) => m.toMap()).toList(),
+        if (includeNulls || material != null)
+          'material': material?.toMap(),
+        if (includeNulls || paperMaterials.isNotEmpty)
+          'material_list':
+              paperMaterials.isEmpty ? null : paperMaterials.map((m) => m.toMap()).toList(),
         'makeready': makeready,
         'val': val,
         'has_form': hasForm,
         'is_old_form': isOldForm,
-        if (newFormNo != null) 'new_form_no': newFormNo,
-        if (formSeries != null) 'form_series': formSeries,
-        if (formCode != null) 'form_code': formCode,
-        if (pdfUrl != null) 'pdf_url': pdfUrl,
-        if (stageTemplateId != null) 'stage_template_id': stageTemplateId,
+        if (includeNulls || newFormNo != null) 'new_form_no': newFormNo,
+        if (includeNulls || formSeries != null) 'form_series': formSeries,
+        if (includeNulls || formCode != null) 'form_code': formCode,
+        if (includeNulls || pdfUrl != null) 'pdf_url': pdfUrl,
+        if (includeNulls || stageTemplateId != null)
+          'stage_template_id': stageTemplateId,
         'contract_signed': contractSigned,
         'payment_done': paymentDone,
         'comments': comments,
         'status': normalizeStatus(status),
         'has_material_shortage': hasMaterialShortage,
         'material_shortage_message': materialShortageMessage,
-        if (assignmentId != null) 'assignment_id': assignmentId,
+        if (includeNulls || assignmentId != null) 'assignment_id': assignmentId,
         'assignment_created': assignmentCreated,
-        if (actualQty != null) 'actual_qty': actualQty,
-        if (shippedAt != null) 'shipped_at': shippedAt!.toIso8601String(),
-        if (shippedBy != null) 'shipped_by': shippedBy,
-        if (shippedQty != null) 'shipped_qty': shippedQty,
+        if (includeNulls || actualQty != null) 'actual_qty': actualQty,
+        if (includeNulls || shippedAt != null)
+          'shipped_at': shippedAt?.toIso8601String(),
+        if (includeNulls || shippedBy != null) 'shipped_by': shippedBy,
+        if (includeNulls || shippedQty != null) 'shipped_qty': shippedQty,
       };
 
   /// Парсим и camelCase, и snake_case.

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -472,7 +472,7 @@ class OrdersProvider with ChangeNotifier {
       // В модулях оформления/редактирования заказа не блокируем сохранение.
       await _supabase
           .from('orders')
-          .update(updated.toMap()..remove('id'))
+          .update(updated.toMap(includeNulls: true)..remove('id'))
           .eq('id', updated.id);
       if (updated.assignmentCreated ||
           updated.statusEnum == OrderStatus.in_production) {


### PR DESCRIPTION
### Motivation
- При редактировании заказа очищённые nullable-поля (например, очередь этапов) снова появлялись при повторном открытии, потому что `UPDATE`-прекламация пропускала поля с `null` и БД сохраняла старые значения. 
- Нужно явно отправлять `null` для очищенных полей при обновлении, чтобы поведение сохранения было идемпотентным (удалил → сохранил → поле остаётся пустым).

### Description
- Добавлен параметр `includeNulls` в `OrderModel.toMap({bool includeNulls = false})`, который включает nullable-поля в мапу даже если они равны `null`.
- Переведён `OrdersProvider.updateOrder` на вызов `updated.toMap(includeNulls: true)` перед `.update(...)`, чтобы при сохранении в Supabase очищённые поля явно писались как `NULL`.
- Изменённые файлы: `lib/modules/orders/order_model.dart` и `lib/modules/orders/orders_provider.dart`.

### Testing
- Выполнены проверки диффа и просмотр изменённых фрагментов с помощью `git diff` и `nl -ba ...` для подтверждения внесённых изменений и их местоположения. 
- Попытка форматирования с `dart format` не выполнена в контейнере из-за отсутствия бинарника `dart` (`/bin/bash: dart: command not found`).
- Коммит с изменениями выполнен успешно; автоматизированных unit-тестов не запускалось, проверка проведена путём ревью кода и инспекции внесённых изменений.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0892dee1c832f9ca212c54782f4db)