### PR TITLE
Fix bobinorezka length display when quantity is missing

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -520,9 +520,13 @@ class OrderDetailsCard extends StatelessWidget {
                               details.add('Ш: $widthValue');
                             }
                             if (qtyValue.isNotEmpty || lenValue.isNotEmpty) {
-                              final left = qtyValue.isEmpty ? '—' : qtyValue;
-                              final right = lenValue.isEmpty ? '—' : lenValue;
-                              details.add('Д: $left * $right L');
+                              if (qtyValue.isNotEmpty && lenValue.isNotEmpty) {
+                                details.add('Д: $qtyValue * $lenValue L');
+                              } else if (qtyValue.isNotEmpty) {
+                                details.add('Д: $qtyValue');
+                              } else {
+                                details.add('Д: $lenValue L');
+                              }
                             }
                             return <Widget>[
                               _buildInfoRow(


### PR DESCRIPTION
### Motivation
- Avoid showing the placeholder pattern `— * ...` when paper quantity is not provided in the "Бобинорезка" section so the UI matches expected output.

### Description
- Change implemented in `lib/modules/orders/order_details_card.dart` to render `Д:` as `Д: <qty> * <length> L` when both values exist, `Д: <qty>` when only quantity exists, and `Д: <length> L` when only length exists.

### Testing
- No automated tests were run in this environment; attempts to run `dart format` and `flutter --version` failed due to missing `dart`/`flutter` binaries, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ac1758e4832f99755095c7dbe5c3)