### PR TITLE
Require explicit stage finalization for separate executors

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4681,7 +4681,10 @@ class _TasksScreenState extends State<TasksScreen>
                       );
                       if (!_anyUserActive(latestTask)) {
                         final _secs = _elapsed(latestTask).inSeconds;
-                        final shouldCloseStage = jointGroup != null || separateAllDone;
+                        // Для режима "Отдельный исполнитель" финальное закрытие
+                        // этапа выполняется только через отдельную кнопку
+                        // "Завершить задание" (ниже в карточке этапа).
+                        final shouldCloseStage = jointGroup != null;
                         if (_isInkConfirmationStage(task)) {
                           await _finalizeTask(task, initialQtyInput: qtyInput);
                           return;
@@ -4694,7 +4697,15 @@ class _TasksScreenState extends State<TasksScreen>
                             task.id, nextStatus,
                             spentSeconds: _secs,
                             startedAt: null);
-                        if (shouldCloseStage &&
+                        if (context.mounted && separateAllDone && jointGroup == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text(
+                                'Все исполнители завершили работу. Нажмите «Завершить задание» для закрытия этапа.',
+                              ),
+                            ),
+                          );
+                        } else if (shouldCloseStage &&
                             nextStatus != TaskStatus.completed &&
                             context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
### Motivation
- Prevent automatic stage closure in the "Отдельный исполнитель" execution mode so that a stage is not fully completed until a performer presses the dedicated finalization control.

### Description
- Changed per-user finish flow in `lib/modules/tasks/tasks_screen.dart` (inside the `onFinish` handler) so `shouldCloseStage` is now true only for joint execution (`jointGroup != null`) and not when all separate performers pressed personal finish.
- Added a `SnackBar` hint that appears when all separate-mode performers finished their personal work asking the user to press the `«Завершить задание»` button to close the stage.
- Preserved existing special-case handling for ink/print confirmation via `_isInkConfirmationStage` and the `_finalizeTask` call.

### Testing
- Ran `git diff -- lib/modules/tasks/tasks_screen.dart` which showed the intended changes and succeeded.
- Attempted `dart format lib/modules/tasks/tasks_screen.dart` which failed due to missing `dart` in the environment (`dart: command not found`).
- Attempted `flutter --version` which failed due to missing `flutter` in the environment (`flutter: command not found`).
- Changes were committed successfully with message `Require explicit stage finalization for separate executors`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e4e94160832f863537ca87446fd7)