### PR TITLE
Fix unexpected form number changes when saving edited orders

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3315,7 +3315,55 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       _isOldForm = false;
     }
 
-    final bool hadFormBefore = _hasAssignedForm();
+    bool persistedHasForm = false;
+    bool? persistedIsOldForm;
+    int? persistedFormNo;
+    String? persistedFormSeries;
+    String? persistedFormCode;
+    try {
+      final persisted = await _sb
+          .from('orders')
+          .select('has_form, is_old_form, new_form_no, form_series, form_code')
+          .eq('id', order.id)
+          .maybeSingle();
+      final persistedHasFormFlag = persisted?['has_form'] as bool?;
+      persistedIsOldForm = persisted?['is_old_form'] as bool?;
+      persistedFormNo = ((persisted?['new_form_no'] as num?)?.toInt());
+      final persistedSeriesRaw = (persisted?['form_series'] ?? '').toString();
+      final persistedCodeRaw = (persisted?['form_code'] ?? '').toString();
+      persistedFormSeries =
+          persistedSeriesRaw.trim().isEmpty ? null : persistedSeriesRaw.trim();
+      persistedFormCode =
+          persistedCodeRaw.trim().isEmpty ? null : persistedCodeRaw.trim();
+      persistedHasForm = persistedHasFormFlag ??
+          (persistedIsOldForm != null ||
+              persistedFormNo != null ||
+              persistedFormCode != null);
+    } catch (_) {
+      persistedHasForm = false;
+    }
+
+    final bool hadFormBefore = _hasAssignedForm() || persistedHasForm;
+    if (!isCreating && !_editingForm && hadFormBefore) {
+      if (mounted &&
+          !_hasAssignedForm() &&
+          (persistedFormNo != null || persistedFormCode != null)) {
+        setState(() {
+          _hasForm = true;
+          _orderFormIsOld = persistedIsOldForm;
+          _orderFormNo = persistedFormNo;
+          _orderFormSeries = persistedFormSeries;
+          _orderFormCode = persistedFormCode;
+          _orderFormDisplay = _buildFormDisplayValue(
+            code: persistedFormCode,
+            series: persistedFormSeries,
+            number: persistedFormNo,
+          );
+        });
+      }
+      return;
+    }
+
     final bool shouldHandle = isCreating || _editingForm || !hadFormBefore;
     if (!shouldHandle) return;
 


### PR DESCRIPTION
### Motivation
- Prevent automatic creation or reassignment of a form when saving order edits that did not touch the form, which could cause the form number to increment (e.g. 450 → 451) unexpectedly.

### Description
- Added a persisted-form lookup in `EditOrderScreen._processFormAssignment` that reads `has_form`, `is_old_form`, `new_form_no`, `form_series`, and `form_code` from the DB for the current order in `lib/modules/orders/edit_order_screen.dart`.
- Combine the persisted values with the local `_hasAssignedForm()` result to compute whether the order already had a form assigned (`hadFormBefore`).
- If the operation is an edit (not creating) and the user did not enter form-edit mode and a form is already persisted, restore the local UI form state from the persisted values and return early to skip any form reassignment or creation.
- Preserve existing behavior for explicit form edits and new-order form creation, and handle DB-read failures by treating persisted form as absent.

### Testing
- Attempted to run the formatter with `dart format lib/modules/orders/edit_order_screen.dart`, but the `dart` CLI is not available in the container so formatting could not be applied (failed).
- No automated unit or integration tests were executed in this environment; changes were validated by code inspection and reviewing the produced diff of `lib/modules/orders/edit_order_screen.dart`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ca405b98832fb4291a1e8dbc5e43)