### PR TITLE
Fix order details form rendering and hide file loading indicator

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -428,9 +428,7 @@ class OrderDetailsCard extends StatelessWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              Text(
-                                '${o.isOldForm ? 'Старая форма' : 'Новая форма'}: ${o.newFormNo?.toString() ?? '—'}',
-                              ),
+                              Text(_formDisplayText(o)),
                               if (formImageUrl != null &&
                                   formImageUrl!.trim().isNotEmpty)
                                 Padding(
@@ -464,11 +462,6 @@ class OrderDetailsCard extends StatelessWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              if (loadingFiles)
-                                const Padding(
-                                  padding: EdgeInsets.only(bottom: 8.0),
-                                  child: LinearProgressIndicator(),
-                                ),
                               if (!loadingFiles && files.isEmpty)
                                 const Text('Нет приложенных файлов'),
                               ...files
@@ -784,4 +777,22 @@ class OrderDetailsCard extends StatelessWidget {
       ),
     );
   }
-}  
+
+  String _formDisplayText(OrderModel order) {
+    if (!order.hasForm) return 'Форма не используется';
+    final typeLabel = order.isOldForm ? 'Старая форма' : 'Новая форма';
+    final formNo = order.newFormNo?.toString();
+    if (formNo != null && formNo.isNotEmpty) {
+      return '$typeLabel: $formNo';
+    }
+    final code = order.formCode?.trim();
+    if (code != null && code.isNotEmpty) {
+      return '$typeLabel: $code';
+    }
+    final series = order.formSeries?.trim();
+    if (series != null && series.isNotEmpty) {
+      return '$typeLabel: $series';
+    }
+    return '$typeLabel: —';
+  }
+}

--- a/lib/modules/orders/order_model.dart
+++ b/lib/modules/orders/order_model.dart
@@ -286,8 +286,13 @@ class OrderModel {
 
     final isOldFormBool =
         _asBool(_pickAny(map, const ['is_old_form', 'isOldForm'])) ?? false;
-    final int? newFormNoVal =
-        (_pickAny(map, const ['new_form_no', 'newFormNo']) as num?)?.toInt();
+    final dynamic rawNewFormNo =
+        _pickAny(map, const ['new_form_no', 'newFormNo']);
+    final int? newFormNoVal = (() {
+      if (rawNewFormNo is num) return rawNewFormNo.toInt();
+      if (rawNewFormNo is String) return int.tryParse(rawNewFormNo.trim());
+      return null;
+    })();
     final String? formSeriesVal =
         (_pickAny(map, const ['form_series', 'formSeries']) as String?);
     final String? formCodeVal =

--- a/lib/modules/orders/view_order_screen.dart
+++ b/lib/modules/orders/view_order_screen.dart
@@ -43,19 +43,37 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
       final paints = await repo.getPaints(widget.order.id);
       final files = await storage.listOrderFiles(widget.order.id);
       String? formImageUrl;
-      final formSeries = widget.order.formSeries;
+      final formCode = widget.order.formCode?.trim();
+      final formSeries = widget.order.formSeries?.trim();
       final formNo = widget.order.newFormNo;
-      if (formSeries != null && formSeries.isNotEmpty && formNo != null) {
-        final form = await Supabase.instance.client
+      Map<String, dynamic>? form;
+      if (formCode != null && formCode.isNotEmpty) {
+        final res = await Supabase.instance.client
+            .from('forms')
+            .select('image_url')
+            .eq('code', formCode)
+            .maybeSingle();
+        if (res != null && res is Map) {
+          form = Map<String, dynamic>.from(res);
+        }
+      }
+      if (form == null &&
+          formSeries != null &&
+          formSeries.isNotEmpty &&
+          formNo != null) {
+        final res = await Supabase.instance.client
             .from('forms')
             .select('image_url')
             .eq('series', formSeries)
             .eq('number', formNo)
             .maybeSingle();
-        final imageUrl = (form?['image_url'] ?? '').toString().trim();
-        if (imageUrl.isNotEmpty) {
-          formImageUrl = imageUrl;
+        if (res != null && res is Map) {
+          form = Map<String, dynamic>.from(res);
         }
+      }
+      final imageUrl = (form?['image_url'] ?? '').toString().trim();
+      if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
+        formImageUrl = imageUrl;
       }
       String? stageTemplateName;
       final tplId = widget.order.stageTemplateId;


### PR DESCRIPTION
### Motivation
- The order details view sometimes showed no form info because `new_form_no` could be provided as a string and wasn't parsed correctly.  
- The form image lookup and display attempted to load invalid/non-HTTP URLs, which caused repeated failed loads.  
- The files section displayed a persistent loading indicator even when no attachments exist, creating noisy UI feedback.

### Description
- Parse `new_form_no` robustly in `OrderModel.fromMap` to accept numeric and string values and convert them to `int` when possible (`lib/modules/orders/order_model.dart`).
- Improve form image lookup in the order dialog by trying `form_code` first and falling back to `series + number`, and only accept `http`/`https` URLs before assigning `formImageUrl` (`lib/modules/orders/view_order_screen.dart`).
- Replace the direct form label rendering with a helper that shows `number -> code -> series -> —` fallback to surface any available form identifier (`lib/modules/orders/order_details_card.dart`).
- Remove the visible `LinearProgressIndicator` from the files area so file loading happens in background without a constant visible spinner when attachments are missing (`lib/modules/orders/order_details_card.dart`).

### Testing
- Verified updated source files are present in the workspace for the three modified modules.  
- Attempted to run `dart format` on the changed files but the environment lacks the `dart` binary, so formatting check could not run (error: `dart: command not found`).  
- Attempted to run `flutter --version` to validate Flutter tooling but the environment lacks `flutter`, so platform checks could not run (error: `flutter: command not found`).  
- No automated unit tests were executed in this environment due to missing SDK/tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b4f43048832f802d9937e05e5f00)