### PR TITLE
Запретить старт следующего этапа до завершения предыдущего

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -618,18 +618,6 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     };
   }
 
-  // Для поэтапного старта: текущий этап можно запускать, если запущен
-  // предыдущий этап в очереди (или этап первый). Это позволяет сотруднику B
-  // начать следующий этап, когда сотрудник A уже начал предыдущий.
-  bool stageHasActivity(String groupKey) {
-    return all.any((t) {
-      if (_groupKey(t.stageId) != groupKey) return false;
-      if (t.status != TaskStatus.waiting) return true;
-      return t.comments.any((c) =>
-          c.type == 'start' || c.type == 'resume' || c.type == 'user_done');
-    });
-  }
-
   final orderedStages = tasks.stageSequenceForOrder(task.orderId) ?? const [];
   if (orderedStages.isNotEmpty) {
     final orderedKeys = <String>[];
@@ -656,7 +644,8 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
       if (!hasPending && prevState['completed'] == true) {
         continue;
       }
-      return stageHasActivity(prevKey) || prevState['completed'] == true;
+      // Следующий этап нельзя запускать, пока предыдущий не завершён.
+      return prevState['completed'] == true;
     }
     return true;
   }


### PR DESCRIPTION
### Motivation
- Исправить баг, при котором сотрудник с другого рабочего места мог начать следующий этап заказа до того, как предыдущий этап был завершён, потому что любая «активность» предыдущего этапа считалась достаточной для разблокировки старта.

### Description
- Изменена логика в `lib/modules/tasks/tasks_screen.dart` в функции `_isFirstPendingStage` так, чтобы при наличии последовательности этапов следующий этап требовал полного завершения предыдущей группы этапов, а не просто наличия активности.
- Удалён обходной механизм проверки активности предыдущего этапа (`stageHasActivity`) и заменён на строгую проверку `prevState['completed'] == true` при принятии решения о разрешении старта.

### Testing
- Попытка запустить `flutter test test/stage_sequence_utils_test.dart` завершилась неудачей из‑за отсутствия Flutter SDK в окружении (`flutter: command not found`).
- Попытка запустить `dart test test/stage_sequence_utils_test.dart` завершилась неудачей из‑за отсутствия Dart SDK в окружении (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ceef3e90832f93b7e0bee2494d0b)