### PR TITLE
Fix TextEditingController disposal timing in paper slot dialogs

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1513,17 +1513,31 @@ class _TasksScreenState extends State<TasksScreen>
                                   IconButton(
                                     tooltip: 'Удалить бумагу',
                                     onPressed: () {
+                                      final removedQtyController =
+                                          qtyControllers[i];
+                                      final removedFormatController =
+                                          formatControllers[i];
+                                      final removedGrammageController =
+                                          grammageControllers[i];
+                                      final removedWidthBController =
+                                          widthBControllers[i];
+                                      final removedBlQuantityController =
+                                          blQuantityControllers[i];
                                       setDialogState(() {
                                         selected.removeAt(i);
-                                        qtyControllers.removeAt(i).dispose();
-                                        formatControllers.removeAt(i).dispose();
-                                        grammageControllers
-                                            .removeAt(i)
-                                            .dispose();
-                                        widthBControllers.removeAt(i).dispose();
-                                        blQuantityControllers
-                                            .removeAt(i)
-                                            .dispose();
+                                        qtyControllers.removeAt(i);
+                                        formatControllers.removeAt(i);
+                                        grammageControllers.removeAt(i);
+                                        widthBControllers.removeAt(i);
+                                        blQuantityControllers.removeAt(i);
+                                      });
+                                      WidgetsBinding.instance
+                                          .addPostFrameCallback((_) {
+                                        removedQtyController.dispose();
+                                        removedFormatController.dispose();
+                                        removedGrammageController.dispose();
+                                        removedWidthBController.dispose();
+                                        removedBlQuantityController.dispose();
                                       });
                                     },
                                     icon: const Icon(Icons.delete_outline),

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1577,17 +1577,31 @@ class _TasksScreenState extends State<TasksScreen>
                                   IconButton(
                                     tooltip: 'Удалить бумагу',
                                     onPressed: () {
+                                      final removedQtyController =
+                                          qtyControllers[i];
+                                      final removedFormatController =
+                                          formatControllers[i];
+                                      final removedGrammageController =
+                                          grammageControllers[i];
+                                      final removedWidthBController =
+                                          widthBControllers[i];
+                                      final removedBlQuantityController =
+                                          blQuantityControllers[i];
                                       setDialogState(() {
                                         selected.removeAt(i);
-                                        qtyControllers.removeAt(i).dispose();
-                                        formatControllers.removeAt(i).dispose();
-                                        grammageControllers
-                                            .removeAt(i)
-                                            .dispose();
-                                        widthBControllers.removeAt(i).dispose();
-                                        blQuantityControllers
-                                            .removeAt(i)
-                                            .dispose();
+                                        qtyControllers.removeAt(i);
+                                        formatControllers.removeAt(i);
+                                        grammageControllers.removeAt(i);
+                                        widthBControllers.removeAt(i);
+                                        blQuantityControllers.removeAt(i);
+                                      });
+                                      WidgetsBinding.instance
+                                          .addPostFrameCallback((_) {
+                                        removedQtyController.dispose();
+                                        removedFormatController.dispose();
+                                        removedGrammageController.dispose();
+                                        removedWidthBController.dispose();
+                                        removedBlQuantityController.dispose();
                                       });
                                     },
                                     icon: const Icon(Icons.delete_outline),


### PR DESCRIPTION
### Motivation
- Prevent `A TextEditingController was used after being disposed` crashes that occur when controllers are removed and disposed within the same rebuild cycle, which can leave widgets attempting to detach listeners from already-disposed controllers.
- Stop cascading layout/render errors caused by the above (observed as large `RenderFlex overflow` errors in logs).

### Description
- In `lib/modules/tasks/tasks_screen.dart` and `lib/modules/orders/edit_order_screen.dart` changed the paper-slot removal flow to avoid calling `dispose()` inside the dialog `setDialogState` rebuild.
- Capture the controllers to be removed in local variables, remove them from controller lists inside `setDialogState`, and call `dispose()` later in a `WidgetsBinding.instance.addPostFrameCallback` to ensure disposal occurs after the frame.
- This preserves the UI update order and prevents listeners from being removed from controllers that widgets are still wiring up during the same frame.

### Testing
- Attempted to run formatting via `dart format` but `dart` was not available in this environment (`/bin/bash: dart: command not found`).
- Attempted to query `flutter` via `flutter --version` but `flutter` was not available in this environment (`/bin/bash: flutter: command not found`).
- Changes were committed locally and the modified files are `lib/modules/tasks/tasks_screen.dart` and `lib/modules/orders/edit_order_screen.dart`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cf884c14832f80f3d6bba3461cfa)