### PR TITLE
Improve extra paper card borders and move delete action

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3978,63 +3978,93 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             onTap: () => setState(() => _activePaperSlotIndex = i + 1),
             borderRadius: BorderRadius.circular(8),
             child: Container(
-              padding: const EdgeInsets.all(4),
+              margin: const EdgeInsets.only(bottom: 8),
+              padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(
                   color: _activePaperSlotIndex == i + 1
                       ? Theme.of(context).colorScheme.primary
-                      : Colors.transparent,
+                      : Theme.of(context).dividerColor.withOpacity(0.8),
+                  width: _activePaperSlotIndex == i + 1 ? 1.4 : 1,
                 ),
               ),
               child: Column(
                 children: [
-                  Autocomplete<String>(
-                    optionsBuilder: (text) => filter(allNames, text.text),
-                    displayStringForOption: (value) => value,
-                    fieldViewBuilder:
-                        (ctx, controller, focusNode, onFieldSubmitted) {
-                      final currentName = _extraPaperMaterials[i].name;
-                      if (controller.text != currentName) {
-                        controller.value = TextEditingValue(
-                          text: currentName,
-                          selection:
-                              TextSelection.collapsed(offset: currentName.length),
-                        );
-                      }
-                      return TextField(
-                        controller: controller,
-                        focusNode: focusNode,
-                        decoration: paperDecoration(
-                          'Материал (бумага №${i + 2})',
-                          _activePaperSlotIndex == i + 1,
-                        ),
-                        onChanged: (value) {
-                          setState(() {
-                            _activePaperSlotIndex = i + 1;
-                            _extraPaperMaterials[i] = _extraPaperMaterials[i].copyWith(
-                              name: value,
-                              format: null,
-                              grammage: null,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Autocomplete<String>(
+                          optionsBuilder: (text) => filter(allNames, text.text),
+                          displayStringForOption: (value) => value,
+                          fieldViewBuilder:
+                              (ctx, controller, focusNode, onFieldSubmitted) {
+                            final currentName = _extraPaperMaterials[i].name;
+                            if (controller.text != currentName) {
+                              controller.value = TextEditingValue(
+                                text: currentName,
+                                selection: TextSelection.collapsed(
+                                  offset: currentName.length,
+                                ),
+                              );
+                            }
+                            return TextField(
+                              controller: controller,
+                              focusNode: focusNode,
+                              decoration: paperDecoration(
+                                'Материал (бумага №${i + 2})',
+                                _activePaperSlotIndex == i + 1,
+                              ),
+                              onChanged: (value) {
+                                setState(() {
+                                  _activePaperSlotIndex = i + 1;
+                                  _extraPaperMaterials[i] =
+                                      _extraPaperMaterials[i].copyWith(
+                                    name: value,
+                                    format: null,
+                                    grammage: null,
+                                  );
+                                });
+                                _scheduleStagePreviewUpdate();
+                              },
+                              onSubmitted: (_) => onFieldSubmitted(),
                             );
+                          },
+                          onSelected: (value) {
+                            setState(() {
+                              _activePaperSlotIndex = i + 1;
+                              _extraPaperMaterials[i] =
+                                  _extraPaperMaterials[i].copyWith(
+                                name: value,
+                                format: null,
+                                grammage: null,
+                              );
+                            });
+                            _scheduleStagePreviewUpdate();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      IconButton(
+                        tooltip: 'Удалить бумагу',
+                        visualDensity: VisualDensity.compact,
+                        onPressed: () {
+                          setState(() {
+                            _extraPaperMaterials.removeAt(i);
+                            if (_activePaperSlotIndex >
+                                _extraPaperMaterials.length) {
+                              _activePaperSlotIndex =
+                                  _extraPaperMaterials.isEmpty
+                                      ? 0
+                                      : _extraPaperMaterials.length;
+                            }
                           });
                           _scheduleStagePreviewUpdate();
                         },
-                        onSubmitted: (_) => onFieldSubmitted(),
-                      );
-                    },
-                    onSelected: (value) {
-                      setState(() {
-                        _activePaperSlotIndex = i + 1;
-                        _extraPaperMaterials[i] =
-                            _extraPaperMaterials[i].copyWith(
-                          name: value,
-                          format: null,
-                          grammage: null,
-                        );
-                      });
-                      _scheduleStagePreviewUpdate();
-                    },
+                        icon: const Icon(Icons.delete_outline),
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 4),
                   Autocomplete<String>(
@@ -4157,25 +4187,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                     },
                   ),
                   const SizedBox(height: 4),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: IconButton(
-                      tooltip: 'Удалить бумагу',
-                      onPressed: () {
-                        setState(() {
-                          _extraPaperMaterials.removeAt(i);
-                          if (_activePaperSlotIndex > _extraPaperMaterials.length) {
-                            _activePaperSlotIndex = _extraPaperMaterials.isEmpty
-                                ? 0
-                                : _extraPaperMaterials.length;
-                          }
-                        });
-                        _scheduleStagePreviewUpdate();
-                      },
-                      icon: const Icon(Icons.delete_outline),
-                    ),
-                  ),
-                  const SizedBox(height: 4),
                   TextFormField(
                     initialValue: _paperExtraDouble(
                               _extraPaperMaterials[i],
@@ -4292,7 +4303,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               ),
             ),
           ),
-          const SizedBox(height: 6),
         ],
       ],
     );

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -4480,281 +4480,316 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                     ? gramsFor(_matSelectedName!, _matSelectedFormat!)
                     : const <String>[];
 
+            InputDecoration mainPaperDecoration(String label) {
+              final bool active = _activePaperSlotIndex == 0;
+              return InputDecoration(
+                labelText: label,
+                border: const OutlineInputBorder(),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(
+                    color: active
+                        ? Theme.of(context).colorScheme.primary
+                        : Theme.of(context).dividerColor,
+                  ),
+                ),
+              );
+            }
+
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Autocomplete<String>(
-                  optionsBuilder: (text) => filter(allNames, text.text),
-                  displayStringForOption: (s) => s,
-                  fieldViewBuilder:
-                      (ctx, controller, focusNode, onFieldSubmitted) {
-                    controller.text = _matNameCtl.text;
-                    controller.selection = _matNameCtl.selection;
-                    controller.addListener(() {
-                      if (controller.text != _matNameCtl.text) {
-                        setState(() {
-                          _activePaperSlotIndex = 0;
-                          _matNameCtl.text = controller.text;
-                          _matNameCtl.selection = controller.selection;
-                          _matSelectedName = null;
-                          _matSelectedFormat = null;
-                          _matSelectedGrammage = null;
-                          _matFormatCtl.text = '';
-                          _matGramCtl.text = '';
-                          _matNameError = (_matNameCtl.text.trim().isEmpty ||
-                                  allNames.map((e) => e.toLowerCase()).contains(
-                                      _matNameCtl.text.trim().toLowerCase()))
-                              ? null
-                              : 'Выберите материал из списка';
-                          _matFormatError = null;
-                          _matGramError = null;
-                          final lowerNames =
-                              allNames.map((e) => e.toLowerCase()).toList();
-                          final typed = _matNameCtl.text.trim().toLowerCase();
-                          if (lowerNames.contains(typed)) {
-                            _matSelectedName =
-                                allNames[lowerNames.indexOf(typed)];
-                          }
-                        });
-                        _scheduleStagePreviewUpdate();
-                      }
-                    });
-                    return TextField(
-                      controller: controller,
-                      focusNode: focusNode,
-                      decoration: InputDecoration(
-                        labelText: 'Материал',
-                        border: const OutlineInputBorder(),
-                        errorText: _matNameError,
+                InkWell(
+                  onTap: () => setState(() => _activePaperSlotIndex = 0),
+                  borderRadius: BorderRadius.circular(8),
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: _activePaperSlotIndex == 0
+                            ? Theme.of(context).colorScheme.primary
+                            : Theme.of(context).dividerColor.withOpacity(0.8),
+                        width: _activePaperSlotIndex == 0 ? 1.4 : 1,
                       ),
-                      onSubmitted: (_) => onFieldSubmitted(),
-                    );
-                  },
-                  onSelected: (value) {
-                    setState(() {
-                      _activePaperSlotIndex = 0;
-                      _matNameCtl.text = value;
-                      _matSelectedName = value;
-                      _matSelectedFormat = null;
-                      _matSelectedGrammage = null;
-                      _matFormatCtl.text = '';
-                      _matGramCtl.text = '';
-                      _matNameError = null;
-                      _matFormatError = null;
-                      _matGramError = null;
-                      _selectedMaterialTmc = null;
-                      _selectedMaterial = null;
-                    });
-                    _scheduleStagePreviewUpdate();
-                  },
-                ),
-                const SizedBox(height: 4),
-                Autocomplete<String>(
-                  optionsBuilder: (text) => filter(formatOptions, text.text),
-                  displayStringForOption: (s) => s,
-                  fieldViewBuilder:
-                      (ctx, controller, focusNode, onFieldSubmitted) {
-                    controller.text = _matFormatCtl.text;
-                    controller.selection = _matFormatCtl.selection;
-                    controller.addListener(() {
-                      if (controller.text != _matFormatCtl.text) {
-                        setState(() {
-                          _activePaperSlotIndex = 0;
-                          _matFormatCtl.text = controller.text;
-                          _matFormatCtl.selection = controller.selection;
-                          _matSelectedFormat = null;
-                          _matSelectedGrammage = null;
-                          _matGramCtl.text = '';
-                          _matFormatError =
-                              (_matFormatCtl.text.trim().isEmpty ||
-                                      formatOptions
-                                          .map((e) => e.toLowerCase())
-                                          .contains(_matFormatCtl.text
-                                              .trim()
-                                              .toLowerCase()))
-                                  ? null
-                                  : 'Выберите формат из списка';
-                          final lowerF = formatOptions
-                              .map((e) => e.toLowerCase())
-                              .toList();
-                          final typed = _matFormatCtl.text.trim().toLowerCase();
-                          if (lowerF.contains(typed)) {
-                            _matSelectedFormat =
-                                formatOptions[lowerF.indexOf(typed)];
-                          }
-                        });
-                        _scheduleStagePreviewUpdate();
-                      }
-                    });
-                    return TextField(
-                      controller: controller,
-                      focusNode: focusNode,
-                      enabled: _matSelectedName != null,
-                      decoration: InputDecoration(
-                        labelText: 'Формат',
-                        border: const OutlineInputBorder(),
-                        helperText: _matSelectedName != null
-                            ? null
-                            : 'Сначала выберите материал',
-                        errorText:
-                            _matSelectedName != null ? _matFormatError : null,
-                      ),
-                      onSubmitted: (_) => onFieldSubmitted(),
-                    );
-                  },
-                  onSelected: (value) {
-                    setState(() {
-                      _activePaperSlotIndex = 0;
-                      _matFormatCtl.text = value;
-                      _matSelectedFormat = value;
-                      _matSelectedGrammage = null;
-                      _matGramCtl.text = '';
-                      _matFormatError = null;
-                      _matGramError = null;
-                    });
-                    _scheduleStagePreviewUpdate();
-                  },
-                ),
-                const SizedBox(height: 4),
-                Autocomplete<String>(
-                  optionsBuilder: (text) => filter(gramOptions, text.text),
-                  displayStringForOption: (s) => s,
-                  fieldViewBuilder:
-                      (ctx, controller, focusNode, onFieldSubmitted) {
-                    controller.text = _matGramCtl.text;
-                    controller.selection = _matGramCtl.selection;
-                    controller.addListener(() {
-                      if (controller.text != _matGramCtl.text) {
-                        setState(() {
-                          _activePaperSlotIndex = 0;
-                          _matGramCtl.text = controller.text;
-                          _matGramCtl.selection = controller.selection;
-                          _matSelectedGrammage = null;
-                          _matGramError = (_matGramCtl.text.trim().isEmpty ||
-                                  gramOptions
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Autocomplete<String>(
+                          optionsBuilder: (text) => filter(allNames, text.text),
+                          displayStringForOption: (s) => s,
+                          fieldViewBuilder:
+                              (ctx, controller, focusNode, onFieldSubmitted) {
+                            controller.text = _matNameCtl.text;
+                            controller.selection = _matNameCtl.selection;
+                            controller.addListener(() {
+                              if (controller.text != _matNameCtl.text) {
+                                setState(() {
+                                  _activePaperSlotIndex = 0;
+                                  _matNameCtl.text = controller.text;
+                                  _matNameCtl.selection = controller.selection;
+                                  _matSelectedName = null;
+                                  _matSelectedFormat = null;
+                                  _matSelectedGrammage = null;
+                                  _matFormatCtl.text = '';
+                                  _matGramCtl.text = '';
+                                  _matNameError = (_matNameCtl.text.trim().isEmpty ||
+                                          allNames
+                                              .map((e) => e.toLowerCase())
+                                              .contains(_matNameCtl.text
+                                                  .trim()
+                                                  .toLowerCase()))
+                                      ? null
+                                      : 'Выберите материал из списка';
+                                  _matFormatError = null;
+                                  _matGramError = null;
+                                  final lowerNames =
+                                      allNames.map((e) => e.toLowerCase()).toList();
+                                  final typed =
+                                      _matNameCtl.text.trim().toLowerCase();
+                                  if (lowerNames.contains(typed)) {
+                                    _matSelectedName =
+                                        allNames[lowerNames.indexOf(typed)];
+                                  }
+                                });
+                                _scheduleStagePreviewUpdate();
+                              }
+                            });
+                            return TextField(
+                              controller: controller,
+                              focusNode: focusNode,
+                              decoration:
+                                  mainPaperDecoration('Материал').copyWith(
+                                errorText: _matNameError,
+                              ),
+                              onSubmitted: (_) => onFieldSubmitted(),
+                            );
+                          },
+                          onSelected: (value) {
+                            setState(() {
+                              _activePaperSlotIndex = 0;
+                              _matNameCtl.text = value;
+                              _matSelectedName = value;
+                              _matSelectedFormat = null;
+                              _matSelectedGrammage = null;
+                              _matFormatCtl.text = '';
+                              _matGramCtl.text = '';
+                              _matNameError = null;
+                              _matFormatError = null;
+                              _matGramError = null;
+                              _selectedMaterialTmc = null;
+                              _selectedMaterial = null;
+                            });
+                            _scheduleStagePreviewUpdate();
+                          },
+                        ),
+                        const SizedBox(height: 4),
+                        Autocomplete<String>(
+                          optionsBuilder: (text) => filter(formatOptions, text.text),
+                          displayStringForOption: (s) => s,
+                          fieldViewBuilder:
+                              (ctx, controller, focusNode, onFieldSubmitted) {
+                            controller.text = _matFormatCtl.text;
+                            controller.selection = _matFormatCtl.selection;
+                            controller.addListener(() {
+                              if (controller.text != _matFormatCtl.text) {
+                                setState(() {
+                                  _activePaperSlotIndex = 0;
+                                  _matFormatCtl.text = controller.text;
+                                  _matFormatCtl.selection = controller.selection;
+                                  _matSelectedFormat = null;
+                                  _matSelectedGrammage = null;
+                                  _matGramCtl.text = '';
+                                  _matFormatError =
+                                      (_matFormatCtl.text.trim().isEmpty ||
+                                              formatOptions
+                                                  .map((e) => e.toLowerCase())
+                                                  .contains(_matFormatCtl.text
+                                                      .trim()
+                                                      .toLowerCase()))
+                                          ? null
+                                          : 'Выберите формат из списка';
+                                  final lowerF = formatOptions
                                       .map((e) => e.toLowerCase())
-                                      .contains(_matGramCtl.text
-                                          .trim()
-                                          .toLowerCase()))
-                              ? null
-                              : 'Выберите грамаж из списка';
-                          final lowerG =
-                              gramOptions.map((e) => e.toLowerCase()).toList();
-                          final typed = _matGramCtl.text.trim().toLowerCase();
-                          if (lowerG.contains(typed)) {
-                            _matSelectedGrammage =
-                                gramOptions[lowerG.indexOf(typed)];
-                          }
-                        });
-                        _scheduleStagePreviewUpdate();
-                      }
-                    });
-                    return TextField(
-                      controller: controller,
-                      focusNode: focusNode,
-                      enabled: _matSelectedName != null &&
-                          _matSelectedFormat != null,
-                      decoration: InputDecoration(
-                        labelText: 'Грамаж',
-                        border: const OutlineInputBorder(),
-                        helperText: (_matSelectedName != null &&
-                                _matSelectedFormat != null)
-                            ? null
-                            : 'Сначала выберите формат',
-                        errorText: (_matSelectedName != null &&
-                                _matSelectedFormat != null)
-                            ? _matGramError
-                            : null,
-                      ),
-                      onSubmitted: (_) => onFieldSubmitted(),
-                    );
-                  },
-                  onSelected: (value) {
-                    setState(() {
-                      _activePaperSlotIndex = 0;
-                      _matGramCtl.text = value;
-                      _matSelectedGrammage = value;
-                      _matGramError = null;
-                      final tmc = findExact(
-                          _matSelectedName!, _matSelectedFormat!, value);
-                      if (tmc != null) {
-                        _selectMaterial(tmc);
-                      }
-                    });
-                  },
+                                      .toList();
+                                  final typed =
+                                      _matFormatCtl.text.trim().toLowerCase();
+                                  if (lowerF.contains(typed)) {
+                                    _matSelectedFormat =
+                                        formatOptions[lowerF.indexOf(typed)];
+                                  }
+                                });
+                                _scheduleStagePreviewUpdate();
+                              }
+                            });
+                            return TextField(
+                              controller: controller,
+                              focusNode: focusNode,
+                              enabled: _matSelectedName != null,
+                              decoration:
+                                  mainPaperDecoration('Формат').copyWith(
+                                helperText: _matSelectedName != null
+                                    ? null
+                                    : 'Сначала выберите материал',
+                                errorText:
+                                    _matSelectedName != null ? _matFormatError : null,
+                              ),
+                              onSubmitted: (_) => onFieldSubmitted(),
+                            );
+                          },
+                          onSelected: (value) {
+                            setState(() {
+                              _activePaperSlotIndex = 0;
+                              _matFormatCtl.text = value;
+                              _matSelectedFormat = value;
+                              _matSelectedGrammage = null;
+                              _matGramCtl.text = '';
+                              _matFormatError = null;
+                              _matGramError = null;
+                            });
+                            _scheduleStagePreviewUpdate();
+                          },
+                        ),
+                        const SizedBox(height: 4),
+                        Autocomplete<String>(
+                          optionsBuilder: (text) => filter(gramOptions, text.text),
+                          displayStringForOption: (s) => s,
+                          fieldViewBuilder:
+                              (ctx, controller, focusNode, onFieldSubmitted) {
+                            controller.text = _matGramCtl.text;
+                            controller.selection = _matGramCtl.selection;
+                            controller.addListener(() {
+                              if (controller.text != _matGramCtl.text) {
+                                setState(() {
+                                  _activePaperSlotIndex = 0;
+                                  _matGramCtl.text = controller.text;
+                                  _matGramCtl.selection = controller.selection;
+                                  _matSelectedGrammage = null;
+                                  _matGramError = (_matGramCtl.text.trim().isEmpty ||
+                                          gramOptions
+                                              .map((e) => e.toLowerCase())
+                                              .contains(_matGramCtl.text
+                                                  .trim()
+                                                  .toLowerCase()))
+                                      ? null
+                                      : 'Выберите грамаж из списка';
+                                  final lowerG =
+                                      gramOptions.map((e) => e.toLowerCase()).toList();
+                                  final typed =
+                                      _matGramCtl.text.trim().toLowerCase();
+                                  if (lowerG.contains(typed)) {
+                                    _matSelectedGrammage =
+                                        gramOptions[lowerG.indexOf(typed)];
+                                  }
+                                });
+                                _scheduleStagePreviewUpdate();
+                              }
+                            });
+                            return TextField(
+                              controller: controller,
+                              focusNode: focusNode,
+                              enabled: _matSelectedName != null &&
+                                  _matSelectedFormat != null,
+                              decoration:
+                                  mainPaperDecoration('Грамаж').copyWith(
+                                helperText: (_matSelectedName != null &&
+                                        _matSelectedFormat != null)
+                                    ? null
+                                    : 'Сначала выберите формат',
+                                errorText: (_matSelectedName != null &&
+                                        _matSelectedFormat != null)
+                                    ? _matGramError
+                                    : null,
+                              ),
+                              onSubmitted: (_) => onFieldSubmitted(),
+                            );
+                          },
+                          onSelected: (value) {
+                            setState(() {
+                              _activePaperSlotIndex = 0;
+                              _matGramCtl.text = value;
+                              _matSelectedGrammage = value;
+                              _matGramError = null;
+                              final tmc = findExact(
+                                  _matSelectedName!, _matSelectedFormat!, value);
+                              if (tmc != null) {
+                                _selectMaterial(tmc);
+                              }
+                            });
+                          },
+                        ),
+                        const SizedBox(height: 4),
+                        TextFormField(
+                          initialValue:
+                              product.widthB != null ? _formatDecimal(product.widthB!) : '',
+                          decoration: mainPaperDecoration('Ширина b'),
+                          keyboardType: TextInputType.number,
+                          onChanged: (val) {
+                            final normalized = val.replaceAll(',', '.');
+                            product.widthB = double.tryParse(normalized);
+                            _scheduleStagePreviewUpdate();
+                          },
+                        ),
+                        const SizedBox(height: 6),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                initialValue: product.blQuantity?.toString() ?? '',
+                                decoration: mainPaperDecoration('Количество'),
+                                keyboardType: TextInputType.text,
+                                onChanged: (val) {
+                                  final trimmed = val.trim();
+                                  product.blQuantity = trimmed.isEmpty ? null : trimmed;
+                                  _scheduleStagePreviewUpdate();
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: TextFormField(
+                                initialValue:
+                                    product.length != null ? _formatDecimal(product.length!) : '',
+                                decoration: mainPaperDecoration('Длина L').copyWith(
+                                  errorText: _lengthExceeded ? 'Недостаточно' : null,
+                                ),
+                                keyboardType: TextInputType.number,
+                                onChanged: (val) {
+                                  final normalized = val.replaceAll(',', '.');
+                                  final d = double.tryParse(normalized);
+                                  setState(() {
+                                    product.length = d;
+                                    final materialTmc =
+                                        _selectedMaterialTmc ?? _resolvePaperByText();
+                                    if (materialTmc != null && d != null) {
+                                      _lengthExceeded = () {
+                                        final current = Provider.of<WarehouseProvider>(
+                                                context,
+                                                listen: false)
+                                            .allTmc
+                                            .where((t) => t.id == materialTmc.id)
+                                            .toList();
+                                        final available = current.isNotEmpty
+                                            ? current.first.quantity
+                                            : materialTmc.quantity;
+                                        return d > available;
+                                      }();
+                                    } else {
+                                      _lengthExceeded = false;
+                                    }
+                                  });
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ],
             );
           },
-        ),
-        TextFormField(
-          initialValue: product.widthB != null ? _formatDecimal(product.widthB!) : '',
-          decoration: const InputDecoration(
-            labelText: 'Ширина b',
-            border: OutlineInputBorder(),
-          ),
-          keyboardType: TextInputType.number,
-          onChanged: (val) {
-            final normalized = val.replaceAll(',', '.');
-            product.widthB = double.tryParse(normalized);
-            _scheduleStagePreviewUpdate();
-          },
-        ),
-        const SizedBox(height: 6),
-        Row(
-          children: [
-            Expanded(
-              child: TextFormField(
-                initialValue: product.blQuantity?.toString() ?? '',
-                decoration: const InputDecoration(
-                  labelText: 'Количество',
-                  border: OutlineInputBorder(),
-                ),
-                keyboardType: TextInputType.text,
-                onChanged: (val) {
-                  final trimmed = val.trim();
-                  product.blQuantity = trimmed.isEmpty ? null : trimmed;
-                  _scheduleStagePreviewUpdate();
-                },
-              ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: TextFormField(
-                initialValue: product.length != null ? _formatDecimal(product.length!) : '',
-                decoration: InputDecoration(
-                  labelText: 'Длина L',
-                  border: const OutlineInputBorder(),
-                  errorText: _lengthExceeded ? 'Недостаточно' : null,
-                ),
-                keyboardType: TextInputType.number,
-                onChanged: (val) {
-                  final normalized = val.replaceAll(',', '.');
-                  final d = double.tryParse(normalized);
-                  setState(() {
-                    product.length = d;
-                    final materialTmc =
-                        _selectedMaterialTmc ?? _resolvePaperByText();
-                    if (materialTmc != null && d != null) {
-                      _lengthExceeded = () {
-                        final current =
-                            Provider.of<WarehouseProvider>(context, listen: false)
-                                .allTmc
-                                .where((t) => t.id == materialTmc.id)
-                                .toList();
-                        final available = current.isNotEmpty
-                            ? current.first.quantity
-                            : materialTmc.quantity;
-                        return d > available;
-                      }();
-                    } else {
-                      _lengthExceeded = false;
-                    }
-                  });
-                },
-              ),
-            ),
-          ],
         ),
         const SizedBox(height: 3),
         _buildExtraPaperSelectors(),


### PR DESCRIPTION
### Motivation
- Make it visually clear which input fields belong to each extra paper entry by grouping them in a distinct card-like block. 
- Preserve an active/highlighted state for the currently selected paper while giving inactive cards a subtle border so the layout reads consistently. 
- Remove a visually disruptive delete button placed mid-form so there is no vertical gap between `Грамаж` and `Ширина b` fields.

### Description
- Updated the extra paper UI in `lib/modules/orders/edit_order_screen.dart` to wrap each extra paper entry in a bordered `Container` with `margin` and increased `padding` for clearer separation and spacing. 
- Changed inactive card border from `Colors.transparent` to `Theme.of(context).dividerColor.withOpacity(0.8)` and made the active border slightly thicker (`width: 1.4`) to retain highlighting. 
- Moved the delete action (`IconButton` with `Icons.delete_outline`) into the top row next to the material `Autocomplete` so the delete control no longer sits between grammage and width fields. 
- Removed the duplicate delete button and tightened spacing between cards by removing the extra `SizedBox` below each card.

### Testing
- Ran `git diff -- lib/modules/orders/edit_order_screen.dart` to review the produced changes and it succeeded. 
- Ran `git status --short` to confirm the working tree and it succeeded. 
- Attempted to run `dart format lib/modules/orders/edit_order_screen.dart`, but it failed because the Dart SDK is not available in this environment (`/bin/bash: line 1: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a5921374832fa739ca425c1e33ef)