### PR TITLE
Respect per-paper `extra.lengthL` when computing paper reserves and shortages

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1248,8 +1248,12 @@ class OrdersProvider with ChangeNotifier {
   }
 
   double _requiredPaperReserveQty(OrderModel order, MaterialModel paper) {
-    final double length =
-        (order.product.length ?? 0).toDouble();
+    final double? perPaperLength = _paperExtraLength(paper);
+    if (perPaperLength != null && perPaperLength > 0) {
+      return perPaperLength;
+    }
+
+    final double length = (order.product.length ?? 0).toDouble();
     if (length > 0) return length;
 
     if (paper.quantity > 0) return paper.quantity;
@@ -1258,9 +1262,12 @@ class OrdersProvider with ChangeNotifier {
   }
 
   Future<MaterialModel> _normalizePaperForReservation(MaterialModel paper) async {
+    final double? perPaperLength = _paperExtraLength(paper);
     final double qty = paper.quantity > 0
         ? paper.quantity
-        : (paper.weight != null && paper.weight! > 0 ? paper.weight! : 0.0);
+        : (perPaperLength != null && perPaperLength > 0
+            ? perPaperLength
+            : (paper.weight != null && paper.weight! > 0 ? paper.weight! : 0.0));
     final normalized = paper.copyWith(quantity: qty);
     final currentId = (normalized.id ?? '').trim();
     if (currentId.isNotEmpty) {
@@ -1295,6 +1302,17 @@ class OrdersProvider with ChangeNotifier {
       return id.isEmpty ? null : id;
     } catch (_) {
       return null;
+    }
+    return null;
+  }
+
+  double? _paperExtraLength(MaterialModel paper) {
+    final dynamic value = paper.extra?['lengthL'];
+    if (value is num) return value.toDouble();
+    if (value is String) {
+      final normalized = value.trim().replaceAll(',', '.');
+      if (normalized.isEmpty) return null;
+      return double.tryParse(normalized);
     }
     return null;
   }


### PR DESCRIPTION
### Motivation
- Secondary/tertiary paper slots (№2/№3) had their required length derived from shared fallbacks, so shortages specific to those slots could be overlooked and orders would not move to `waiting_materials` as expected. 
- The goal is to make reserve and availability calculations use the per-paper `Длина L` (`extra.lengthL`) when provided.

### Description
- Prefer per-paper length by adding and using helper `_paperExtraLength(MaterialModel)` to parse `extra['lengthL']` from numeric or string values. 
- Update `_requiredPaperReserveQty` to return per-paper `lengthL` when present before falling back to `product.length`, `paper.quantity`, and `paper.weight`. 
- Update `_normalizePaperForReservation` to populate `quantity` from per-paper `lengthL` when `quantity` is not set, preserving previous fallbacks. 
- Changes applied in `lib/modules/orders/orders_provider.dart` and commit message updated accordingly.

### Testing
- Ran `git status --short` which showed the modified file and succeeded. 
- Attempted `dart format lib/modules/orders/orders_provider.dart` but it failed because `dart` is not available in the environment (`/bin/bash: line 1: dart: command not found`). 
- Committed the change with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08bcc1e5c832f908e8e5a1a74f4c7)