### PR TITLE
Исправить ввод пароля, автопрокрутку чата и мерцание блока файлов

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -342,148 +342,182 @@ class _LoginScreenState extends State<LoginScreen> {
   /// выполняет навигацию в нужный модуль.
   Future<void> _promptPassword(BuildContext context, _UserItem user) async {
     final TextEditingController controller = TextEditingController();
+    final FocusNode passwordFocusNode = FocusNode();
     String? error;
 
-    await showDialog(
+    Future<void> submitLogin(
+      StateSetter setDialogState,
+      BuildContext dialogContext,
+      BuildContext ctx,
+    ) async {
+      final rootNavigator = Navigator.of(context);
+      final dialogNavigator = Navigator.of(ctx);
+      final personnel = dialogContext.read<PersonnelProvider>();
+      final password = controller.text.trim();
+      if (password == user.password) {
+        // Запоминаем пользователя
+        if (user.isTechLeader) {
+          AuthHelper.setTechLeader(name: user.name);
+        } else {
+          AuthHelper.setEmployee(id: user.id, name: user.name);
+        }
+
+        // Логируем вход
+        final analytics = dialogContext.read<AnalyticsProvider>();
+        String category;
+        if (user.isTechLeader) {
+          category = 'manager';
+        } else {
+          final emp = personnel.employees.firstWhere(
+            (e) => e.id == user.id,
+            orElse: () => EmployeeModel(
+              id: user.id,
+              lastName: '',
+              firstName: '',
+              patronymic: '',
+              iin: '',
+              photoUrl: null,
+              positionIds: const [],
+              isFired: false,
+              comments: '',
+              login: '',
+              password: '',
+            ),
+          );
+          if (isManagerUser(emp, personnel)) {
+            category = 'manager';
+          } else if (isWarehouseHeadUser(emp, personnel)) {
+            category = 'warehouse';
+          } else {
+            category = 'production';
+          }
+        }
+
+        await analytics.logEvent(
+          orderId: '',
+          stageId: '',
+          userId: user.id,
+          action: 'login',
+          category: category,
+        );
+
+        if (!mounted) {
+          return;
+        }
+
+        dialogNavigator.pop();
+
+        // Навигация
+        if (user.isTechLeader) {
+          rootNavigator.pushReplacement(
+            MaterialPageRoute(
+              builder: (_) => const AdminPanelScreen(),
+            ),
+          );
+        } else {
+          final emp = personnel.employees.firstWhere(
+            (e) => e.id == user.id,
+            orElse: () => EmployeeModel(
+              id: user.id,
+              lastName: '',
+              firstName: '',
+              patronymic: '',
+              iin: '',
+              photoUrl: null,
+              positionIds: const [],
+              isFired: false,
+              comments: '',
+              login: '',
+              password: '',
+            ),
+          );
+
+          final screen = isManagerUser(emp, personnel)
+              ? ManagerWorkspaceScreen(employeeId: user.id)
+              : isWarehouseHeadUser(emp, personnel)
+                  ? WarehouseManagerWorkspaceScreen(employeeId: user.id)
+                  : EmployeeWorkspaceScreen(employeeId: user.id);
+
+          rootNavigator.pushReplacement(
+            MaterialPageRoute(builder: (_) => screen),
+          );
+        }
+      } else {
+        setDialogState(() {
+          error = 'Неверный пароль';
+        });
+      }
+    }
+
+    await showDialog<void>(
       context: context,
       barrierDismissible: false,
       builder: (ctx) {
         return StatefulBuilder(
           builder: (dialogContext, setState) {
-            return AlertDialog(
-              title: Text('Введите пароль для ${user.name}'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(
-                    controller: controller,
-                    obscureText: true,
-                    decoration: const InputDecoration(labelText: 'Пароль'),
+            return Shortcuts(
+              shortcuts: const <ShortcutActivator, Intent>{
+                SingleActivator(LogicalKeyboardKey.escape): DismissIntent(),
+                SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+                SingleActivator(LogicalKeyboardKey.numpadEnter): ActivateIntent(),
+              },
+              child: Actions(
+                actions: <Type, Action<Intent>>{
+                  DismissIntent: CallbackAction<DismissIntent>(
+                    onInvoke: (intent) {
+                      Navigator.pop(ctx);
+                      return null;
+                    },
                   ),
-                  if (error != null) ...[
-                    const SizedBox(height: 8),
-                    Text(
-                      error!,
-                      style: const TextStyle(color: Colors.red, fontSize: 12),
+                  ActivateIntent: CallbackAction<ActivateIntent>(
+                    onInvoke: (intent) {
+                      submitLogin(setState, dialogContext, ctx);
+                      return null;
+                    },
+                  ),
+                },
+                child: AlertDialog(
+                  title: Text('Введите пароль для ${user.name}'),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      TextField(
+                        controller: controller,
+                        focusNode: passwordFocusNode,
+                        autofocus: true,
+                        obscureText: true,
+                        decoration: const InputDecoration(labelText: 'Пароль'),
+                        onSubmitted: (_) =>
+                            submitLogin(setState, dialogContext, ctx),
+                      ),
+                      if (error != null) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          error!,
+                          style: const TextStyle(color: Colors.red, fontSize: 12),
+                        ),
+                      ],
+                    ],
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx),
+                      child: const Text('Отмена'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => submitLogin(setState, dialogContext, ctx),
+                      child: const Text('Войти'),
                     ),
                   ],
-                ],
+                ),
               ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(ctx),
-                  child: const Text('Отмена'),
-                ),
-                ElevatedButton(
-                  onPressed: () async {
-                    final rootNavigator = Navigator.of(context);
-                    final dialogNavigator = Navigator.of(ctx);
-                    final personnel = dialogContext.read<PersonnelProvider>();
-                    final password = controller.text.trim();
-                    if (password == user.password) {
-                      // Запоминаем пользователя
-                      if (user.isTechLeader) {
-                        AuthHelper.setTechLeader(name: user.name);
-                      } else {
-                        AuthHelper.setEmployee(id: user.id, name: user.name);
-                      }
-
-                      // Логируем вход
-                      final analytics =
-                          dialogContext.read<AnalyticsProvider>();
-                      String category;
-                      if (user.isTechLeader) {
-                        category = 'manager';
-                      } else {
-                        final emp = personnel.employees.firstWhere(
-                          (e) => e.id == user.id,
-                          orElse: () => EmployeeModel(
-                            id: user.id,
-                            lastName: '',
-                            firstName: '',
-                            patronymic: '',
-                            iin: '',
-                            photoUrl: null,
-                            positionIds: const [],
-                            isFired: false,
-                            comments: '',
-                            login: '',
-                            password: '',
-                          ),
-                        );
-                        if (isManagerUser(emp, personnel)) {
-                          category = 'manager';
-                        } else if (isWarehouseHeadUser(emp, personnel)) {
-                          category = 'warehouse';
-                        } else {
-                          category = 'production';
-                        }
-                      }
-
-                      await analytics.logEvent(
-                        orderId: '',
-                        stageId: '',
-                        userId: user.id,
-                        action: 'login',
-                        category: category,
-                      );
-
-                      if (!mounted) {
-                        return;
-                      }
-
-                      dialogNavigator.pop();
-
-                      // Навигация
-                      if (user.isTechLeader) {
-                        rootNavigator.pushReplacement(
-                          MaterialPageRoute(
-                            builder: (_) => const AdminPanelScreen(),
-                          ),
-                        );
-                      } else {
-                        final emp = personnel.employees.firstWhere(
-                          (e) => e.id == user.id,
-                          orElse: () => EmployeeModel(
-                            id: user.id,
-                            lastName: '',
-                            firstName: '',
-                            patronymic: '',
-                            iin: '',
-                            photoUrl: null,
-                            positionIds: const [],
-                            isFired: false,
-                            comments: '',
-                            login: '',
-                            password: '',
-                          ),
-                        );
-
-                        final screen = isManagerUser(emp, personnel)
-                            ? ManagerWorkspaceScreen(employeeId: user.id)
-                            : isWarehouseHeadUser(emp, personnel)
-                                ? WarehouseManagerWorkspaceScreen(
-                                    employeeId: user.id)
-                                : EmployeeWorkspaceScreen(employeeId: user.id);
-
-                        rootNavigator.pushReplacement(
-                          MaterialPageRoute(builder: (_) => screen),
-                        );
-                      }
-                    } else {
-                      setState(() {
-                        error = 'Неверный пароль';
-                      });
-                    }
-                  },
-                  child: const Text('Войти'),
-                ),
-              ],
             );
           },
         );
       },
     );
+    controller.dispose();
+    passwordFocusNode.dispose();
   }
 }
 

--- a/lib/modules/chat/chat_screen.dart
+++ b/lib/modules/chat/chat_screen.dart
@@ -31,6 +31,7 @@ class _ChatScreenState extends State<ChatScreen> {
   late ChatProvider _chat;
   bool _chatReady = false;
   final _scroll = ScrollController();
+  int _lastRenderedMessageCount = 0;
 
   Future<void> _subscribeToRoom() async {
     if (!_chatReady) return;
@@ -76,6 +77,11 @@ class _ChatScreenState extends State<ChatScreen> {
       duration: const Duration(milliseconds: 250),
       curve: Curves.easeOut,
     );
+  }
+
+  void _scrollToEndImmediately() {
+    if (!mounted || !_scroll.hasClients) return;
+    _scroll.jumpTo(_scroll.position.maxScrollExtent);
   }
 
   Future<void> _handleMenu(String value) async {
@@ -125,11 +131,20 @@ class _ChatScreenState extends State<ChatScreen> {
     return Consumer<ChatProvider>(
       builder: (context, chat, _) {
         final list = chat.messages(widget.roomId);
-        // автопрокрутка вниз при новых сообщениях
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          _scrollToEnd();
-        });
+        final hasNewMessages = list.length > _lastRenderedMessageCount;
+        _lastRenderedMessageCount = list.length;
+
+        // Автопрокрутка только когда добавились новые сообщения.
+        if (hasNewMessages) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            _scrollToEndImmediately();
+            Future<void>.delayed(const Duration(milliseconds: 50), () {
+              if (!mounted) return;
+              _scrollToEnd();
+            });
+          });
+        }
 
         final media = MediaQuery.of(context);
         final bool isTablet = media.size.shortestSide >= 600 && media.size.shortestSide < 1100;

--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -462,8 +462,17 @@ class OrderDetailsCard extends StatelessWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              if (!loadingFiles && files.isEmpty)
+                              if (files.isEmpty)
                                 const Text('Нет приложенных файлов'),
+                              if (loadingFiles && files.isNotEmpty)
+                                const Padding(
+                                  padding: EdgeInsets.only(bottom: 4),
+                                  child: SizedBox(
+                                    width: 14,
+                                    height: 14,
+                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                  ),
+                                ),
                               ...files
                                   .map((f) => _fileTile(context, f, compact: true))
                                   .toList(),


### PR DESCRIPTION
### Motivation
- Убрать постоянное мерцание в блоке «Файлы» при просмотре заказа и показать стабильный пустой состояние. 
- Обеспечить автопрокрутку чата/комментариев вниз при появлении новых сообщений. 
- Улучшить UX входа: сразу фокус на поле пароля, возможность закрыть `Esc` и отправить `Enter`/`NumpadEnter` без дополнительного клика.

### Description
- В `lib/modules/orders/order_details_card.dart` изменено условие показа пустого состояния: теперь `if (files.isEmpty)` всегда показывает `«Нет приложенных файлов»`, а индикатор загрузки отображается только когда `loadingFiles && files.isNotEmpty` (убирает мигание). 
- В `lib/modules/chat/chat_screen.dart` добавлено поле `int _lastRenderedMessageCount`, метод `_scrollToEndImmediately()` и логика, которая определяет появление новых сообщений и выполняет сначала `jumpTo`, затем короткое `animateTo` для надежной автопрокрутки. 
- В `lib/login_screen.dart` вынесена единая логика входа в `submitLogin`, добавлен `FocusNode` и `autofocus: true` для поля пароля, добавлены `Shortcuts`/`Actions` для обработки `Escape` (закрыть) и `Enter`/`NumpadEnter` (выполнить вход), и корректно освобождаются ресурсы (`controller.dispose()` и `passwordFocusNode.dispose()`). 
- Обновлён код для единообразного поведения кнопки и клавиатурных событий, чтобы избежать дублирования путей выполнения входа.

### Testing
- Попытка запустить форматирование с помощью `dart format` не удалась, так как `dart` отсутствует в `PATH` в этой среде (ошибка: `dart: command not found`).
- Изменения были зафиксированы в репозитории через `git commit` успешно (коммит создан). 
- Автоматических тестов выполнения не запускалось в этом окружении, рабочее дерево после коммита чистое (`git status` показывает нет изменений).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d32525f0832f822f4da55a1b7abd)