### PR TITLE
Allow shipment when actual < planned and prioritize old forms by customer

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -948,14 +948,6 @@ class OrdersProvider with ChangeNotifier {
     final double actualQty =
         orderData.actualQty ?? orderData.product.quantity.toDouble();
     final double safeActual = actualQty < 0 ? 0 : actualQty;
-    if (safeActual < plannedQty) {
-      // Бизнес-правило отгрузки: нельзя отгружать меньше тиража.
-      throw Exception(
-        'Отгрузка запрещена: фактическое количество '
-        '(${_formatQty(safeActual)}) меньше тиража (${_formatQty(plannedQty)}).',
-      );
-    }
-
     double writeoffQty = writeoffOverride ??
         (safeActual < plannedQty ? safeActual : plannedQty.toDouble());
     if (writeoffQty.isNaN || writeoffQty.isInfinite) {

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -187,14 +187,76 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     try {
       final wp = WarehouseProvider();
       // Не фильтруем по _formSeries, поскольку series теперь хранит полное название
-      _formResults = await wp.searchForms(
+      final fetchedForms = await wp.searchForms(
         query: search ?? _formSearchCtl.text,
         limit: 50,
+      );
+      _formResults = _prioritizeFormsByCustomer(
+        fetchedForms,
+        customerName: _customerController.text,
       );
     } catch (_) {
     } finally {
       if (mounted) setState(() => _loadingForms = false);
     }
+  }
+
+  List<Map<String, dynamic>> _prioritizeFormsByCustomer(
+    List<Map<String, dynamic>> forms, {
+    required String customerName,
+  }) {
+    if (forms.isEmpty) return forms;
+    final customer = _normalizeSearch(customerName);
+    if (customer.isEmpty) return forms;
+
+    final scored = forms.map((row) {
+      final series = _normalizeSearch((row['series'] ?? '').toString());
+      final title = _normalizeSearch((row['title'] ?? '').toString());
+      final description = _normalizeSearch((row['description'] ?? '').toString());
+      final code = _normalizeSearch((row['code'] ?? '').toString());
+
+      int score = 0;
+      if (series == customer || title == customer) {
+        score += 1000;
+      }
+      if (series.contains(customer) || customer.contains(series)) {
+        score += 400;
+      }
+      if (title.contains(customer) || customer.contains(title)) {
+        score += 300;
+      }
+      if (description.contains(customer) || customer.contains(description)) {
+        score += 200;
+      }
+      if (code.contains(customer)) {
+        score += 80;
+      }
+
+      final customerTokens = customer.split(' ').where((e) => e.isNotEmpty);
+      for (final token in customerTokens) {
+        if (token.length < 3) continue;
+        if (series.contains(token)) score += 50;
+        if (title.contains(token)) score += 40;
+        if (description.contains(token)) score += 20;
+      }
+
+      return (row: row, score: score);
+    }).toList();
+
+    scored.sort((a, b) {
+      if (a.score != b.score) return b.score.compareTo(a.score);
+      final aNumber = (a.row['number'] as num?)?.toInt() ?? 0;
+      final bNumber = (b.row['number'] as num?)?.toInt() ?? 0;
+      return bNumber.compareTo(aNumber);
+    });
+
+    return scored.map((e) => e.row).toList(growable: false);
+  }
+
+  String _normalizeSearch(String value) {
+    final lower = value.toLowerCase().trim();
+    if (lower.isEmpty) return '';
+    return lower.replaceAll(RegExp(r'\s+'), ' ');
   }
 
   final _formKey = GlobalKey<FormState>();
@@ -352,7 +414,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
     super.initState();
 
-    _reloadForms();
     // order передан при редактировании, initialOrder - при создании на основе шаблона
     final template = widget.order ?? widget.initialOrder;
     // Текущий менеджер будет выбран позже в didChangeDependencies, когда загрузится список менеджеров.
@@ -443,6 +504,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       );
     }
     _customerController.addListener(_updateStockExtra);
+    _reloadForms();
     // ensure at least one paint row only for new orders (not editing)
     if (_paints.isEmpty && widget.order == null) _paints.add(_PaintEntry());
     _loadCategoriesForProduct();
@@ -2406,7 +2468,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 labelText: 'Заказчик',
                 border: OutlineInputBorder(),
               ),
-              onChanged: (_) => _updateStockExtra(),
+              onChanged: (_) {
+                _updateStockExtra();
+                if (_isOldForm) {
+                  _reloadForms();
+                }
+              },
               validator: (value) {
                 if (value == null || value.trim().isEmpty) {
                   return 'Введите заказчика';


### PR DESCRIPTION
### Motivation
- Пользователи не могут отгрузить заказ, если `фактическое количество` оказалось меньше тиража, и в режиме «Старая форма» в поиске не всегда показываются наиболее релевантные формы клиента.

### Description
- Убрана жесткая проверка, бросавшая исключение при `safeActual < plannedQty`, чтобы отгрузка шла корректно, а `writeoffQty` рассчитывался исходя из фактического количества или переданного override (файл: `lib/modules/orders/orders_provider.dart`).
- Добавлена приоритизация результатов поиска форм по совпадениям с именем заказчика: реализована функция `_prioritizeFormsByCustomer` с нормализацией и скорингом по `series`, `title`, `description`, `code` и по токенам, после чего результаты сортируются по оценке и номеру формы (файл: `lib/modules/production_planning/form_editor_screen.dart`).
- Исправлен порядок инициализации и обновления поиска форм: ` _reloadForms()` теперь вызывается после инициализации ` _customerController`, и при изменении поля «Заказчик» добавлено обновление списка форм, если включен режим «Старая форма» (файл: `lib/modules/production_planning/form_editor_screen.dart`).

### Testing
- Выполнена проверка статуса изменений через `git diff --check` (успешно).
- Попытки запустить автоформатирование и среду: `dart format` и `flutter --version` не были выполнены из‑за отсутствия `dart`/`flutter` в окружении (`/bin/bash: dart: command not found`, `/bin/bash: flutter: command not found`).
- Никаких автоматизированных unit/widget тестов не было выполнено в этом контейнере из‑за отсутствия Flutter/Dart.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ce085ec0832fa9910f4eb4451731)