### PR TITLE
Extra paper shortage indicator and stage preview updates

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -2120,6 +2120,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       );
       _activePaperSlotIndex = _extraPaperMaterials.length;
     });
+    _scheduleStagePreviewUpdate();
   }
 
   double? _paperExtraDouble(MaterialModel paper, String key) {
@@ -3879,6 +3880,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (_extraPaperMaterials.isEmpty) return const SizedBox.shrink();
 
     final papers = _paperItems();
+    final warehouse = Provider.of<WarehouseProvider>(context, listen: false);
     final nameSet = <String>{};
     for (final t in papers) {
       final n = t.description.trim();
@@ -3913,6 +3915,38 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       final sorted = grammages.toList()
         ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
       return sorted;
+    }
+
+    TmcModel? resolveExtraPaper(MaterialModel paper) {
+      final name = paper.name.trim().toLowerCase();
+      final format = (paper.format ?? '').trim().toLowerCase();
+      final grammage = (paper.grammage ?? '').trim().toLowerCase();
+      if (name.isEmpty || format.isEmpty || grammage.isEmpty) {
+        return null;
+      }
+      for (final t in papers) {
+        if (t.description.trim().toLowerCase() == name &&
+            (t.format ?? '').trim().toLowerCase() == format &&
+            (t.grammage ?? '').trim().toLowerCase() == grammage) {
+          return t;
+        }
+      }
+      return null;
+    }
+
+    bool extraLengthExceeded(MaterialModel paper) {
+      final length = _paperExtraDouble(paper, 'lengthL');
+      if (length == null || length <= 0) return false;
+      final resolved = resolveExtraPaper(paper);
+      if (resolved == null) return false;
+      var available = resolved.quantity;
+      for (final t in warehouse.allTmc) {
+        if (t.id == resolved.id) {
+          available = t.quantity;
+          break;
+        }
+      }
+      return length > available;
     }
 
     Iterable<String> filter(Iterable<String> source, String query) {
@@ -4136,6 +4170,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                                 : _extraPaperMaterials.length;
                           }
                         });
+                        _scheduleStagePreviewUpdate();
                       },
                       icon: const Icon(Icons.delete_outline),
                     ),
@@ -4171,6 +4206,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                           extra: nextExtra.isEmpty ? null : nextExtra,
                         );
                       });
+                      _scheduleStagePreviewUpdate();
                     },
                   ),
                   const SizedBox(height: 4),
@@ -4201,6 +4237,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                                 extra: nextExtra.isEmpty ? null : nextExtra,
                               );
                             });
+                            _scheduleStagePreviewUpdate();
                           },
                         ),
                       ),
@@ -4218,6 +4255,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                           decoration: const InputDecoration(
                             labelText: 'Длина L',
                             border: OutlineInputBorder(),
+                          ).copyWith(
+                            errorText: extraLengthExceeded(_extraPaperMaterials[i])
+                                ? 'Недостаточно'
+                                : null,
                           ),
                           keyboardType: const TextInputType.numberWithOptions(
                               decimal: true),
@@ -4241,6 +4282,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                                 extra: nextExtra.isEmpty ? null : nextExtra,
                               );
                             });
+                            _scheduleStagePreviewUpdate();
                           },
                         ),
                       ),


### PR DESCRIPTION
### Motivation
- Сделать для второй/третьей бумаги такой же индикатор нехватки ("Недостаточно") в поле `Длина L`, как для первой бумаги. 
- Обеспечить обновление превью/очереди этапов при изменении полей второй или третьей бумаги, так же как это происходит при изменении первой бумаги.

### Description
- Добавлена функция разрешения дополнительной бумаги по тройке `name/format/grammage` и проверка актуального остатка через провайдера склада в `lib/modules/orders/edit_order_screen.dart`.
- Добавлена функция `extraLengthExceeded` и подключён `warehouse = Provider.of<WarehouseProvider>(...)` для вычисления доступного количества по id TMC.
- В поле `Длина L` для дополнительных слотов бумаги (`#2/#3`) теперь устанавливается `errorText: 'Недостаточно'` при превышении доступного остатка.
- Вызовы `_scheduleStagePreviewUpdate()` добавлены при добавлении слота, удалении слота и при изменении полей `Ширина b`, `Количество` и `Длина L` у доп. бумаг для триггера пересчёта очереди этапов.

### Testing
- Попытки запустить форматирование: `dart format lib/modules/orders/edit_order_screen.dart` и `flutter format lib/modules/orders/edit_order_screen.dart` не выполнены из‑за отсутствия `dart`/`flutter` в PATH (ошибка: `command not found`).
- Проверка статуса git: `git status --short` прошла успешно.
- Фиксация изменений в репозитории выполнена успешно через `git commit` с сообщением об исправлении. 
- Изменения просмотрены через `git diff` / просмотр файла после патча (line-level inspection) и интегрированы в код.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08e3b0bf8832fbdd8a0f7842746f8)