### PR TITLE
Fix UI flicker, comment auto-scroll, and login keyboard behavior

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -342,7 +343,112 @@ class _LoginScreenState extends State<LoginScreen> {
   /// выполняет навигацию в нужный модуль.
   Future<void> _promptPassword(BuildContext context, _UserItem user) async {
     final TextEditingController controller = TextEditingController();
+    final FocusNode passwordFocusNode = FocusNode();
     String? error;
+
+    Future<void> submitLogin(
+      BuildContext dialogContext,
+      StateSetter setState,
+      BuildContext ctx,
+    ) async {
+      final rootNavigator = Navigator.of(context);
+      final dialogNavigator = Navigator.of(ctx);
+      final personnel = dialogContext.read<PersonnelProvider>();
+      final password = controller.text.trim();
+      if (password == user.password) {
+        // Запоминаем пользователя
+        if (user.isTechLeader) {
+          AuthHelper.setTechLeader(name: user.name);
+        } else {
+          AuthHelper.setEmployee(id: user.id, name: user.name);
+        }
+
+        // Логируем вход
+        final analytics = dialogContext.read<AnalyticsProvider>();
+        String category;
+        if (user.isTechLeader) {
+          category = 'manager';
+        } else {
+          final emp = personnel.employees.firstWhere(
+            (e) => e.id == user.id,
+            orElse: () => EmployeeModel(
+              id: user.id,
+              lastName: '',
+              firstName: '',
+              patronymic: '',
+              iin: '',
+              photoUrl: null,
+              positionIds: const [],
+              isFired: false,
+              comments: '',
+              login: '',
+              password: '',
+            ),
+          );
+          if (isManagerUser(emp, personnel)) {
+            category = 'manager';
+          } else if (isWarehouseHeadUser(emp, personnel)) {
+            category = 'warehouse';
+          } else {
+            category = 'production';
+          }
+        }
+
+        await analytics.logEvent(
+          orderId: '',
+          stageId: '',
+          userId: user.id,
+          action: 'login',
+          category: category,
+        );
+
+        if (!mounted) {
+          return;
+        }
+
+        dialogNavigator.pop();
+
+        // Навигация
+        if (user.isTechLeader) {
+          rootNavigator.pushReplacement(
+            MaterialPageRoute(
+              builder: (_) => const AdminPanelScreen(),
+            ),
+          );
+        } else {
+          final emp = personnel.employees.firstWhere(
+            (e) => e.id == user.id,
+            orElse: () => EmployeeModel(
+              id: user.id,
+              lastName: '',
+              firstName: '',
+              patronymic: '',
+              iin: '',
+              photoUrl: null,
+              positionIds: const [],
+              isFired: false,
+              comments: '',
+              login: '',
+              password: '',
+            ),
+          );
+
+          final screen = isManagerUser(emp, personnel)
+              ? ManagerWorkspaceScreen(employeeId: user.id)
+              : isWarehouseHeadUser(emp, personnel)
+                  ? WarehouseManagerWorkspaceScreen(employeeId: user.id)
+                  : EmployeeWorkspaceScreen(employeeId: user.id);
+
+          rootNavigator.pushReplacement(
+            MaterialPageRoute(builder: (_) => screen),
+          );
+        }
+      } else {
+        setState(() {
+          error = 'Неверный пароль';
+        });
+      }
+    }
 
     await showDialog(
       context: context,
@@ -350,140 +456,72 @@ class _LoginScreenState extends State<LoginScreen> {
       builder: (ctx) {
         return StatefulBuilder(
           builder: (dialogContext, setState) {
-            return AlertDialog(
-              title: Text('Введите пароль для ${user.name}'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(
-                    controller: controller,
-                    obscureText: true,
-                    decoration: const InputDecoration(labelText: 'Пароль'),
+            return Shortcuts(
+              shortcuts: <ShortcutActivator, Intent>{
+                const SingleActivator(LogicalKeyboardKey.escape):
+                    const DismissIntent(),
+                const SingleActivator(LogicalKeyboardKey.enter):
+                    const ActivateIntent(),
+                const SingleActivator(LogicalKeyboardKey.numpadEnter):
+                    const ActivateIntent(),
+              },
+              child: Actions(
+                actions: <Type, Action<Intent>>{
+                  DismissIntent: CallbackAction<DismissIntent>(
+                    onInvoke: (_) {
+                      Navigator.pop(ctx);
+                      return null;
+                    },
                   ),
-                  if (error != null) ...[
-                    const SizedBox(height: 8),
-                    Text(
-                      error!,
-                      style: const TextStyle(color: Colors.red, fontSize: 12),
+                  ActivateIntent: CallbackAction<ActivateIntent>(
+                    onInvoke: (_) {
+                      submitLogin(dialogContext, setState, ctx);
+                      return null;
+                    },
+                  ),
+                },
+                child: AlertDialog(
+                  title: Text('Введите пароль для ${user.name}'),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      TextField(
+                        controller: controller,
+                        focusNode: passwordFocusNode,
+                        autofocus: true,
+                        obscureText: true,
+                        decoration: const InputDecoration(labelText: 'Пароль'),
+                        onSubmitted: (_) =>
+                            submitLogin(dialogContext, setState, ctx),
+                      ),
+                      if (error != null) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          error!,
+                          style: const TextStyle(color: Colors.red, fontSize: 12),
+                        ),
+                      ],
+                    ],
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx),
+                      child: const Text('Отмена'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => submitLogin(dialogContext, setState, ctx),
+                      child: const Text('Войти'),
                     ),
                   ],
-                ],
+                ),
               ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(ctx),
-                  child: const Text('Отмена'),
-                ),
-                ElevatedButton(
-                  onPressed: () async {
-                    final rootNavigator = Navigator.of(context);
-                    final dialogNavigator = Navigator.of(ctx);
-                    final personnel = dialogContext.read<PersonnelProvider>();
-                    final password = controller.text.trim();
-                    if (password == user.password) {
-                      // Запоминаем пользователя
-                      if (user.isTechLeader) {
-                        AuthHelper.setTechLeader(name: user.name);
-                      } else {
-                        AuthHelper.setEmployee(id: user.id, name: user.name);
-                      }
-
-                      // Логируем вход
-                      final analytics =
-                          dialogContext.read<AnalyticsProvider>();
-                      String category;
-                      if (user.isTechLeader) {
-                        category = 'manager';
-                      } else {
-                        final emp = personnel.employees.firstWhere(
-                          (e) => e.id == user.id,
-                          orElse: () => EmployeeModel(
-                            id: user.id,
-                            lastName: '',
-                            firstName: '',
-                            patronymic: '',
-                            iin: '',
-                            photoUrl: null,
-                            positionIds: const [],
-                            isFired: false,
-                            comments: '',
-                            login: '',
-                            password: '',
-                          ),
-                        );
-                        if (isManagerUser(emp, personnel)) {
-                          category = 'manager';
-                        } else if (isWarehouseHeadUser(emp, personnel)) {
-                          category = 'warehouse';
-                        } else {
-                          category = 'production';
-                        }
-                      }
-
-                      await analytics.logEvent(
-                        orderId: '',
-                        stageId: '',
-                        userId: user.id,
-                        action: 'login',
-                        category: category,
-                      );
-
-                      if (!mounted) {
-                        return;
-                      }
-
-                      dialogNavigator.pop();
-
-                      // Навигация
-                      if (user.isTechLeader) {
-                        rootNavigator.pushReplacement(
-                          MaterialPageRoute(
-                            builder: (_) => const AdminPanelScreen(),
-                          ),
-                        );
-                      } else {
-                        final emp = personnel.employees.firstWhere(
-                          (e) => e.id == user.id,
-                          orElse: () => EmployeeModel(
-                            id: user.id,
-                            lastName: '',
-                            firstName: '',
-                            patronymic: '',
-                            iin: '',
-                            photoUrl: null,
-                            positionIds: const [],
-                            isFired: false,
-                            comments: '',
-                            login: '',
-                            password: '',
-                          ),
-                        );
-
-                        final screen = isManagerUser(emp, personnel)
-                            ? ManagerWorkspaceScreen(employeeId: user.id)
-                            : isWarehouseHeadUser(emp, personnel)
-                                ? WarehouseManagerWorkspaceScreen(
-                                    employeeId: user.id)
-                                : EmployeeWorkspaceScreen(employeeId: user.id);
-
-                        rootNavigator.pushReplacement(
-                          MaterialPageRoute(builder: (_) => screen),
-                        );
-                      }
-                    } else {
-                      setState(() {
-                        error = 'Неверный пароль';
-                      });
-                    }
-                  },
-                  child: const Text('Войти'),
-                ),
-              ],
             );
           },
         );
       },
     );
+    controller.dispose();
+    passwordFocusNode.dispose();
   }
 }
 

--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -462,8 +462,12 @@ class OrderDetailsCard extends StatelessWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              if (!loadingFiles && files.isEmpty)
-                                const Text('Нет приложенных файлов'),
+                              if (files.isEmpty)
+                                Text(
+                                  loadingFiles
+                                      ? 'Загрузка файлов…'
+                                      : 'Нет приложенных файлов',
+                                ),
                               ...files
                                   .map((f) => _fileTile(context, f, compact: true))
                                   .toList(),

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -770,6 +770,9 @@ class _TasksScreenState extends State<TasksScreen>
   final Map<String, List<Map<String, dynamic>>> _orderFilesCache = {};
   final Map<String, Future<List<Map<String, dynamic>>>> _orderFilesPending = {};
   final Map<String, Map<String, _StageComment>> _orderCommentsCache = {};
+  String? _lastCommentsTaskId;
+  String _lastCommentsSignature = '';
+  int _lastCommentsCount = 0;
   String get _widKey => 'ws-${widget.employeeId}-wid';
   String get _tidKey => 'ws-${widget.employeeId}-tid';
   static const Map<TaskStatus, String> _statusLabels = {
@@ -809,6 +812,48 @@ class _TasksScreenState extends State<TasksScreen>
       _selectionUpdateScheduled = false;
       if (!mounted) return;
       update();
+    });
+  }
+
+  String _commentsSignature(List<_StageComment> comments) => comments
+      .map((entry) {
+        final c = entry.comment;
+        return '${entry.taskId}-${c.id}-${c.timestamp}-${c.type}-${c.userId}-${c.text}';
+      })
+      .join('|');
+
+  void _maybeAutoScrollComments(String taskId, List<_StageComment> comments) {
+    final signature = _commentsSignature(comments);
+    final count = comments.length;
+
+    if (_lastCommentsTaskId != taskId) {
+      _lastCommentsTaskId = taskId;
+      _lastCommentsSignature = signature;
+      _lastCommentsCount = count;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_commentsScrollController.hasClients) return;
+        _commentsScrollController.jumpTo(
+          _commentsScrollController.position.maxScrollExtent,
+        );
+      });
+      return;
+    }
+
+    if (signature == _lastCommentsSignature) return;
+
+    final hasNewComments = count > _lastCommentsCount;
+    _lastCommentsSignature = signature;
+    _lastCommentsCount = count;
+
+    if (!hasNewComments) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_commentsScrollController.hasClients) return;
+      _commentsScrollController.animateTo(
+        _commentsScrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOut,
+      );
     });
   }
 
@@ -2924,6 +2969,7 @@ class _TasksScreenState extends State<TasksScreen>
     final personnel = context.watch<PersonnelProvider>();
     final taskProvider = context.watch<TaskProvider>();
     final aggregated = _collectOrderComments(taskProvider, task);
+    _maybeAutoScrollComments(task.id, aggregated);
 
     Widget commentList() {
       if (aggregated.isEmpty) {


### PR DESCRIPTION
### Motivation
- Prevent visual flicker in order details when file list is empty or loading so the UI feels stable.
- Ensure comments view scrolls to newest items automatically when opening a task or when new comments arrive.
- Improve login dialog UX so the password field is focused immediately and common keyboard keys (`Esc`, `Enter`) behave as expected.

### Description
- In `lib/modules/orders/order_details_card.dart` show a stable placeholder when `files` is empty and render `Загрузка файлов…` while `loadingFiles` is true instead of conditionally omitting the text node.
- In `lib/modules/tasks/tasks_screen.dart` add tracking state and helpers (`_lastCommentsTaskId`, `_lastCommentsSignature`, `_lastCommentsCount`, `_commentsSignature`, `_maybeAutoScrollComments`) and call `_maybeAutoScrollComments` from `_buildCommentsPanel` to jump/animate scroll to the bottom when opening a task or when new comments are appended.
- In `lib/login_screen.dart` make the password `TextField` autofocus and add keyboard shortcuts via `Shortcuts`/`Actions` to treat `Esc` as dialog dismiss and `Enter`/`NumpadEnter` as submit; extract the login submission into a local `submitLogin` helper and dispose the created `TextEditingController` and `FocusNode`.

### Testing
- `git diff --check` passed after changes.
- `git status --short` and local commit were performed successfully.
- Attempts to run `dart format` and check `flutter` failed in this environment because `dart`/`flutter` binaries are not available, so automated formatting/build checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d32525f0832f822f4da55a1b7abd)