### PR TITLE
Update paper material display format in order details card

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -504,52 +504,33 @@ class OrderDetailsCard extends StatelessWidget {
                             if (material.name.isNotEmpty) parts.add(material.name);
                             if (material.format != null &&
                                 material.format!.isNotEmpty) {
-                              parts.add(' ${material.format}/');
+                              parts.add(material.format!);
                             }
                             if (material.grammage != null &&
                                 material.grammage!.isNotEmpty) {
-                              parts.add('${material.grammage}Гр');
+                              parts.add('${material.grammage} гр');
                             }
                             final materialLine =
                                 parts.isEmpty ? '—' : parts.join(' ');
-                            final rows = <Widget>[
+                            final widthValue = _paperWidthValue(material, index);
+                            final qtyValue = _paperQuantityValue(material, index);
+                            final lenValue = _paperLengthValue(material, index);
+                            final details = <String>[materialLine];
+                            if (widthValue.isNotEmpty) {
+                              details.add('Ш: $widthValue');
+                            }
+                            if (qtyValue.isNotEmpty || lenValue.isNotEmpty) {
+                              final left = qtyValue.isEmpty ? '—' : qtyValue;
+                              final right = lenValue.isEmpty ? '—' : lenValue;
+                              details.add('Д: $left * $right L');
+                            }
+                            return <Widget>[
                               _buildInfoRow(
                                 'Бумага №${index + 1}',
-                                materialLine,
+                                details.join('\n'),
                                 compact: true,
                               ),
                             ];
-                            final widthValue = _paperWidthValue(material, index);
-                            if (widthValue.isNotEmpty) {
-                              rows.add(
-                                _buildInfoRow(
-                                  'Ширина B №${index + 1}',
-                                  widthValue,
-                                  compact: true,
-                                ),
-                              );
-                            }
-                            final qtyValue = _paperQuantityValue(material, index);
-                            if (qtyValue.isNotEmpty) {
-                              rows.add(
-                                _buildInfoRow(
-                                  'Количество №${index + 1}',
-                                  qtyValue,
-                                  compact: true,
-                                ),
-                              );
-                            }
-                            final lenValue = _paperLengthValue(material, index);
-                            if (lenValue.isNotEmpty) {
-                              rows.add(
-                                _buildInfoRow(
-                                  'Длина L №${index + 1}',
-                                  lenValue,
-                                  compact: true,
-                                ),
-                              );
-                            }
-                            return rows;
                           }),
                         _buildInfoRow('Приладка',
                             o.makeready > 0 ? _fmtNum(o.makeready) : '—',


### PR DESCRIPTION
### Motivation

- Provide a more compact, grouped presentation of paper material info in the order details view so each paper appears as a single block matching the requested layout.
- Make the material header and its parameters easier to scan by combining name/format/grammage and showing width and length/quantity as labeled sublines.

### Description

- Modified `lib/modules/orders/order_details_card.dart` to render each paper as one `_buildInfoRow` with a multiline value instead of separate rows for width/quantity/length.
- Updated the material header formatting to `name format grammage` and normalized grammar spacing to use `гр`.
- Added inline detail lines under the header: `Ш: <width>` and `Д: <quantity> * <length> L` (the asterisk is textual, not multiplicative in logic).
- Removed the previous separate `_buildInfoRow` calls for width, quantity and length to produce the compact grouped view.

### Testing

- Attempted to run `dart format lib/modules/orders/order_details_card.dart`, but the `dart` binary is not available in this environment so formatting could not be executed (failed).
- No unit or widget tests were executed against this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a8def0a0832f8d3a4a147fe779b2)