### PR TITLE
Fix final completion semantics for separate executors and shipment gating

### DIFF
--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../tasks/task_provider.dart';
 import '../tasks/task_model.dart';
+import '../tasks/task_completion_rules.dart';
 import '../warehouse/warehouse_table_styles.dart';
 import '../warehouse/warehouse_provider.dart';
 import '../personnel/personnel_provider.dart';
@@ -998,7 +999,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
   _OrderStatusInfo _computeStatus(OrderModel order, List<TaskModel> allTasks) {
     final tasks = allTasks.where((t) => t.orderId == order.id).toList();
     if (tasks.isNotEmpty) {
-      if (tasks.every((t) => t.status == TaskStatus.completed)) {
+      if (isOrderFinallyCompleted(tasks)) {
         return const _OrderStatusInfo(Colors.green, 'Завершено');
       }
       if (tasks.any((t) => t.status == TaskStatus.inProgress)) {

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -22,6 +22,7 @@ import '../orders/orders_repository.dart';
 import '../orders/order_model.dart';
 import '../tasks/task_model.dart';
 import '../tasks/task_provider.dart';
+import '../tasks/task_completion_rules.dart';
 // УДАЛЕНО: import '../production_planning/planned_stage_model.dart';
 import '../personnel/employee_model.dart';
 import '../personnel/personnel_provider.dart';
@@ -177,25 +178,8 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
 
   TaskStatus? _groupStatus(List<TaskModel> stageTasks) {
     if (stageTasks.isEmpty) return null;
-
-    bool isEffectivelyCompleted(TaskModel task) {
-      if (task.status == TaskStatus.completed) return true;
-      for (final comment in task.comments) {
-        final type = comment.type.trim().toLowerCase();
-        if (type == 'user_done' || type == 'finish_note') {
-          return true;
-        }
-
-        final text = comment.text.trim().toLowerCase();
-        if (text == 'done' || text == 'finish' || text == 'finished') {
-          return true;
-        }
-
-        if (text.startsWith('{') && text.contains('"endtime"')) {
-          return true;
-        }
-      }
-      return false;
+    if (isStageGroupFinallyCompleted(stageTasks)) {
+      return TaskStatus.completed;
     }
 
     if (stageTasks.any((t) => t.status == TaskStatus.problem)) {
@@ -206,9 +190,6 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
     }
     if (stageTasks.any((t) => t.status == TaskStatus.paused)) {
       return TaskStatus.paused;
-    }
-    if (stageTasks.any(isEffectivelyCompleted)) {
-      return TaskStatus.completed;
     }
     return TaskStatus.waiting;
   }

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -9,6 +9,7 @@ import '../personnel/personnel_provider.dart';
 import '../production/production_queue_provider.dart';
 import '../tasks/task_model.dart';
 import '../tasks/task_provider.dart';
+import '../tasks/task_completion_rules.dart';
 import '../production_planning/template_provider.dart';
 import '../production_planning/template_model.dart';
 import '../production_planning/planned_stage_model.dart';
@@ -83,11 +84,11 @@ class _OrderGroupingData {
 }
 
 TaskStatus _groupStatus(List<TaskModel> tasks) {
+  if (isStageGroupFinallyCompleted(tasks)) {
+    return TaskStatus.completed;
+  }
   if (tasks.any((t) => t.status == TaskStatus.problem)) {
     return TaskStatus.problem;
-  }
-  if (tasks.any((t) => t.status == TaskStatus.completed)) {
-    return TaskStatus.completed;
   }
   if (tasks.any((t) => t.status == TaskStatus.inProgress)) {
     return TaskStatus.inProgress;
@@ -99,7 +100,7 @@ TaskStatus _groupStatus(List<TaskModel> tasks) {
 }
 
 bool _groupCompleted(List<TaskModel> tasks) =>
-    tasks.any((t) => t.status == TaskStatus.completed);
+    isStageGroupFinallyCompleted(tasks);
 
 bool _orderCompletedByGroups(
   Map<String, _StageGroupInfo> stageGroups,

--- a/lib/modules/tasks/task_completion_rules.dart
+++ b/lib/modules/tasks/task_completion_rules.dart
@@ -1,0 +1,46 @@
+import 'task_model.dart';
+
+/// Финальная завершённость конкретной задачи/ветки этапа.
+///
+/// Важно: для режима "отдельный исполнитель" промежуточные признаки
+/// (например, `user_done`) не считаются окончательным завершением — только
+/// статус `completed` после отдельного подтверждения.
+bool isTaskFinallyCompleted(TaskModel task) => task.status == TaskStatus.completed;
+
+String stageGroupKeyForTask(TaskModel task) {
+  final key = task.stageGroupKey.trim();
+  if (key.isNotEmpty) return key;
+  return task.stageId.trim();
+}
+
+/// Группа этапа (включая альтернативные рабочие места) считается завершённой,
+/// когда хотя бы одна выбранная ветка (stage_id) завершена полностью.
+bool isStageGroupFinallyCompleted(List<TaskModel> groupTasks) {
+  if (groupTasks.isEmpty) return false;
+  final tasksByStage = <String, List<TaskModel>>{};
+  for (final task in groupTasks) {
+    final stageId = task.stageId.trim();
+    if (stageId.isEmpty) continue;
+    tasksByStage.putIfAbsent(stageId, () => <TaskModel>[]).add(task);
+  }
+  if (tasksByStage.isEmpty) return false;
+  for (final stageTasks in tasksByStage.values) {
+    if (stageTasks.isNotEmpty && stageTasks.every(isTaskFinallyCompleted)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool isOrderFinallyCompleted(Iterable<TaskModel> orderTasks) {
+  final tasks = orderTasks.toList(growable: false);
+  if (tasks.isEmpty) return false;
+  final tasksByGroup = <String, List<TaskModel>>{};
+  for (final task in tasks) {
+    final key = stageGroupKeyForTask(task);
+    if (key.isEmpty) continue;
+    tasksByGroup.putIfAbsent(key, () => <TaskModel>[]).add(task);
+  }
+  if (tasksByGroup.isEmpty) return false;
+  return tasksByGroup.values.every(isStageGroupFinallyCompleted);
+}

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import '../../services/app_auth.dart';
 
 import '../orders/order_model.dart';
+import 'task_completion_rules.dart';
 import 'stage_sequence_utils.dart';
 import 'task_model.dart';
 
@@ -944,18 +945,18 @@ class TaskProvider with ChangeNotifier {
       debugPrint('❌ tasks.updateStatus error: $e\n$st');
     }
 
-    // If all tasks for order are completed — close the order
+    // If all stage groups for order are finally completed — close the order
     final orderId = updated.orderId;
     if (orderId != null && orderId.isNotEmpty) {
       try {
         final rows = await _supabase
             .from('tasks')
-            .select('status')
+            .select('*')
             .eq('order_id', orderId);
-        final list = List<Map<String, dynamic>>.from(rows as List);
-        final allCompleted = list.isNotEmpty &&
-            list.every((r) => (r['status'] ?? '') == 'completed');
-        if (allCompleted) {
+        final list = List<Map<String, dynamic>>.from(rows as List)
+            .map(_rowToTask)
+            .toList(growable: false);
+        if (isOrderFinallyCompleted(list)) {
           await _supabase
               .from('orders')
               .update({'status': OrderStatus.completed.name}).eq('id', orderId);

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -21,6 +21,7 @@ import '../production_planning/planned_stage_model.dart';
 import '../warehouse/tmc_model.dart';
 import '../warehouse/warehouse_provider.dart';
 import 'task_model.dart';
+import 'task_completion_rules.dart';
 import 'task_provider.dart';
 import '../common/pdf_view_screen.dart';
 import '../../services/storage_service.dart';
@@ -462,27 +463,7 @@ bool _containsBobbin(String text) {
 }
 
 bool _isEffectivelyCompleted(TaskModel task) {
-  if (task.status == TaskStatus.completed) return true;
-  if (task.assignees.isEmpty) return false;
-
-  final mode = _stageExecutionMode(task);
-  if (mode == ExecutionMode.joint || mode == ExecutionMode.solo) {
-    final ownerId = task.assignees.first;
-    return _userRunState(task, ownerId) == UserRunState.finished;
-  }
-
-  final performers = task.assignees
-      .where((id) => _execModeForUser(task, id) == ExecutionMode.separate)
-      .toList();
-  if (performers.isEmpty) return false;
-  // Для отдельного режима считаем этап завершённым, когда каждый
-  // исполнитель явно зафиксировал личное завершение (comment: user_done).
-  for (final id in performers) {
-    final hasDone = task.comments
-        .any((c) => c.type == 'user_done' && c.userId == id);
-    if (!hasDone) return false;
-  }
-  return true;
+  return isTaskFinallyCompleted(task);
 }
 
 String _workplaceName(PersonnelProvider personnel, String stageId,


### PR DESCRIPTION
### Motivation
- Separate-executor stages were being treated as "completed" based on per-user intermediate markers (comments like `user_done` / per-user quantities), which caused inconsistent ordering: UI could show a stage/order as finished while backend rules still blocked final transitions (including shipment).
- The business rule requiring an explicit final confirmation (a separate "Завершить задание" action that sets a task `status = completed`) must be preserved and used as the source of truth for stage/order completion and shipment readiness.

### Description
- Added a central completion rules module `lib/modules/tasks/task_completion_rules.dart` that exposes `isTaskFinallyCompleted`, `isStageGroupFinallyCompleted`, `isOrderFinallyCompleted`, and helper `stageGroupKeyForTask` to express final-completion semantics consistently across the app.
- Worker UI: replaced the previous `_isEffectivelyCompleted` heuristic with `isTaskFinallyCompleted` so a task in "separate executor" mode is not considered finally complete until its `status == completed` (the final button remains required). (`lib/modules/tasks/tasks_screen.dart`).
- Backend aggregation: updated `TaskProvider.updateStatus` to fetch/parse the order tasks as `TaskModel`s and call `isOrderFinallyCompleted(...)` before auto-closing the order; this ensures order auto-close aligns with final confirmation semantics and handles alternative stage branches correctly. (`lib/modules/tasks/task_provider.dart`).
- Production UI: unified group/ stage status computation to use `isStageGroupFinallyCompleted(...)` so stage-group completion (including alternative stage paths) is determined by final task completion, removing reliance on intermediate comments/texts. (`lib/modules/production/production_screen.dart`, `lib/modules/production/production_details_screen.dart`).
- Orders UI: order status aggregation in `orders_screen.dart` now uses `isOrderFinallyCompleted(...)` so the order card and shipment button visibility follow the same final-completion rule used by the provider. (`lib/modules/orders/orders_screen.dart`).
- No DB schema or enum changes were made; the fix is applied to application logic and providers so existing data remains intact and backward-compatible.

### Testing
- Static checks: inspected diffs and committed the changes; `git status`/`git diff` reflect the expected modifications and new file `task_completion_rules.dart` (commit created successfully).
- Formatting / tooling: attempted to run `dart format` and `flutter --version` but the environment does not provide Dart/Flutter binaries, so automated formatting and Flutter tests could not be executed here (`/bin/bash: dart: command not found`, `/bin/bash: flutter: command not found`).
- Code-path verification performed by searching and updating all relevant usages: worker workspace completion checks, production stage/group rendering, order aggregation for UI, and backend order-auto-close path were updated and cross-checked in the codebase.

Files changed (high level):
- Added: `lib/modules/tasks/task_completion_rules.dart` — centralized final-completion logic.
- Modified: `lib/modules/tasks/tasks_screen.dart`, `lib/modules/tasks/task_provider.dart`, `lib/modules/production/production_screen.dart`, `lib/modules/production/production_details_screen.dart`, `lib/modules/orders/orders_screen.dart` — use the centralized rules to decide final completion and shipment readiness.

If you want, I can prepare a small unit-test scaffold for the new `task_completion_rules.dart` functions (requires running `dart test` in an environment with Dart) and/or produce the exact one-line SQL migration placeholders if later DB changes are desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0db1f097c832fa75253f2f9767619)