### PR TITLE
Fix paper picker controller lifecycle crash

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1144,29 +1144,28 @@ class _TasksScreenState extends State<TasksScreen>
     required BuildContext context,
     required List<TmcModel> papers,
   }) async {
-    final searchController = TextEditingController();
     var search = '';
-    try {
-      return showDialog<TmcModel>(
-        context: context,
-        builder: (pickerContext) {
-          return StatefulBuilder(
-            builder: (pickerContext, setPickerState) {
-              final filtered = papers.where((paper) {
-                // В рабочем пространстве разрешаем повторно выбирать ту же бумагу
-                // в разных слотах (например, как дополнительную бумагу того же типа).
-                // Поэтому intentionally НЕ исключаем уже выбранные id.
-                return _matchPaperSearch(paper, search);
-              }).toList(growable: false);
-              return AlertDialog(
+    return showDialog<TmcModel>(
+      context: context,
+      builder: (pickerContext) {
+        return StatefulBuilder(
+          builder: (pickerContext, setPickerState) {
+            final filtered = papers.where((paper) {
+              // В рабочем пространстве разрешаем повторно выбирать ту же бумагу
+              // в разных слотах (например, как дополнительную бумагу того же типа).
+              // Поэтому intentionally НЕ исключаем уже выбранные id.
+              return _matchPaperSearch(paper, search);
+            }).toList(growable: false);
+            return AlertDialog(
               title: const Text('Выбор бумаги'),
               content: SizedBox(
                 width: 540,
                 height: 420,
                 child: Column(
                   children: [
-                    TextField(
-                      controller: searchController,
+                    TextFormField(
+                      key: ValueKey(search.isEmpty),
+                      initialValue: search,
                       decoration: InputDecoration(
                         labelText: 'Поиск бумаги',
                         hintText: 'Наименование, формат, грамаж',
@@ -1177,7 +1176,6 @@ class _TasksScreenState extends State<TasksScreen>
                                 onPressed: () {
                                   setPickerState(() {
                                     search = '';
-                                    searchController.clear();
                                   });
                                 },
                                 icon: const Icon(Icons.clear),
@@ -1222,11 +1220,8 @@ class _TasksScreenState extends State<TasksScreen>
             );
           },
         );
-        },
-      );
-    } finally {
-      searchController.dispose();
-    }
+      },
+    );
   }
 
   String _buildWorkspacePaperChangeComment({


### PR DESCRIPTION
### Motivation
- The paper selection modal could trigger `A TextEditingController was used after being disposed.` when the dialog was closed during framework transitions. 
- This controller lifecycle bug could cascade into large render/overflow issues and break the picker UX.

### Description
- Replaced the ephemeral `TextField` + `TextEditingController` used inside the picker with a `TextFormField` driven by a local `search` variable inside the `StatefulBuilder` to avoid controller lifecycle mismatch. 
- Removed the temporary controller creation and disposal and added a `ValueKey(search.isEmpty)` so the input field rebuilds correctly when clearing search. 
- Kept the existing filtering and paper selection behavior unchanged and only modified `lib/modules/tasks/tasks_screen.dart` to implement the fix.

### Testing
- Inspected the modified file and verified the picker builds with `TextFormField` and the `search` state controls filtering. 
- Attempted to run `dart format` for formatting validation but the environment lacks the `dart` binary so the check could not be executed. 
- Attempted to query Flutter with `flutter --version` but the environment lacks the `flutter` binary, so runtime tests were not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d6fe4568832f99cc77b4516a393c)