### PR TITLE
Переставить поля 'Ширина b' и 'Количество' перед 'Длина L' в форме редактирования заказа

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -4187,42 +4187,46 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                     },
                   ),
                   const SizedBox(height: 4),
-                  TextFormField(
-                    initialValue: _paperExtraDouble(
-                              _extraPaperMaterials[i],
-                              'widthB',
-                            ) !=
-                            null
-                        ? _formatDecimal(
-                            _paperExtraDouble(_extraPaperMaterials[i], 'widthB')!)
-                        : '',
-                    decoration: const InputDecoration(
-                      labelText: 'Ширина b',
-                      border: OutlineInputBorder(),
-                    ),
-                    keyboardType:
-                        const TextInputType.numberWithOptions(decimal: true),
-                    onChanged: (value) {
-                      final parsed = double.tryParse(value.replaceAll(',', '.'));
-                      setState(() {
-                        final nextExtra = Map<String, dynamic>.from(
-                          _extraPaperMaterials[i].extra ?? const {},
-                        );
-                        if (parsed == null) {
-                          nextExtra.remove('widthB');
-                        } else {
-                          nextExtra['widthB'] = parsed;
-                        }
-                        _extraPaperMaterials[i] = _extraPaperMaterials[i].copyWith(
-                          extra: nextExtra.isEmpty ? null : nextExtra,
-                        );
-                      });
-                      _scheduleStagePreviewUpdate();
-                    },
-                  ),
-                  const SizedBox(height: 4),
                   Row(
                     children: [
+                      Expanded(
+                        child: TextFormField(
+                          initialValue: _paperExtraDouble(
+                                    _extraPaperMaterials[i],
+                                    'widthB',
+                                  ) !=
+                                  null
+                              ? _formatDecimal(_paperExtraDouble(
+                                  _extraPaperMaterials[i], 'widthB')!)
+                              : '',
+                          decoration: const InputDecoration(
+                            labelText: 'Ширина b',
+                            border: OutlineInputBorder(),
+                          ),
+                          keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true),
+                          onChanged: (value) {
+                            final parsed =
+                                double.tryParse(value.replaceAll(',', '.'));
+                            setState(() {
+                              final nextExtra = Map<String, dynamic>.from(
+                                _extraPaperMaterials[i].extra ?? const {},
+                              );
+                              if (parsed == null) {
+                                nextExtra.remove('widthB');
+                              } else {
+                                nextExtra['widthB'] = parsed;
+                              }
+                              _extraPaperMaterials[i] =
+                                  _extraPaperMaterials[i].copyWith(
+                                extra: nextExtra.isEmpty ? null : nextExtra,
+                              );
+                            });
+                            _scheduleStagePreviewUpdate();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
                       Expanded(
                         child: TextFormField(
                           initialValue:
@@ -4718,21 +4722,23 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                             });
                           },
                         ),
-                        const SizedBox(height: 4),
-                        TextFormField(
-                          initialValue:
-                              product.widthB != null ? _formatDecimal(product.widthB!) : '',
-                          decoration: mainPaperDecoration('Ширина b'),
-                          keyboardType: TextInputType.number,
-                          onChanged: (val) {
-                            final normalized = val.replaceAll(',', '.');
-                            product.widthB = double.tryParse(normalized);
-                            _scheduleStagePreviewUpdate();
-                          },
-                        ),
-                        const SizedBox(height: 6),
                         Row(
                           children: [
+                            Expanded(
+                              child: TextFormField(
+                                initialValue: product.widthB != null
+                                    ? _formatDecimal(product.widthB!)
+                                    : '',
+                                decoration: mainPaperDecoration('Ширина b'),
+                                keyboardType: TextInputType.number,
+                                onChanged: (val) {
+                                  final normalized = val.replaceAll(',', '.');
+                                  product.widthB = double.tryParse(normalized);
+                                  _scheduleStagePreviewUpdate();
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 8),
                             Expanded(
                               child: TextFormField(
                                 initialValue: product.blQuantity?.toString() ?? '',


### PR DESCRIPTION
### Motivation
- Улучшить удобство ввода в форме изменения заказа, чтобы поля размера бумаги шли логично: `Ширина b`, `Количество`, затем `Длина L`.
- Привести единообразие между основной секцией бумаги и блоком дополнительных материалов, чтобы поведение и порядок полей совпадали.

### Description
- Внесён рефакторинг разметки в `lib/modules/orders/edit_order_screen.dart` для блока основной бумаги, переставив поле `Ширина b` и `Количество` перед полем `Длина L` в одной строке с сохранением валидации.
- Аналогичные изменения применены к блоку дополнительных материалов (`_extraPaperMaterials`), объединив поля `Ширина b`, `Количество`, `Длина L` в одной строке и сохранив существующую логику парсинга/сохранения в `extra`.
- Сохранены все существующие проверки доступности длины и логика обновления состояния (`_scheduleStagePreviewUpdate`, проверка `Недостаточно` и т.д.).

### Testing
- Попытка прогнать форматирование с помощью `dart format lib/modules/orders/edit_order_screen.dart` выполнена, но завершилась ошибкой из‑за отсутствия `dart` в контейнере (`/bin/bash: line 1: dart: command not found`).
- Изменения проверены путём просмотра диффа и инспекции кода в `lib/modules/orders/edit_order_screen.dart`, автоматизированных тестов не запускалось из‑за недоступности инструментов в среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b55bfea0832f8d7e3fa8c1ec29f4)