### PR TITLE
Улучшить читаемость комментариев производства и исправить логику пересмены

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1612,9 +1612,12 @@ class OrdersProvider with ChangeNotifier {
       final next = i < after.length ? after[i] : null;
       final slot = i + 1;
       if (old != null && next != null) {
+        final delta = next.quantity - old.quantity;
+        final deltaPrefix = delta >= 0 ? '+' : '';
         buffer.writeln(
           'Бумага №$slot: было ${materialName(old)} — ${old.quantity.toStringAsFixed(2)} м, '
-          'стало ${materialName(next)} — ${next.quantity.toStringAsFixed(2)} м',
+          'стало ${materialName(next)} — ${next.quantity.toStringAsFixed(2)} м '
+          '($deltaPrefix${delta.toStringAsFixed(2)} м)',
         );
       } else if (old == null && next != null) {
         buffer.writeln(

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -448,9 +448,31 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
     }
   }
 
+  String _formatQuantityDisplay(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return '0';
+    final value = double.tryParse(trimmed.replaceAll(',', '.'));
+    if (value == null) return trimmed;
+    if ((value - value.round()).abs() < 0.0001) {
+      return value.round().toString();
+    }
+    return value.toStringAsFixed(2);
+  }
+
   String _renderCommentText(TaskComment comment, List<EmployeeModel> employees) {
     final rawText = comment.text.trim();
-    if (rawText.isEmpty) return 'Без комментария';
+    if (rawText.isEmpty) {
+      switch (comment.type) {
+        case 'shift_pause':
+          return 'Пересмена: этап приостановлен';
+        case 'shift_resume':
+          return 'Пересмена: работа возобновлена';
+        case 'ink_writeoff':
+          return 'Зафиксировано списание краски';
+        default:
+          return 'Без комментария';
+      }
+    }
 
     final parsed = TaskTimeEvent.fromPayload(
       rawText,
@@ -468,6 +490,36 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
       final note = parsed.note?.trim();
       final notePart = (note != null && note.isNotEmpty) ? ' · $note' : '';
       return '${_timeTypeLabel(parsed.type)}: $periodStart — $periodEnd · $subject$notePart';
+    }
+
+    switch (comment.type) {
+      case 'start':
+        return 'Начал(а) этап';
+      case 'pause':
+        return 'Пауза: $rawText';
+      case 'problem':
+        return 'Проблема: $rawText';
+      case 'setup_start':
+        return 'Начал(а) наладку';
+      case 'setup_resume':
+        return 'Продолжил(а) наладку';
+      case 'setup_done':
+        return 'Завершил(а) наладку';
+      case 'quantity_done':
+        return 'Выполнил(а): ${_formatQuantityDisplay(rawText)} шт.';
+      case 'quantity_team_total':
+        return 'Команда выполнила: ${_formatQuantityDisplay(rawText)} шт.';
+      case 'quantity_share':
+        return 'Личный вклад: ${_formatQuantityDisplay(rawText)} шт.';
+      case 'shift_pause':
+      case 'shift_resume':
+      case 'finish_note':
+      case 'ink_writeoff':
+        return rawText;
+      case 'shift_pause_state':
+      case 'exec_mode':
+      case 'exec_mode_stage':
+        return 'Служебная отметка этапа';
     }
 
     if (rawText.startsWith('{') && rawText.endsWith('}')) {
@@ -514,8 +566,17 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
     required PersonnelProvider personnel,
   }) {
     final comments = <TaskComment>[];
+    const hiddenTypes = <String>{
+      'shift_pause_state',
+      'exec_mode',
+      'exec_mode_stage',
+    };
     for (final t in tasks) {
-      comments.addAll(t.comments);
+      comments.addAll(
+        t.comments.where(
+          (comment) => !hiddenTypes.contains(comment.type.trim().toLowerCase()),
+        ),
+      );
     }
     comments.sort((a, b) => a.timestamp.compareTo(b.timestamp));
 

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1679,6 +1679,8 @@ class _TasksScreenState extends State<TasksScreen>
             : 'Проблема: ${comment.text}';
       case 'setup_start':
         return 'Начал(а) наладку';
+      case 'setup_resume':
+        return 'Продолжил(а) наладку';
       case 'setup_done':
         return 'Завершил(а) наладку';
       case 'quantity_done':
@@ -1708,6 +1710,12 @@ class _TasksScreenState extends State<TasksScreen>
         return comment.text.isNotEmpty
             ? comment.text
             : 'Пересмена: работа возобновлена';
+      case 'shift_pause_state':
+        return 'Состояние для пересмены сохранено';
+      case 'ink_writeoff':
+        return comment.text.isNotEmpty
+            ? comment.text
+            : 'Зафиксировано списание краски';
       default:
         return comment.text;
     }
@@ -3640,10 +3648,12 @@ class _TasksScreenState extends State<TasksScreen>
           qty: qtyForStock,
           reason: humanReadableReason,
         );
+        final qtyText = qtyForStock.toStringAsFixed(0);
         await taskProvider.addCommentAutoUser(
           taskId: task.id,
           type: 'ink_writeoff',
-          text: humanReadableReason,
+          text: 'Изменение краски: «$paintName» списано на $qtyText г. '
+              'Причина: $humanReadableReason',
           userIdOverride: widget.employeeId,
         );
       }
@@ -4286,6 +4296,18 @@ class _TasksScreenState extends State<TasksScreen>
                             !setupInProgressForCurrentUser) {
                           await _finishSetup(task, provider);
                         }
+                        final latestTaskAfterStartPrep = taskProvider.tasks.firstWhere(
+                          (t) => t.id == task.id,
+                          orElse: () => task,
+                        );
+                        final shouldResumeSetup =
+                            _isSetupInProgressForUser(
+                                  latestTaskAfterStartPrep,
+                                  widget.employeeId,
+                                ) &&
+                                !_hasProductionStartedForStage(
+                                  latestTaskAfterStartPrep,
+                                );
                         final startedAtTs =
                             task.startedAt ?? DateTime.now().millisecondsSinceEpoch;
                         await taskProvider.updateStatus(
@@ -4299,7 +4321,7 @@ class _TasksScreenState extends State<TasksScreen>
                           text: 'Начал(а) этап',
                           userIdOverride: widget.employeeId,
                         );
-                        if (setupInProgressForCurrentUser) {
+                        if (shouldResumeSetup) {
                           await taskProvider.addCommentAutoUser(
                             taskId: task.id,
                             type: 'setup_resume',
@@ -4648,9 +4670,12 @@ class _TasksScreenState extends State<TasksScreen>
                           latestTask,
                           currentRowUserId,
                         );
-                        final shiftResumeState = (isSetupActiveForRow ||
-                                isSetupInProgress ||
-                                hasPendingSetup)
+                        final stageProductionStarted =
+                            _hasProductionStartedForStage(latestTask);
+                        final shiftResumeState = (!stageProductionStarted &&
+                                (isSetupActiveForRow ||
+                                    isSetupInProgress ||
+                                    hasPendingSetup))
                             ? 'setup'
                             : stateRowUser == UserRunState.paused
                                 ? 'paused'


### PR DESCRIPTION
### Motivation
- Операторы должны видеть в ленте комментариев понятные, человекочитаемые записи о том, кто и когда что сделал, а служебные метки не должны мешать восприятию истории. 
- Сейчас при возобновлении работы после пересмены иногда пишется ложный комментарий «Продолжил(а) наладку», что вводит в заблуждение; это нужно исправить.

### Description
- Исправлена логика стартовой последовательности: перед записью `setup_resume` условие пересчитывается по актуальному снимку задачи (`taskProvider.tasks.firstWhere`) и `setup_resume` теперь добавляется только если производство ещё не начиналось, чтобы избежать ложных сообщений (изменения в `lib/modules/tasks/tasks_screen.dart`).
- При восстановлении после пересмены (`shift_resume`) состояние теперь определяется с учётом того, началось ли уже производство для этапа, чтобы `setup` восстанавливался только если производство не стартовало (изменения в `lib/modules/tasks/tasks_screen.dart`).
- Улучшено отображение комментариев в просмотре заказа: добавлены человекочитаемые формулировки для ключевых типов (`start`, `pause`, `problem`, `setup_*`, `quantity_*`, `ink_writeoff` и т.д.) и форматирование количеств через вспомогательную ` _formatQuantityDisplay` (изменения в `lib/modules/production/production_details_screen.dart`).
- Скрыты служебные типы комментариев (`shift_pause_state`, `exec_mode`, `exec_mode_stage`) из списка комментариев в карточке производства для уменьшения шума (изменения в `lib/modules/production/production_details_screen.dart`).
- Расширены комментарии при списании краски: теперь в `ink_writeoff` записывается название краски, точное количество в граммах и причина, чтобы в ленте было видно «на сколько» и почему списали (изменения в `lib/modules/tasks/tasks_screen.dart`).
- В историю изменений бумаги добавлена явная дельта `+/-` в метрах, чтобы сразу видеть на сколько изменили количество бумаги (изменения в `lib/modules/orders/orders_provider.dart`).

### Testing
- Попытка запустить `flutter test` не удалась из-за отсутствия Flutter SDK в окружении: `flutter: command not found`.
- Попытка выполнить `dart format` не удалась из-за отсутствия Dart SDK в окружении: `dart: command not found`.
- Статическая сборка/запуск в CI не выполнялись в этом окружении, поэтому изменения нуждаются в прогоне тестов и ручной проверке на устройстве/эмуляторе с установленными SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0965f5d00832fbf372a726c2af82c)