### PR TITLE
Fix form reassignment on repeated order saves

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -2685,6 +2685,22 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       }
       createdOrUpdatedOrder = _created;
     } else {
+      final bool effectivePersistedHasForm = (_orderFormNo != null) ||
+          (_orderFormCode != null && _orderFormCode!.trim().isNotEmpty) ||
+          ((_orderFormIsOld != null) &&
+              ((_orderFormNo != null) ||
+                  (_orderFormCode != null &&
+                      _orderFormCode!.trim().isNotEmpty))) ||
+          widget.order!.hasForm;
+      final bool effectivePersistedIsOldForm =
+          _orderFormIsOld ?? widget.order!.isOldForm;
+      final int? effectivePersistedFormNo =
+          _orderFormNo ?? widget.order!.newFormNo;
+      final String? effectivePersistedFormSeries =
+          _orderFormSeries ?? widget.order!.formSeries;
+      final String? effectivePersistedFormCode =
+          _orderFormCode ?? widget.order!.formCode;
+
       final List<MaterialModel> oldPapers =
           widget.order!.paperMaterials.isNotEmpty
               ? widget.order!.paperMaterials
@@ -2718,7 +2734,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         val: _val,
         pdfUrl: widget.order!.pdfUrl,
         stageTemplateId: _stageTemplateId,
-        hasForm: _hasForm,
+        // На этапе базового сохранения не перетираем уже привязанную форму.
+        // Фактическая запись формы всегда выполняется позже в _processFormAssignment.
+        hasForm: effectivePersistedHasForm,
+        isOldForm: effectivePersistedIsOldForm,
+        newFormNo: effectivePersistedFormNo,
+        formSeries: effectivePersistedFormSeries,
+        formCode: effectivePersistedFormCode,
         // Временно отключено в форме создания/редактирования заказа.
         contractSigned: false,
         paymentDone: false,


### PR DESCRIPTION
### Motivation
- Prevent accidental reassignment/increment of a form number when saving unrelated edits to an existing order.
- Ensure the base order update does not overwrite already-linked form fields before the dedicated form logic runs.
- Keep form persistence centralized in `_processFormAssignment` so form edits/creation remain the single source of truth.

### Description
- In `lib/modules/orders/edit_order_screen.dart` compute `effectivePersisted*` values (`hasForm`, `isOldForm`, `newFormNo`, `formSeries`, `formCode`) from the current UI state and the existing `widget.order` when saving an existing order. 
- Use those `effectivePersisted*` values when constructing the `OrderModel` for the base update to avoid stomping previously persisted form linkage. 
- Added comments clarifying that actual form creation/updates are performed later by `_processFormAssignment` and should not be overwritten by the base save. 

### Testing
- Verified the code change with `git diff -- lib/modules/orders/edit_order_screen.dart` to confirm the applied patch. (succeeded)
- Attempted to run `dart format lib/modules/orders/edit_order_screen.dart` but the environment lacks the Dart SDK (`/bin/bash: line 1: dart: command not found`). (failed due to missing SDK)
- Committed the change (`git commit`) and verified the file was updated in the working tree. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cc007d64832fb1ff76a585d1f917)