### PR TITLE
Fix deleteOrder UUID filtering for assignment IDs

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -812,6 +812,9 @@ class OrdersProvider with ChangeNotifier {
         id.trim(),
         if (assignmentId.isNotEmpty) assignmentId,
       }..removeWhere((value) => value.isEmpty);
+      final dbOrderRefs = relatedOrderIds
+          .where(_looksLikeUuid)
+          .toList(growable: false);
 
       // Фикс: логируем удаление до фактического удаления заказа, иначе
       // вставка в order_events ломается по FK order_events_order_id_fkey.
@@ -821,7 +824,7 @@ class OrdersProvider with ChangeNotifier {
       // в модуле производственных заданий и рабочем пространстве.
       // Если этап уже запущен, сначала принудительно завершаем его, затем удаляем,
       // чтобы в очереди не оставались "висящие" назначения.
-      for (final orderRef in relatedOrderIds) {
+      for (final orderRef in dbOrderRefs) {
         try {
           await _supabase
               .from('tasks')
@@ -869,6 +872,15 @@ class OrdersProvider with ChangeNotifier {
       notifyListeners();
       debugPrint('❌ deleteOrder error: $e\n$st');
     }
+  }
+
+  bool _looksLikeUuid(String value) {
+    final normalized = value.trim();
+    if (normalized.isEmpty) return false;
+    final uuidPattern = RegExp(
+      r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$',
+    );
+    return uuidPattern.hasMatch(normalized);
   }
 
   Future<void> _cleanupProductionQueueState(Set<String> removedOrderIds) async {


### PR DESCRIPTION
### Motivation

- Deleting an order could fail with PostgREST error `22P02 invalid input syntax for type uuid` when `assignmentId` used a business format (e.g. `ЗК-2026.04.15-1`) and was passed into `.eq('order_id', ...)` queries against UUID columns.

### Description

- Restrict task cleanup in `deleteOrder` to only query `tasks.order_id` for UUID-like values by introducing `dbOrderRefs = relatedOrderIds.where(_looksLikeUuid)` and iterating over `dbOrderRefs` when updating/deleting tasks.
- Add helper `bool _looksLikeUuid(String)` that validates v1–v5 UUIDs with a `RegExp` and ignores empty/whitespace values.
- Keep queue cleanup logic unchanged so non-UUID business assignment IDs are still removed from UI queue state via `_cleanupProductionQueueState(relatedOrderIds)`.

### Testing

- Attempted to run `dart format lib/modules/orders/orders_provider.dart`, but the `dart` tool is not available in the environment, so formatting could not be executed.
- Attempted to check Flutter with `flutter --version`, but `flutter` is not installed in the environment, so no runtime/CLI checks were possible.
- Static inspection of the modified file was performed locally in the workspace and the change compiles conceptually (no automated Dart compile/run executed due to missing toolchain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e2b0bed0832fa53bf2c5acfd2aba)