### PR TITLE
Fix separate stage finalization without quantity prompt

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3945,43 +3945,50 @@ class _TasksScreenState extends State<TasksScreen>
       }
     }
 
-    while (qtyInput == null) {
-      final result = await _askQuantity(
-        context,
-        unit: unitLabel,
-        allowPaperEdit: true,
-      );
-      if (result == null) return;
-      if (!result.openPaperEditor) {
-        qtyInput = result;
-        break;
-      }
-      final order = _orderById(task.orderId);
-      if (order == null) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Не удалось найти заказ для редактирования бумаги.'),
-            ),
-          );
-        }
-        return;
-      }
-      await _openPaperEditDialog(order);
-    }
+    final stageMode = _execModeForUser(task, widget.employeeId);
+    final isSeparateFinalizeWithoutPrefilledQty =
+        stageMode == ExecutionMode.separate && qtyInput == null;
 
-    final qtyText = qtyInput.displayText;
+    if (!isSeparateFinalizeWithoutPrefilledQty) {
+      while (qtyInput == null) {
+        final result = await _askQuantity(
+          context,
+          unit: unitLabel,
+          allowPaperEdit: true,
+        );
+        if (result == null) return;
+        if (!result.openPaperEditor) {
+          qtyInput = result;
+          break;
+        }
+        final order = _orderById(task.orderId);
+        if (order == null) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Не удалось найти заказ для редактирования бумаги.'),
+              ),
+            );
+          }
+          return;
+        }
+        await _openPaperEditDialog(order);
+      }
+    }
 
     final tp = context.read<TaskProvider>();
     final wroteOff = await _writeoffInks(task, paints);
     if (!wroteOff) return;
 
-    await tp.addCommentAutoUser(
-      taskId: task.id,
-      type: 'quantity_done',
-      text: qtyText,
-      userIdOverride: widget.employeeId,
-    );
+    if (qtyInput != null) {
+      final qtyText = qtyInput.displayText;
+      await tp.addCommentAutoUser(
+        taskId: task.id,
+        type: 'quantity_done',
+        text: qtyText,
+        userIdOverride: widget.employeeId,
+      );
+    }
 
     final latest = tp.tasks.firstWhere(
       (t) => t.id == task.id,


### PR DESCRIPTION
### Motivation
- Пользователи видели окно ввода количества при нажатии дополнительной кнопки «Завершить задание» для этапов в режиме `ExecutionMode.separate`, хотя количество уже могло быть передано отдельной кнопкой участия. 
- Нужно избежать повторного запроса количества в сценарии финализации этапа в режиме «Отдельный исполнитель». 

### Description
- Изменён метод ` _finalizeTask` в `lib/modules/tasks/tasks_screen.dart` чтобы пропускать диалог ввода количества, когда `ExecutionMode.separate` и `qtyInput` не передан (переменные `stageMode` и `isSeparateFinalizeWithoutPrefilledQty`).
- Сохранено текущее поведение запроса количества для всех остальных сценариев (включая совместный режим и когда `initialQtyInput` передан).
- Добавлена проверка, что комментарий `quantity_done` добавляется только если `qtyInput != null`.

### Testing
- Выполнена проверка с помощью `git diff --check`, которая прошла успешно.
- Попытка запустить форматирование `dart format lib/modules/tasks/tasks_screen.dart` не выполнялась в этой среде, так как `dart` не установлен (`/bin/bash: line 1: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c4e29ce8832f8a7db95f6576e4f9)