### PR TITLE
Обновить редактирование бумаги в диалоге изменения заказа

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -513,6 +513,8 @@ class OrdersProvider with ChangeNotifier {
     double? lengthL,
     double? width,
     int? quantity,
+    double? widthB,
+    String? blQuantity,
   }) async {
     await _ensureAuthed();
 
@@ -545,6 +547,8 @@ class OrdersProvider with ChangeNotifier {
     final normalizedWidth = width != null && width > 0 ? width : null;
     final normalizedQuantity =
         quantity != null && quantity > 0 ? quantity : null;
+    final normalizedWidthB = widthB != null && widthB > 0 ? widthB : null;
+    final normalizedBlQuantity = (blQuantity ?? '').trim();
     final nextProduct = ProductModel.fromMap(prev.product.toMap());
     if (normalizedLength != null) {
       nextProduct.length = normalizedLength;
@@ -555,6 +559,9 @@ class OrdersProvider with ChangeNotifier {
     if (normalizedQuantity != null) {
       nextProduct.quantity = normalizedQuantity;
     }
+    nextProduct.widthB = normalizedWidthB;
+    nextProduct.blQuantity =
+        normalizedBlQuantity.isEmpty ? null : normalizedBlQuantity;
     final updated = prev.copyWith(
       product: nextProduct,
       paperMaterials: prepared,
@@ -1658,13 +1665,27 @@ class OrdersProvider with ChangeNotifier {
 
     final before = _resolveOrderPapers(previous);
     final after = _resolveOrderPapers(updated);
+    if ((previous.product.widthB ?? 0) != (updated.product.widthB ?? 0)) {
+      return true;
+    }
+    final prevBlQuantity = previous.product.blQuantity?.trim() ?? '';
+    final nextBlQuantity = updated.product.blQuantity?.trim() ?? '';
+    if (prevBlQuantity != nextBlQuantity) {
+      return true;
+    }
     if (before.length != after.length) return true;
     for (var i = 0; i < before.length; i++) {
+      final beforeWidthB = _toDouble(before[i].extra?['widthB']);
+      final afterWidthB = _toDouble(after[i].extra?['widthB']);
+      final beforeBlQuantity = (before[i].extra?['blQuantity'] ?? '').toString().trim();
+      final afterBlQuantity = (after[i].extra?['blQuantity'] ?? '').toString().trim();
       if (before[i].id != after[i].id ||
           textChanged(before[i].name, after[i].name) ||
           textChanged(before[i].format, after[i].format) ||
           textChanged(before[i].grammage, after[i].grammage) ||
-          (before[i].quantity - after[i].quantity).abs() > 0.0001) {
+          (before[i].quantity - after[i].quantity).abs() > 0.0001 ||
+          (beforeWidthB - afterWidthB).abs() > 0.0001 ||
+          beforeBlQuantity != afterBlQuantity) {
         return true;
       }
     }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1298,17 +1298,46 @@ class _TasksScreenState extends State<TasksScreen>
       for (final item in selected)
         TextEditingController(text: _paperGrammageText(item.grammage)),
     ];
+    double? paperWidthBFromExtra(MaterialModel item) {
+      final raw = item.extra?['widthB'];
+      if (raw is num) return raw.toDouble();
+      if (raw is String) {
+        final normalized = raw.trim().replaceAll(',', '.');
+        if (normalized.isEmpty) return null;
+        return double.tryParse(normalized);
+      }
+      return null;
+    }
+
+    String? paperBlQuantityFromExtra(MaterialModel item) {
+      final value = item.extra?['blQuantity'];
+      final text = value?.toString().trim() ?? '';
+      return text.isEmpty ? null : text;
+    }
+
+    String _formatEditableDouble(double value) {
+      if (value <= 0) return '';
+      return value % 1 == 0 ? value.toStringAsFixed(0) : value.toStringAsFixed(2);
+    }
+
     final reasonController = TextEditingController();
-    final widthController = TextEditingController(
-      text: latest.product.width > 0
-          ? latest.product.width.toStringAsFixed(
-              latest.product.width % 1 == 0 ? 0 : 2,
-            )
-          : '',
-    );
-    final quantityController = TextEditingController(
-      text: latest.product.quantity > 0 ? latest.product.quantity.toString() : '',
-    );
+    final widthBControllers = <TextEditingController>[
+      for (var i = 0; i < selected.length; i++)
+        () {
+          final widthB = i == 0
+              ? (latest.product.widthB ?? 0)
+              : (paperWidthBFromExtra(selected[i]) ?? 0);
+          return TextEditingController(text: _formatEditableDouble(widthB));
+        }(),
+    ];
+    final blQuantityControllers = <TextEditingController>[
+      for (var i = 0; i < selected.length; i++)
+        TextEditingController(
+          text: i == 0
+              ? (latest.product.blQuantity?.trim() ?? '')
+              : (paperBlQuantityFromExtra(selected[i]) ?? ''),
+        ),
+    ];
     final formKey = GlobalKey<FormState>();
     String? errorText;
     bool saving = false;
@@ -1333,6 +1362,8 @@ class _TasksScreenState extends State<TasksScreen>
         grammageControllers.add(
           TextEditingController(text: _paperGrammageText(pick.grammage)),
         );
+        widthBControllers.add(TextEditingController());
+        blQuantityControllers.add(TextEditingController());
       });
     }
 
@@ -1457,6 +1488,27 @@ class _TasksScreenState extends State<TasksScreen>
                                     },
                                   ),
                                 ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: widthBControllers[i],
+                                    keyboardType: const TextInputType.numberWithOptions(
+                                      decimal: true,
+                                    ),
+                                    decoration: const InputDecoration(
+                                      labelText: 'Ширина b',
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: blQuantityControllers[i],
+                                    decoration: const InputDecoration(
+                                      labelText: 'Количество бумаги',
+                                    ),
+                                  ),
+                                ),
                                 if (i > 0)
                                   IconButton(
                                     tooltip: 'Удалить бумагу',
@@ -1466,6 +1518,10 @@ class _TasksScreenState extends State<TasksScreen>
                                         qtyControllers.removeAt(i).dispose();
                                         formatControllers.removeAt(i).dispose();
                                         grammageControllers
+                                            .removeAt(i)
+                                            .dispose();
+                                        widthBControllers.removeAt(i).dispose();
+                                        blQuantityControllers
                                             .removeAt(i)
                                             .dispose();
                                       });
@@ -1484,37 +1540,6 @@ class _TasksScreenState extends State<TasksScreen>
                             icon: const Icon(Icons.add),
                             label: const Text('Добавить бумагу'),
                           ),
-                        ),
-                        const SizedBox(height: 8),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: TextFormField(
-                                controller: widthController,
-                                readOnly: true,
-                                enabled: false,
-                                keyboardType:
-                                    const TextInputType.numberWithOptions(
-                                  decimal: true,
-                                ),
-                                decoration: const InputDecoration(
-                                  labelText: 'Ширина заказа (мм)',
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: TextFormField(
-                                controller: quantityController,
-                                readOnly: true,
-                                enabled: false,
-                                keyboardType: TextInputType.number,
-                                decoration: const InputDecoration(
-                                  labelText: 'Количество по заказу',
-                                ),
-                              ),
-                            ),
-                          ],
                         ),
                         const SizedBox(height: 8),
                         TextFormField(
@@ -1556,6 +1581,8 @@ class _TasksScreenState extends State<TasksScreen>
                           });
                           final nextMaterials = <MaterialModel>[];
                           double? nextLengthL;
+                          double? primaryWidthB;
+                          String? primaryBlQuantity;
                           for (var i = 0; i < selected.length; i++) {
                             final qty = double.parse(
                               qtyControllers[i].text.trim().replaceAll(',', '.'),
@@ -1578,12 +1605,37 @@ class _TasksScreenState extends State<TasksScreen>
                               });
                               return;
                             }
+                            final parsedWidthB = double.tryParse(
+                              widthBControllers[i].text.trim().replaceAll(',', '.'),
+                            );
+                            final parsedBlQuantity =
+                                blQuantityControllers[i].text.trim();
+                            final nextExtra = Map<String, dynamic>.from(
+                              selected[i].extra ?? const {},
+                            );
+                            if (parsedWidthB == null || parsedWidthB <= 0) {
+                              nextExtra.remove('widthB');
+                            } else {
+                              nextExtra['widthB'] = parsedWidthB;
+                            }
+                            if (parsedBlQuantity.isEmpty) {
+                              nextExtra.remove('blQuantity');
+                            } else {
+                              nextExtra['blQuantity'] = parsedBlQuantity;
+                            }
                             nextLengthL ??= qty;
+                            if (i == 0) {
+                              primaryWidthB = parsedWidthB;
+                              primaryBlQuantity = parsedBlQuantity.isEmpty
+                                  ? null
+                                  : parsedBlQuantity;
+                            }
                             nextMaterials.add(
                               selected[i].copyWith(
                                 quantity: qty,
                                 format: editedFormat,
                                 grammage: editedGrammage,
+                                extra: nextExtra.isEmpty ? null : nextExtra,
                               ),
                             );
                           }
@@ -1601,6 +1653,8 @@ class _TasksScreenState extends State<TasksScreen>
                             lengthL: nextLengthL,
                             width: nextWidth,
                             quantity: nextQuantity,
+                            widthB: primaryWidthB,
+                            blQuantity: primaryBlQuantity,
                           );
                           if (!mounted) return;
                           if (error != null) {
@@ -1635,9 +1689,13 @@ class _TasksScreenState extends State<TasksScreen>
     for (final controller in grammageControllers) {
       controller.dispose();
     }
+    for (final controller in widthBControllers) {
+      controller.dispose();
+    }
+    for (final controller in blQuantityControllers) {
+      controller.dispose();
+    }
     reasonController.dispose();
-    widthController.dispose();
-    quantityController.dispose();
   }
 
   List<String> _stageGroupMembers(String orderId, String stageId) {


### PR DESCRIPTION
### Motivation
- Убрать неинтерактивные поля «Ширина заказа» и «Количество по заказу» из диалога изменения бумаги и вместо этого дать возможность редактировать ширину b и количество бумаги для каждой строки отдельно, чтобы изменения применялись и в самом заказе после сохранения.

### Description
- В диалоге «Изменение бумаги в заказе» (lib/modules/tasks/tasks_screen.dart) убраны поля «Ширина заказа (мм)» и «Количество по заказу» и для каждой бумаги добавлены редактируемые поля «Ширина b» и «Количество бумаги» с отдельными контроллерами и корректной очисткой ресурсов при закрытии диалога.
- При сохранении значения «Ширина b» и «Количество бумаги» записываются в `paper.extra['widthB']` / `paper.extra['blQuantity']` для каждой бумаги, а для первой бумаги дополнительно передаются в `product.widthB` и `product.blQuantity`, чтобы изменения отражались в самом заказе.
- В `OrdersProvider.updateOrderPapersFromWorkspace` (lib/modules/orders/orders_provider.dart) добавлены параметры `widthB` и `blQuantity`, их нормализация и применение к `nextProduct`, а также изменение оптимистичного обновления заказа.
- Логика сравнения состава бумаги `_hasPaperCompositionChanged` расширена, чтобы учитывать изменения `product.widthB`/`product.blQuantity` и `extra['widthB']`/`extra['blQuantity']` в отдельных материалах, что обеспечивает корректное определение необходимости сохранения.

### Testing
- Просмотрены diffs и содержимое изменённых участков командой `git diff` и `nl` для ручной проверки корректности изменений, проверка прошла успешно.
- Изменения закоммичены в локальный репозиторий, коммит создан успешно.
- Автоматическое форматирование и тесты (`dart format`, `flutter`) не запускались из-за отсутствия `dart`/`flutter` в окружении, поэтому автоматические тесты не выполнялись.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b13939b4832fa320831c2f1f535b)