### PR TITLE
Cleanup production tasks and queue when deleting orders

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -793,13 +793,41 @@ class OrdersProvider with ChangeNotifier {
     notifyListeners();
 
     try {
+      final assignmentId = (removed.assignmentId ?? '').trim();
+      final relatedOrderIds = <String>{
+        id.trim(),
+        if (assignmentId.isNotEmpty) assignmentId,
+      }..removeWhere((value) => value.isEmpty);
+
       // Фикс: логируем удаление до фактического удаления заказа, иначе
       // вставка в order_events ломается по FK order_events_order_id_fkey.
       await _logOrderEvent(id, 'Удаление', 'Удалён заказ');
 
       // Важно: удаляем связанные сущности синхронно, чтобы заказ не "висел"
       // в модуле производственных заданий и рабочем пространстве.
-      await _supabase.from('tasks').delete().eq('order_id', id);
+      // Если этап уже запущен, сначала принудительно завершаем его, затем удаляем,
+      // чтобы в очереди не оставались "висящие" назначения.
+      for (final orderRef in relatedOrderIds) {
+        try {
+          await _supabase
+              .from('tasks')
+              .update({
+                'status': 'done',
+                'completed_at': DateTime.now().toUtc().toIso8601String(),
+              })
+              .eq('order_id', orderRef)
+              .neq('status', 'done');
+        } catch (_) {
+          // На старых схемах может отсутствовать completed_at.
+          await _supabase
+              .from('tasks')
+              .update({'status': 'done'})
+              .eq('order_id', orderRef)
+              .neq('status', 'done');
+        }
+        await _supabase.from('tasks').delete().eq('order_id', orderRef);
+      }
+      await _cleanupProductionQueueState(relatedOrderIds);
       // Бизнес-правило: удаление заказа освобождает весь резерв бумаги.
       await _releasePaperReservations(orderId: id);
       await _supabase.from('order_paints').delete().eq('order_id', id);
@@ -826,6 +854,48 @@ class OrdersProvider with ChangeNotifier {
       _orders.insert(index, removed);
       notifyListeners();
       debugPrint('❌ deleteOrder error: $e\n$st');
+    }
+  }
+
+  Future<void> _cleanupProductionQueueState(Set<String> removedOrderIds) async {
+    if (removedOrderIds.isEmpty) return;
+
+    try {
+      final rows = await _supabase
+          .from('production_queue_state')
+          .select('group_id, order_sequence, hidden_order_ids');
+      if (rows is! List) return;
+
+      for (final row in rows.whereType<Map>()) {
+        final map = Map<String, dynamic>.from(row as Map);
+        final groupId = (map['group_id'] ?? '').toString();
+        final originalSequence = (map['order_sequence'] as List? ?? const [])
+            .map((e) => e?.toString() ?? '')
+            .toList(growable: false);
+        final originalHidden = (map['hidden_order_ids'] as List? ?? const [])
+            .map((e) => e?.toString() ?? '')
+            .toList(growable: false);
+
+        final nextSequence = originalSequence
+            .where((value) => !removedOrderIds.contains(value.trim()))
+            .toList(growable: false);
+        final nextHidden = originalHidden
+            .where((value) => !removedOrderIds.contains(value.trim()))
+            .toList(growable: false);
+
+        final changed =
+            nextSequence.length != originalSequence.length || nextHidden.length != originalHidden.length;
+        if (!changed) continue;
+
+        await _supabase.from('production_queue_state').upsert({
+          'group_id': groupId,
+          'order_sequence': nextSequence,
+          'hidden_order_ids': nextHidden,
+          'updated_at': DateTime.now().toUtc().toIso8601String(),
+        });
+      }
+    } catch (e, st) {
+      debugPrint('⚠️ cleanup production_queue_state failed: $e\n$st');
     }
   }
 


### PR DESCRIPTION
### Motivation
- При удалении заказа нужно полностью удалить все связанные этапы/задачи и ссылки на заказ в очереди производства, чтобы не оставалось «мусора» в модуле производственных заданий даже если этап был начат.
- В некоторых сценариях задачи могут ссылаться на `assignmentId`, поэтому удаление должно учитывать и эти связки, чтобы не оставлять висячие записи.

### Description
- В `deleteOrder` собираются все связанные идентификаторы (`id` заказа и, если есть, `assignmentId`) в множество `relatedOrderIds` для комплексной очистки.  
- Перед удалением задач по каждому идентификатору выполняется принудительное завершение: обновление `status` → `done` и попытка установки `completed_at`, с совместимым fallback для старых схем, и затем удаление задач из таблицы `tasks`.  
- Добавлена функция `_cleanupProductionQueueState(Set<String>)`, которая читает строки из `production_queue_state`, удаляет из `order_sequence` и `hidden_order_ids` удалённые идентификаторы и выполняет `upsert` с обновлёнными списками.  
- Сохранено поведение отката в случае ошибки (оптимистичное восстановление локального списка `_orders`) и добавлена защита от отсутствующих таблиц/полей.

### Testing
- Попытка форматирования с помощью `dart format lib/modules/orders/orders_provider.dart` не выполнена из-за отсутствия `dart` в окружении (failed).  
- Проверка наличия SDK через `flutter --version` не выполнена из-за отсутствия `flutter` в окружении (failed).  
- Никакие автоматические unit/integration тесты в этом окружении не запускались (none run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0913697e8832fa8a825401d76518d)