### PR TITLE
Добавлен режим списания «по пачкам» и снят лимит 3 видов бумаги

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -495,7 +495,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   bool _lastPreviewPaintsFilled = false;
   MaterialModel? _selectedMaterial;
   TmcModel? _selectedMaterialTmc;
-  // Бизнес-правило: заказ может содержать до 3 видов бумаги.
+  // Дополнительные типы бумаги в заказе (без искусственного лимита).
   final List<MaterialModel> _extraPaperMaterials = <MaterialModel>[];
   int _activePaperSlotIndex = 0;
   // === Каскадный выбор Материал → Формат → Грамаж (строгий) ===
@@ -653,7 +653,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _selectedMaterial = initialPapers.isNotEmpty ? initialPapers.first : null;
     _extraPaperMaterials
       ..clear()
-      ..addAll(initialPapers.skip(1).take(2));
+      ..addAll(initialPapers.skip(1));
     _hasForm = template?.hasForm ?? false;
 
     // Инициализация каскадных полей (если есть материал в шаблоне)
@@ -2079,7 +2079,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         ),
       );
     }
-    // Бизнес-правило: поддерживаем второй/третий тип бумаги как отдельные позиции.
+    // Дополнительные типы бумаги сохраняем отдельными позициями.
     for (final paper in _extraPaperMaterials) {
       final resolved = resolvePaperByMaterial(paper);
       final id = (resolved?.id ?? paper.id ?? '').trim();
@@ -2095,14 +2095,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         ),
       );
     }
-    if (selected.length > 3) {
-      return selected.take(3).toList(growable: false);
-    }
     return selected;
   }
 
   void _addExtraPaperSlot() {
-    if (_extraPaperMaterials.length >= 2) return;
     setState(() {
       _extraPaperMaterials.add(
         MaterialModel(
@@ -2594,7 +2590,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _upsertPensInParameters(penName);
     final provider = Provider.of<OrdersProvider>(context, listen: false);
     final warehouse = Provider.of<WarehouseProvider>(context, listen: false);
-    // Бизнес-правило: бумага хранится списком (до 3 позиций).
+    // Бумага хранится динамическим списком без жёсткого лимита.
     final List<MaterialModel> selectedPapers = _collectSelectedPapers();
     bool hasEnoughPaperForLaunch() {
       if (selectedPapers.isEmpty) return true;
@@ -4799,15 +4795,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         ),
         const SizedBox(height: 3),
         _buildExtraPaperSelectors(),
-        if (_extraPaperMaterials.length < 2)
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton.icon(
-              onPressed: _addExtraPaperSlot,
-              icon: const Icon(Icons.add),
-              label: Text('Добавить бумагу №${_extraPaperMaterials.length + 2}'),
-            ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: _addExtraPaperSlot,
+            icon: const Icon(Icons.add),
+            label: Text('Добавить бумагу №${_extraPaperMaterials.length + 2}'),
           ),
+        ),
         const SizedBox(height: 3),
       ],
     );

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -504,7 +504,7 @@ class OrdersProvider with ChangeNotifier {
   ///
   /// Бизнес-правила:
   /// - причина изменения обязательна;
-  /// - допускается до 3 типов бумаги;
+  /// - количество типов бумаги не ограничено искусственным лимитом;
   /// - при запущенном заказе пересчитываем только резерв (без списания).
   Future<String?> updateOrderPapersFromWorkspace({
     required String orderId,
@@ -534,10 +534,6 @@ class OrdersProvider with ChangeNotifier {
     if (prepared.isEmpty) {
       return 'Добавьте хотя бы один тип бумаги.';
     }
-    if (prepared.length > 3) {
-      return 'Допускается не более 3 типов бумаги в заказе.';
-    }
-
     final index = _orders.indexWhere((o) => o.id == orderId);
     if (index == -1) {
       return 'Заказ не найден в локальном кеше.';
@@ -955,6 +951,21 @@ class OrdersProvider with ChangeNotifier {
     }
     if (writeoffQty < 0) {
       writeoffQty = 0;
+    }
+    if (writeoffQty <= 0) {
+      throw Exception('Количество для списания должно быть больше нуля.');
+    }
+
+    final snapshot = await loadCategoryItemSnapshot(orderData);
+    final double? snapshotQty = _toDoubleNullable(snapshot?['quantity']);
+    final double availableQty = snapshotQty != null
+        ? (snapshotQty < 0 ? 0 : snapshotQty)
+        : safeActual;
+    if (writeoffQty > availableQty) {
+      throw Exception(
+        'Итоговое количество (${_formatQty(writeoffQty)}) превышает '
+        'доступный остаток (${_formatQty(availableQty)}).',
+      );
     }
 
     final double leftoverQty =

--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -25,7 +25,7 @@ enum SortOption {
   quantityDesc,
 }
 
-enum ShipmentQuantityMode { tirage, custom, actual }
+enum ShipmentQuantityMode { tirage, custom, actual, packs }
 
 /// Главный экран модуля оформления заказа. Показывает список заказов с
 /// возможностью фильтрации по статусам, поиска и создания нового заказа.
@@ -505,11 +505,15 @@ class _OrdersScreenState extends State<OrdersScreen> {
     final double suggestedWriteoff =
         actualLessThanPlanned ? safeActual : plannedQty;
     double customQty = suggestedWriteoff;
+    double packsCount = 0;
+    double qtyPerPack = 0;
     ShipmentQuantityMode mode = actualLessThanPlanned
         ? ShipmentQuantityMode.actual
         : ShipmentQuantityMode.tirage;
     final TextEditingController customController =
         TextEditingController(text: _formatQuantity(customQty));
+    final TextEditingController packsCountController = TextEditingController();
+    final TextEditingController qtyPerPackController = TextEditingController();
     bool updatingCustomText = false;
 
     double sliderMax = math.max(plannedQty, safeActual);
@@ -520,6 +524,8 @@ class _OrdersScreenState extends State<OrdersScreen> {
     if (!sliderEnabled) {
       sliderMax = 1;
     }
+    final double availableQty =
+        warehouseExtraQty != null ? math.max(0, warehouseExtraQty) : safeActual;
 
     final double? selectedWriteoff = await showDialog<double>(
       context: context,
@@ -529,6 +535,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
             final double effectiveCustom = sliderEnabled
                 ? math.max(0, math.min(customQty, sliderMax))
                 : math.max(0, customQty);
+            final double computedPacksQty = packsCount * qtyPerPack;
             double currentWriteoff;
             switch (mode) {
               case ShipmentQuantityMode.tirage:
@@ -540,8 +547,17 @@ class _OrdersScreenState extends State<OrdersScreen> {
               case ShipmentQuantityMode.custom:
                 currentWriteoff = effectiveCustom;
                 break;
+              case ShipmentQuantityMode.packs:
+                currentWriteoff = computedPacksQty;
+                break;
             }
             if (currentWriteoff < 0) currentWriteoff = 0;
+            final bool packsInputIncomplete = mode == ShipmentQuantityMode.packs &&
+                (packsCountController.text.trim().isEmpty ||
+                    qtyPerPackController.text.trim().isEmpty);
+            final bool packsInvalid = mode == ShipmentQuantityMode.packs &&
+                (packsCount <= 0 || qtyPerPack <= 0 || currentWriteoff <= 0);
+            final bool exceedsStock = currentWriteoff > availableQty;
             final double leftoverQty =
                 safeActual > currentWriteoff ? (safeActual - currentWriteoff) : 0;
 
@@ -605,6 +621,17 @@ class _OrdersScreenState extends State<OrdersScreen> {
                         });
                       },
                     ),
+                    RadioListTile<ShipmentQuantityMode>(
+                      title: const Text('Списать по пачкам'),
+                      value: ShipmentQuantityMode.packs,
+                      groupValue: mode,
+                      onChanged: (value) {
+                        if (value == null) return;
+                        setDialogState(() {
+                          mode = value;
+                        });
+                      },
+                    ),
                     if (mode == ShipmentQuantityMode.custom) ...[
                       TextField(
                         controller: customController,
@@ -656,9 +683,80 @@ class _OrdersScreenState extends State<OrdersScreen> {
                             : null,
                       ),
                     ],
+                    if (mode == ShipmentQuantityMode.packs) ...[
+                      TextField(
+                        controller: packsCountController,
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                        ),
+                        decoration: const InputDecoration(
+                          labelText: 'Количество пачек',
+                          border: OutlineInputBorder(),
+                        ),
+                        onChanged: (value) {
+                          final parsed = double.tryParse(
+                            value.trim().replaceAll(',', '.'),
+                          );
+                          setDialogState(() {
+                            packsCount = parsed != null && parsed >= 0 ? parsed : 0;
+                          });
+                        },
+                      ),
+                      const SizedBox(height: 8),
+                      TextField(
+                        controller: qtyPerPackController,
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                        ),
+                        decoration: const InputDecoration(
+                          labelText: 'Количество в одной пачке',
+                          border: OutlineInputBorder(),
+                        ),
+                        onChanged: (value) {
+                          final parsed = double.tryParse(
+                            value.trim().replaceAll(',', '.'),
+                          );
+                          setDialogState(() {
+                            qtyPerPack = parsed != null && parsed >= 0 ? parsed : 0;
+                          });
+                        },
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Итог к списанию: ${_formatQuantity(computedPacksQty)} '
+                        '(пачек: ${_formatQuantity(packsCount)} × '
+                        '${_formatQuantity(qtyPerPack)})',
+                      ),
+                    ],
                     const Divider(),
                     Text('К списанию: ${_formatQuantity(currentWriteoff)}'),
                     Text('Остаток после отгрузки: ${_formatQuantity(leftoverQty)}'),
+                    if (mode == ShipmentQuantityMode.packs &&
+                        packsInputIncomplete)
+                      const Padding(
+                        padding: EdgeInsets.only(top: 8),
+                        child: Text(
+                          'Заполните оба поля для списания по пачкам.',
+                          style: TextStyle(color: Colors.red),
+                        ),
+                      ),
+                    if (mode == ShipmentQuantityMode.packs && packsInvalid)
+                      const Padding(
+                        padding: EdgeInsets.only(top: 8),
+                        child: Text(
+                          'Количество пачек и количество в пачке должны быть больше нуля.',
+                          style: TextStyle(color: Colors.red),
+                        ),
+                      ),
+                    if (exceedsStock)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8),
+                        child: Text(
+                          'Итоговое количество (${_formatQuantity(currentWriteoff)}) '
+                          'превышает доступный остаток (${_formatQuantity(availableQty)}).',
+                          style: const TextStyle(color: Colors.red),
+                        ),
+                      ),
                   ],
                 ),
               ),
@@ -668,7 +766,12 @@ class _OrdersScreenState extends State<OrdersScreen> {
                   child: const Text('Отмена'),
                 ),
                 ElevatedButton(
-                  onPressed: () => Navigator.pop(ctx, currentWriteoff),
+                  onPressed: (currentWriteoff <= 0 ||
+                          (mode == ShipmentQuantityMode.packs &&
+                              (packsInputIncomplete || packsInvalid)) ||
+                          exceedsStock)
+                      ? null
+                      : () => Navigator.pop(ctx, currentWriteoff),
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.red,
                     foregroundColor: Colors.white,
@@ -683,6 +786,8 @@ class _OrdersScreenState extends State<OrdersScreen> {
     );
 
     customController.dispose();
+    packsCountController.dispose();
+    qtyPerPackController.dispose();
 
     if (selectedWriteoff == null) {
       return;

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1294,7 +1294,7 @@ class _TasksScreenState extends State<TasksScreen>
     }
 
     final selected = currentMaterials.isNotEmpty
-        ? currentMaterials.take(3).toList()
+        ? currentMaterials.toList()
         : <MaterialModel>[
             MaterialModel(
               id: papers.first.id,
@@ -1392,7 +1392,6 @@ class _TasksScreenState extends State<TasksScreen>
     bool saving = false;
 
     Future<void> addSlot(StateSetter setDialogState) async {
-      if (selected.length >= 3) return;
       final pick = papers.first;
       setDialogState(() {
         selected.add(MaterialModel(
@@ -1588,7 +1587,7 @@ class _TasksScreenState extends State<TasksScreen>
                         Align(
                           alignment: Alignment.centerLeft,
                           child: TextButton.icon(
-                            onPressed: selected.length >= 3 || saving
+                            onPressed: saving
                                 ? null
                                 : () => addSlot(setDialogState),
                             icon: const Icon(Icons.add),


### PR DESCRIPTION
### Motivation
- Добавить в диалог отгрузки новый полноценный способ списания «по пачкам» с валидацией и гарантией, что списание не превысит фактический остаток.
- Устранить искусственное ограничение «максимум 3 вида бумаги» в создании/редактировании заказа и в изменении бумаги из рабочего пространства, чтобы список бумаг стал динамическим.

### Description
- В UI подтверждения отгрузки добавлен новый режим `ShipmentQuantityMode.packs` с двумя полями: `Количество пачек` и `Количество в одной пачке`, автоматическим расчётом итогового количества (`packsCount * qtyPerPack`), индикацией итогового количества и блокировкой кнопки отгрузки при пустых/некорректных значениях или при превышении остатка (фронтенд). (lib/modules/orders/orders_screen.dart)
- На серверной стороне перед списанием в методе `shipOrder` добавлена защита: проверка, что количество к списанию > 0 и не превышает доступный остаток (подгружаемый snapshot); при несоответствии бросается исключение и списание не выполняется (backend). (lib/modules/orders/orders_provider.dart)
- Убраны все логические ограничения, срезы и блокировки, связанные с «до 3 видов бумаги»: убраны `take(3)`, удалены проверки блокировки добавления слотов и серверный guard `prepared.length > 3`, а добавление/удаление/инициализация бумаги переведены на динамический список (frontend + provider). (lib/modules/orders/edit_order_screen.dart, lib/modules/tasks/tasks_screen.dart, lib/modules/orders/orders_provider.dart)
- Коротко по файлам:
  - `lib/modules/orders/orders_screen.dart` — добавлен enum-значение `packs`, UI радио-опция и поля ввода пачек/шт.в пачке, расчёт итогового writeoff и фронтэнд-валидация/сообщения об ошибках. 
  - `lib/modules/orders/orders_provider.dart` — добавлена серверная проверка перед списанием: `writeoffQty > 0` и `writeoffQty <= availableQty` (snapshot), возвращается ошибка до изменений склада. Также удалён лимит на 3 бумаги в `updateOrderPapersFromWorkspace` комментариями/логикой. 
  - `lib/modules/orders/edit_order_screen.dart` — убраны усечения списка бумаги при загрузке/сборе/инициализации, сняты ограничения при добавлении дополнительных слотов, интерфейс хранения бумаги сделан динамическим. 
  - `lib/modules/tasks/tasks_screen.dart` — убран иссечатель `take(3)` и блокировка добавления бумаги (диалог рабочего пространства теперь поддерживает произвольное количество слотов). 
- Не потребовались изменения в БД или миграции: логика проверки и списка реализована в текущих структурах таблиц/сервисах. 

### Testing
- Проверка синтаксического диффа выполнена: `git diff --check` — проблем не выявлено. (успех)
- Попытка локально запустить автоформаттер `dart format` завершилась неудачей из-за отсутствия SDK в окружении (`no-sdk`), поэтому форматирование/запуск тестов не выполнены в этом рантайме. (ограничение окружения)
- Функциональные проверки вручную при разработке: просмотрены и проверены изменения диалогов/условий блокировки в коде (UI логика) и добавлена серверная проверка в `shipOrder`, поэтому сценарии в коде покрывают: расчёт пачек, валидацию >0, блокировку при превышении остатка и отказ на сервере до выполнения списания.
- Рекомендации по дальнейшем тестированию: запустить `flutter analyze`, `dart format` и unit/UI тесты в окружении с установленным Flutter/Dart SDK и выполнить пробную отгрузку в тестовой БД, а также сценарий создания/редактирования заказа с >3 видами бумаги для подтверждения сохранения/загрузки (внешние интеграционные проверки не выполнялись автоматически здесь).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dcdd47a8832fb1782c07a6bbe91f)