### PR TITLE
Fix missing Text argument in orders shipment dialog

### DIFF
--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -744,7 +744,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
                       const Padding(
                         padding: EdgeInsets.only(top: 8),
                         child: Text(
-                          
+                          'Количество пачек и количество в пачке должны быть больше нуля.',
                           style: TextStyle(color: Colors.red),
                         ),
                       ),


### PR DESCRIPTION
### Motivation
- Resolve a Flutter compile-time error caused by a `Text` widget created without the required positional `String` argument in the shipment dialog, which made the Windows build fail.

### Description
- Inserted a user-facing validation message in `lib/modules/orders/orders_screen.dart` for the `packsInvalid` case: `'Количество пачек и количество в пачке должны быть больше нуля.'` so the `Text(...)` widget now has the required string argument.

### Testing
- Attempted to run `dart analyze lib/modules/orders/orders_screen.dart`, but `dart` is not available in this environment so static analysis could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e68cc2c0832f833790254ba11c0e)