### PR TITLE
Fix wrong initial paper length shown after stage completion

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1256,18 +1256,33 @@ class _TasksScreenState extends State<TasksScreen>
             ),
           ];
 
-    double initialPaperQty(MaterialModel item) {
+    double? paperLengthFromExtra(MaterialModel item) {
+      final raw = item.extra?['lengthL'];
+      if (raw is num) return raw.toDouble();
+      if (raw is String) {
+        final normalized = raw.trim().replaceAll(',', '.');
+        if (normalized.isEmpty) return null;
+        return double.tryParse(normalized);
+      }
+      return null;
+    }
+
+    double initialPaperQty(MaterialModel item, int index) {
       final fromCurrent = item.quantity > 0 ? item.quantity : 0.0;
+      final fromExtra = paperLengthFromExtra(item) ?? 0.0;
       final orderLength = (latest.product.length ?? 0).toDouble();
+
+      if (index == 0 && orderLength > 0) return orderLength;
+      if (fromExtra > 0) return fromExtra;
       if (fromCurrent > 0) return fromCurrent;
       if (orderLength > 0) return orderLength;
-      return fromCurrent;
+      return 0.0;
     }
 
     final qtyControllers = <TextEditingController>[
-      for (final item in selected)
+      for (var i = 0; i < selected.length; i++)
         () {
-          final qty = initialPaperQty(item);
+          final qty = initialPaperQty(selected[i], i);
           return TextEditingController(
             text: qty > 0 ? qty.toStringAsFixed(2) : '',
           );


### PR DESCRIPTION
### Motivation
- The workspace dialog `Изменение бумаги в заказе` initialized the `Длина L` field from `material.quantity`, which can hold a runtime/remaining value after a stage is completed and therefore show a wrong length compared to the order's product length.

### Description
- Added a local parser `paperLengthFromExtra` for `extra['lengthL']` and made `initialPaperQty` index-aware so the first paper prefers `product.length` while additional papers prefer `extra['lengthL']` with fallbacks to `quantity` and order length.
- Updated the controllers initialization loop to pass the paper index into `initialPaperQty` and set the default return to `0.0` when no length is available.
- All edits are contained in `lib/modules/tasks/tasks_screen.dart`.

### Testing
- Ran `dart format lib/modules/tasks/tasks_screen.dart`, which failed in this environment because `dart` is not installed.
- Ran `flutter --version`, which failed in this environment because `flutter` is not installed.
- No automated unit tests were executed here; changes were validated by inspecting the dialog initialization and controller setup in the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0936edd70832f872ea6c7e5aa4d50)