### PR TITLE
Запретить сотрудникам менять Ширину и Количество в диалоге изменения бумаги

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1491,6 +1491,8 @@ class _TasksScreenState extends State<TasksScreen>
                             Expanded(
                               child: TextFormField(
                                 controller: widthController,
+                                readOnly: true,
+                                enabled: false,
                                 keyboardType:
                                     const TextInputType.numberWithOptions(
                                   decimal: true,
@@ -1498,32 +1500,18 @@ class _TasksScreenState extends State<TasksScreen>
                                 decoration: const InputDecoration(
                                   labelText: 'Ширина заказа (мм)',
                                 ),
-                                validator: (value) {
-                                  final normalized =
-                                      (value ?? '').trim().replaceAll(',', '.');
-                                  final width = double.tryParse(normalized);
-                                  if (width == null || width <= 0) {
-                                    return 'Введите > 0';
-                                  }
-                                  return null;
-                                },
                               ),
                             ),
                             const SizedBox(width: 12),
                             Expanded(
                               child: TextFormField(
                                 controller: quantityController,
+                                readOnly: true,
+                                enabled: false,
                                 keyboardType: TextInputType.number,
                                 decoration: const InputDecoration(
                                   labelText: 'Количество по заказу',
                                 ),
-                                validator: (value) {
-                                  final qty = int.tryParse((value ?? '').trim());
-                                  if (qty == null || qty <= 0) {
-                                    return 'Введите > 0';
-                                  }
-                                  return null;
-                                },
                               ),
                             ),
                           ],
@@ -1601,12 +1589,8 @@ class _TasksScreenState extends State<TasksScreen>
                           }
 
                           final orders = context.read<OrdersProvider>();
-                          final nextWidth = double.parse(
-                            widthController.text.trim().replaceAll(',', '.'),
-                          );
-                          final nextQuantity = int.parse(
-                            quantityController.text.trim(),
-                          );
+                          final nextWidth = latest.product.width;
+                          final nextQuantity = latest.product.quantity;
                           // Бизнес-логика рабочего пространства: изменение бумаги
                           // обязательно сопровождается причиной и сразу
                           // синхронизируется с заказом/управлением/резервом.


### PR DESCRIPTION
### Motivation
- Сотрудник в диалоге «Изменение бумаги в заказе» не должен иметь возможность изменять размеры заказа (ширину) и тираж (количество), поэтому поля должны быть недоступны и сохранение должно брать значения из текущего заказа.

### Description
- Сделано поле `Ширина заказа (мм)` и `Количество по заказу` в диалоге только для чтения с `readOnly: true` и `enabled: false` в `lib/modules/tasks/tasks_screen.dart`.
- Удалены валидации для этих полей, так как ввод больше недоступен.
- При сохранении вместо парсинга значений из UI теперь используются `latest.product.width` и `latest.product.quantity` и эти значения передаются в `updateOrderPapersFromWorkspace`.

### Testing
- Выполнен поиск по коду с `rg -n` для подтверждения точек изменения и мест использования полей (успешно).
- Запуск форматтера `dart format lib/modules/tasks/tasks_screen.dart` завершился с ошибкой в окружении: `dart: command not found` (не установлен `dart`).
- Проверка окружения Flutter через `flutter --version` также не прошла: `flutter: command not found` (не установлен `flutter`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0aec58720832f86b79e19188c2cc8)