### PR TITLE
Fix undefined `e` in catch blocks in edit_order_screen.dart

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -580,7 +580,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       }
       names.sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
       setState(() => _categoryTitles = names);
-    } catch (_) {
+    } catch (e) {
       debugPrint('load categories error: $e');
     } finally {
       if (mounted) setState(() => _catsLoading = false);
@@ -1622,7 +1622,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         _stagePreviewInitialized = true;
         _stageOrderManuallyChanged = false;
       });
-    } catch (_) {
+    } catch (e) {
       if (!mounted) return;
       setState(() {
         _stagePreviewStages = <Map<String, dynamic>>[];
@@ -2296,7 +2296,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       await _sb.from('orders').update({
         'product': _product.toMap(),
       }).eq('id', orderId);
-    } catch (_) {
+    } catch (e) {
       // не блокируем сохранение заказа, просто сообщим в консоль
       debugPrint('❌ persist paints error: ' + e.toString());
     }
@@ -2353,7 +2353,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           return;
         }
       }
-    } catch (_) {
+    } catch (e) {
       debugPrint('❌ restore paints from DB error: ' + e.toString());
     }
     // Фолбэк к старому парсеру parameters
@@ -3156,7 +3156,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     // Списание лишнего выполняется на этапе отгрузки.
 
     await _goToOrdersModuleHome();
-    } catch (_) {
+    } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Не удалось сохранить заказ: $e')),


### PR DESCRIPTION
### Motivation
- Prevent runtime/build errors caused by referencing an undefined identifier `e` inside `catch` blocks that used `catch (_)` while still logging the exception.
- Ensure exception handlers actually capture the exception value for debug logging and user-facing messages in the edit order screen.

### Description
- Replaced five occurrences of `catch (_) { ... $e ... }` with `catch (e) { ... }` in `lib/modules/orders/edit_order_screen.dart` so the exception value is available for logging and messages.
- Fixed error logging in category loading (`_loadCategoriesForProduct`).
- Fixed error handling when applying stage rules (stage preview initialization).
- Fixed logging when persisting `order_paints`/`orders` and when restoring paints from the database.
- Fixed the order save failure handler so the snackbar shows the actual exception value.

### Testing
- Attempted to run `dart analyze lib/modules/orders/edit_order_screen.dart` but analysis could not run because `dart` is not available in the current environment, so static analysis was not completed (failed).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c854dc24832f9fda5be919ff1a69)