### PR TITLE
Fix order form rendering and suppress file-loading indicator

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -185,6 +185,14 @@ class OrderDetailsCard extends StatelessWidget {
     );
   }
 
+  String _formDisplayValue(OrderModel order) {
+    if (!order.hasForm) return 'Форма не используется';
+    final type = order.isOldForm ? 'Старая форма' : 'Новая форма';
+    final code = (order.formCode ?? '').trim();
+    final number = order.newFormNo?.toString() ?? (code.isNotEmpty ? code : '—');
+    return '$type: $number';
+  }
+
   /// Builds a combined row for the "Картон" and "Подрезка" properties. In the
   /// updated design these two fields should appear on one line, separated
   /// evenly across the width of the card. Each side includes its own label
@@ -429,30 +437,22 @@ class OrderDetailsCard extends StatelessWidget {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                                '${o.isOldForm ? 'Старая форма' : 'Новая форма'}: ${o.newFormNo?.toString() ?? '—'}',
+                                _formDisplayValue(o),
                               ),
                               if (formImageUrl != null &&
                                   formImageUrl!.trim().isNotEmpty)
                                 Padding(
                                   padding: const EdgeInsets.only(top: 8),
-                                  child: InkWell(
-                                    onTap: () => _showImagePreview(
+                                  child: TextButton.icon(
+                                    onPressed: () => _showImagePreview(
                                       context,
                                       formImageUrl!,
-                                      title: 'Форма ${o.newFormNo?.toString() ?? ''}'
-                                          .trim(),
+                                      title:
+                                          'Форма ${o.newFormNo?.toString() ?? ''}'
+                                              .trim(),
                                     ),
-                                    borderRadius: BorderRadius.circular(8),
-                                    child: ClipRRect(
-                                      borderRadius: BorderRadius.circular(8),
-                                      child: Image.network(
-                                        formImageUrl!,
-                                        height: 90,
-                                        fit: BoxFit.cover,
-                                        errorBuilder: (_, __, ___) =>
-                                            const Text('Изображение формы недоступно'),
-                                      ),
-                                    ),
+                                    icon: const Icon(Icons.image_outlined),
+                                    label: const Text('Открыть изображение формы'),
                                   ),
                                 ),
                             ],
@@ -464,11 +464,6 @@ class OrderDetailsCard extends StatelessWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              if (loadingFiles)
-                                const Padding(
-                                  padding: EdgeInsets.only(bottom: 8.0),
-                                  child: LinearProgressIndicator(),
-                                ),
                               if (!loadingFiles && files.isEmpty)
                                 const Text('Нет приложенных файлов'),
                               ...files

--- a/lib/modules/orders/order_model.dart
+++ b/lib/modules/orders/order_model.dart
@@ -286,8 +286,20 @@ class OrderModel {
 
     final isOldFormBool =
         _asBool(_pickAny(map, const ['is_old_form', 'isOldForm'])) ?? false;
+    int? _parseInt(dynamic value) {
+      if (value == null) return null;
+      if (value is int) return value;
+      if (value is num) return value.toInt();
+      if (value is String) {
+        final s = value.trim();
+        if (s.isEmpty) return null;
+        return int.tryParse(s);
+      }
+      return null;
+    }
+
     final int? newFormNoVal =
-        (_pickAny(map, const ['new_form_no', 'newFormNo']) as num?)?.toInt();
+        _parseInt(_pickAny(map, const ['new_form_no', 'newFormNo']));
     final String? formSeriesVal =
         (_pickAny(map, const ['form_series', 'formSeries']) as String?);
     final String? formCodeVal =


### PR DESCRIPTION
### Motivation
- Order details sometimes showed an empty form number and repeatedly attempted to load a non-existent form image which produced visible load activity; the UI should show a meaningful form label and avoid aggressive background fetches and visible loading UI for files.

### Description
- Parse `new_form_no` robustly in `OrderModel.fromMap` by adding a `_parseInt` helper so numeric form numbers returned as strings are handled correctly (`lib/modules/orders/order_model.dart`).
- Add `_formDisplayValue` to `OrderDetailsCard` to produce a clear label such as `Форма не используется` or `Старая форма: <number>` / `Новая форма: <number|formCode>` with `formCode` as a fallback (`lib/modules/orders/order_details_card.dart`).
- Replace the auto-rendered `Image.network` thumbnail with an explicit `TextButton.icon` that opens the image preview on demand to prevent repeated background fetch attempts when the image is unavailable (`lib/modules/orders/order_details_card.dart`).
- Remove the visible `LinearProgressIndicator` from the files section while the file list is loading so the UI no longer shows an ongoing spinner each second (`lib/modules/orders/order_details_card.dart`).

### Testing
- Attempted to run `dart format lib/modules/orders/order_model.dart lib/modules/orders/order_details_card.dart`, but the command failed because `dart` is not available in the environment (`/bin/bash: dart: command not found`).
- No additional automated tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b4f43048832f802d9937e05e5f00)