### PR TITLE
Автоприсвоение новой формы при добавлении красок и возможность заменить форму в режиме редактирования

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3307,6 +3307,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   Future<void> _processFormAssignment(OrderModel order,
       {required bool isCreating}) async {
+    final bool paintsFilled = _hasAnyPaints();
+    if (!_hasForm && paintsFilled) {
+      // Если добавлены краски, а форма не выбрана, автоматически создаём новую
+      // форму для текущего заказа по данным из заказа/красок.
+      _hasForm = true;
+      _isOldForm = false;
+    }
+
     final bool hadFormBefore = _hasAssignedForm();
     final bool shouldHandle = isCreating || _editingForm || !hadFormBefore;
     if (!shouldHandle) return;
@@ -6119,6 +6127,19 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     final controls = <Widget>[];
     if (showFormSummary) {
       controls.add(_buildFormSummary(context));
+      if (isEditing && hasAssignedForm) {
+        controls.addAll([
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: _startFormEditing,
+              icon: const Icon(Icons.edit),
+              label: const Text('Изменить форму'),
+            ),
+          ),
+        ]);
+      }
     }
     if (showFormEditor) {
       if (controls.isNotEmpty) {


### PR DESCRIPTION
### Motivation
- Закрыть сценарий, когда пользователь добавляет краски в заказ и сохраняет, но не выбирает форму — в этом случае заказ должен автоматически получить новую форму. 
- Дать пользователю явный способ изменить уже присвоенную форму при редактировании заказа (например, заменить её на старую форму).

### Description
- В `lib/modules/orders/edit_order_screen.dart` в `_processFormAssignment` добавлена проверка `paintsFilled = _hasAnyPaints()` и при наличии красок и отсутствии выбранной формы автоматически выставляется `_hasForm = true` и `_isOldForm = false` чтобы продолжить обработку как для новой формы.
- В том же файле в секции отображения сводки формы (`_buildFormSection`) добавлена кнопка `TextButton.icon` с надписью «Изменить форму», которая вызывает `_startFormEditing`, что позволяет перейти в режим редактирования формы для уже существующего заказа.
- Изменения ограничены `edit_order_screen.dart` и используют существующую логику сохранения/создания форм и синхронизации с БД.

### Testing
- Запущено форматирование через `dart format lib/modules/orders/edit_order_screen.dart`, которое завершилось ошибкой из-за отсутствия `dart` в окружении (не выполнено).
- Проверка окружения через `flutter --version` также завершилась ошибкой из-за отсутствия `flutter` (не выполнено).
- Юнит-тесты или интеграционные тесты не запускались в этом окружении из-за отсутствия инструментов сборки/SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c6fd3c40832fbc8d917c83a326d7)