### PR TITLE
Show order files in task view; allow editing order width/quantity in paper dialog; fix problem flow

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -511,6 +511,8 @@ class OrdersProvider with ChangeNotifier {
     required List<MaterialModel> paperMaterials,
     required String reason,
     double? lengthL,
+    double? width,
+    int? quantity,
   }) async {
     await _ensureAuthed();
 
@@ -540,9 +542,18 @@ class OrdersProvider with ChangeNotifier {
     }
     final prev = _orders[index];
     final normalizedLength = lengthL != null && lengthL > 0 ? lengthL : null;
+    final normalizedWidth = width != null && width > 0 ? width : null;
+    final normalizedQuantity =
+        quantity != null && quantity > 0 ? quantity : null;
     final nextProduct = ProductModel.fromMap(prev.product.toMap());
     if (normalizedLength != null) {
       nextProduct.length = normalizedLength;
+    }
+    if (normalizedWidth != null) {
+      nextProduct.width = normalizedWidth;
+    }
+    if (normalizedQuantity != null) {
+      nextProduct.quantity = normalizedQuantity;
     }
     final updated = prev.copyWith(
       product: nextProduct,

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -797,6 +797,8 @@ class _TasksScreenState extends State<TasksScreen>
   final Map<String, Future<String?>> _formImagePending = {};
   final Map<String, List<Map<String, dynamic>>> _orderPaintsCache = {};
   final Map<String, Future<List<Map<String, dynamic>>>> _orderPaintsPending = {};
+  final Map<String, List<Map<String, dynamic>>> _orderFilesCache = {};
+  final Map<String, Future<List<Map<String, dynamic>>>> _orderFilesPending = {};
   final Map<String, Map<String, _StageComment>> _orderCommentsCache = {};
   String get _widKey => 'ws-${widget.employeeId}-wid';
   String get _tidKey => 'ws-${widget.employeeId}-tid';
@@ -1297,6 +1299,16 @@ class _TasksScreenState extends State<TasksScreen>
         TextEditingController(text: _paperGrammageText(item.grammage)),
     ];
     final reasonController = TextEditingController();
+    final widthController = TextEditingController(
+      text: latest.product.width > 0
+          ? latest.product.width.toStringAsFixed(
+              latest.product.width % 1 == 0 ? 0 : 2,
+            )
+          : '',
+    );
+    final quantityController = TextEditingController(
+      text: latest.product.quantity > 0 ? latest.product.quantity.toString() : '',
+    );
     final formKey = GlobalKey<FormState>();
     String? errorText;
     bool saving = false;
@@ -1474,6 +1486,49 @@ class _TasksScreenState extends State<TasksScreen>
                           ),
                         ),
                         const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                controller: widthController,
+                                keyboardType:
+                                    const TextInputType.numberWithOptions(
+                                  decimal: true,
+                                ),
+                                decoration: const InputDecoration(
+                                  labelText: 'Ширина заказа (мм)',
+                                ),
+                                validator: (value) {
+                                  final normalized =
+                                      (value ?? '').trim().replaceAll(',', '.');
+                                  final width = double.tryParse(normalized);
+                                  if (width == null || width <= 0) {
+                                    return 'Введите > 0';
+                                  }
+                                  return null;
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: TextFormField(
+                                controller: quantityController,
+                                keyboardType: TextInputType.number,
+                                decoration: const InputDecoration(
+                                  labelText: 'Количество по заказу',
+                                ),
+                                validator: (value) {
+                                  final qty = int.tryParse((value ?? '').trim());
+                                  if (qty == null || qty <= 0) {
+                                    return 'Введите > 0';
+                                  }
+                                  return null;
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
                         TextFormField(
                           controller: reasonController,
                           maxLines: 3,
@@ -1546,6 +1601,12 @@ class _TasksScreenState extends State<TasksScreen>
                           }
 
                           final orders = context.read<OrdersProvider>();
+                          final nextWidth = double.parse(
+                            widthController.text.trim().replaceAll(',', '.'),
+                          );
+                          final nextQuantity = int.parse(
+                            quantityController.text.trim(),
+                          );
                           // Бизнес-логика рабочего пространства: изменение бумаги
                           // обязательно сопровождается причиной и сразу
                           // синхронизируется с заказом/управлением/резервом.
@@ -1554,6 +1615,8 @@ class _TasksScreenState extends State<TasksScreen>
                             paperMaterials: nextMaterials,
                             reason: reasonController.text,
                             lengthL: nextLengthL,
+                            width: nextWidth,
+                            quantity: nextQuantity,
                           );
                           if (!mounted) return;
                           if (error != null) {
@@ -1589,6 +1652,8 @@ class _TasksScreenState extends State<TasksScreen>
       controller.dispose();
     }
     reasonController.dispose();
+    widthController.dispose();
+    quantityController.dispose();
   }
 
   List<String> _stageGroupMembers(String orderId, String stageId) {
@@ -3021,10 +3086,12 @@ class _TasksScreenState extends State<TasksScreen>
         future: Future.wait<dynamic>([
           _getFormImageFuture(order),
           _getOrderPaintsFuture(order.id),
+          _getOrderFilesFuture(order.id),
         ]),
         initialData: <dynamic>[
           cachedFormImageUrl,
           _orderPaintsCache[order.id] ?? const <Map<String, dynamic>>[],
+          _orderFilesCache[order.id] ?? const <Map<String, dynamic>>[],
         ],
         builder: (context, snapshot) {
           final data = snapshot.data;
@@ -3036,14 +3103,21 @@ class _TasksScreenState extends State<TasksScreen>
                       ? data[1] as List<Map<String, dynamic>>
                       : null) ??
                   (_orderPaintsCache[order.id] ?? const <Map<String, dynamic>>[]);
+          final resolvedFiles =
+              (data != null && data.length > 2
+                      ? data[2] as List<Map<String, dynamic>>
+                      : null) ??
+                  (_orderFilesCache[order.id] ?? const <Map<String, dynamic>>[]);
           return Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               OrderDetailsCard(
                 order: order,
                 paints: resolvedPaints,
-                files: const [],
-                loadingFiles: false,
+                files: resolvedFiles,
+                loadingFiles:
+                    snapshot.connectionState == ConnectionState.waiting &&
+                        resolvedFiles.isEmpty,
                 stageTemplateName: templateName,
                 formImageUrl: resolvedFormImageUrl,
                 extraSections: [
@@ -3079,6 +3153,35 @@ class _TasksScreenState extends State<TasksScreen>
     });
 
     _orderPaintsPending[normalizedOrderId] = future;
+    return future;
+  }
+
+  Future<List<Map<String, dynamic>>> _getOrderFilesFuture(String orderId) {
+    final normalizedOrderId = orderId.trim();
+    if (normalizedOrderId.isEmpty) {
+      return Future.value(const <Map<String, dynamic>>[]);
+    }
+
+    final pending = _orderFilesPending[normalizedOrderId];
+    if (pending != null) {
+      return pending;
+    }
+
+    final future = listOrderFiles(normalizedOrderId)
+        .then((files) {
+          final normalizedFiles = List<Map<String, dynamic>>.from(files);
+          _orderFilesCache[normalizedOrderId] = normalizedFiles;
+          return normalizedFiles;
+        })
+        .catchError((_) {
+          return _orderFilesCache[normalizedOrderId] ??
+              const <Map<String, dynamic>>[];
+        })
+        .whenComplete(() {
+          _orderFilesPending.remove(normalizedOrderId);
+        });
+
+    _orderFilesPending[normalizedOrderId] = future;
     return future;
   }
 
@@ -4511,12 +4614,9 @@ class _TasksScreenState extends State<TasksScreen>
                           userIdOverride: widget.employeeId);
                       await recordTimeEventForUser(TaskTimeType.problem,
                           note: comment);
-                      if (!_anyUserActive(task,
-                          exceptUserId: widget.employeeId)) {
-                        await context
-                            .read<TaskProvider>()
-                            .updateStatus(task.id, TaskStatus.problem);
-                      }
+                      await context
+                          .read<TaskProvider>()
+                          .updateStatus(task.id, TaskStatus.problem);
                     }
 
                     Future<void> onAddHelper() async {
@@ -4656,7 +4756,11 @@ class _TasksScreenState extends State<TasksScreen>
                         final unitLabel =
                             _workplaceUnit(personnel, task.stageId);
                         final qtyInput =
-                            await _askQuantity(context, unit: unitLabel);
+                            await _askQuantity(
+                          context,
+                          unit: unitLabel,
+                          allowPaperEdit: true,
+                        );
                         if (qtyInput == null) return;
                         final qtyText = qtyInput.displayText;
                         final helperIds = jointGroup != null && isMyRow


### PR DESCRIPTION
### Motivation
- Ensure files attached to an order are visible when viewing/executing tasks, instead of always showing an empty list.
- Allow workspace users to edit order dimensions (width) and run quantity together with paper composition so the workspace can update product attributes in the order.
- Fix inconsistent behavior when marking a task as a problem so the task reliably transitions to `TaskStatus.problem` and doesn't block expected flows.

### Description
- Added order files support to the tasks details panel by introducing `_orderFilesCache`, `_orderFilesPending` and `_getOrderFilesFuture`, and passing loaded `files` and `loadingFiles` into `OrderDetailsCard` so attached files are shown during execution (file: `lib/modules/tasks/tasks_screen.dart`).
- Extended the "Изменение бумаги в заказе" dialog to include `width` and `quantity` inputs with validation, wired controllers and disposal, and included these values when calling the workspace update (file: `lib/modules/tasks/tasks_screen.dart`).
- Extended `updateOrderPapersFromWorkspace` to accept `width` and `quantity` parameters and apply them to the order `product` before persisting, preserving existing length behavior (file: `lib/modules/orders/orders_provider.dart`).
- Adjusted problem handling and quantity dialog flows: the `onProblem` handler now always updates the task status to `TaskStatus.problem`, and the shift-handoff / quantity dialogs call `_askQuantity(..., allowPaperEdit: true)` to allow opening paper editor from those flows (file: `lib/modules/tasks/tasks_screen.dart`).

### Testing
- Ran environment/format checks: `dart format lib/modules/tasks/tasks_screen.dart lib/modules/orders/orders_provider.dart` could not run because `dart` is not available in the execution environment, so formatting/analysis was not performed.
- Queried Flutter runtime with `flutter --version` which also failed due to missing `flutter` in the environment, so no build or runtime tests were performed.
- No automated unit/integration tests were executed in this environment; changes were limited to code edits and basic smoke checks described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a9af5fd0832fbd8e9536556e8027)