### PR TITLE
Default shipment write-off to actual quantity when produced < tirage

### DIFF
--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -500,8 +500,13 @@ class _OrdersScreenState extends State<OrdersScreen> {
       debugPrint('⚠️ shipment leftover snapshot error: $e\n$st');
     }
 
-    double customQty = plannedQty;
-    ShipmentQuantityMode mode = ShipmentQuantityMode.tirage;
+    final bool actualLessThanPlanned = safeActual < plannedQty;
+    final double suggestedWriteoff =
+        actualLessThanPlanned ? safeActual : plannedQty;
+    double customQty = suggestedWriteoff;
+    ShipmentQuantityMode mode = actualLessThanPlanned
+        ? ShipmentQuantityMode.actual
+        : ShipmentQuantityMode.tirage;
     final TextEditingController customController =
         TextEditingController(text: _formatQuantity(customQty));
     bool updatingCustomText = false;


### PR DESCRIPTION
### Motivation
- При отгрузке предыдущая логика по умолчанию выбирала списание тиража, из‑за чего сотрудник не мог корректно отгрузить заказ, если фактическое количество было меньше тиража.

### Description
- В `lib/modules/orders/orders_screen.dart` в `_confirmShipment` введены переменные `actualLessThanPlanned` и `suggestedWriteoff` для определения рекомендуемого значения списания.
- Поле `customQty` теперь инициализируется значением `suggestedWriteoff` и контроллер `customController` получает это форматированное значение по умолчанию.
- Значение `mode` теперь по умолчанию устанавливается в `ShipmentQuantityMode.actual`, когда фактическое количество меньше тиража, и в `ShipmentQuantityMode.tirage` в противном случае.

### Testing
- Автоматическая команда `dart format lib/modules/orders/orders_screen.dart` была запущена и завершилась с ошибкой из‑за отсутствия `dart` CLI в окружении (неуспех). 
- Не было запущено других автоматических тестов в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d5457b18832f80fcdb64a599e2a0)