### PR TITLE
Fix flicker in empty files row on order details card

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -12,7 +12,6 @@ class OrderDetailsCard extends StatelessWidget {
     required this.order,
     required this.paints,
     required this.files,
-    required this.loadingFiles,
     required this.stageTemplateName,
     this.formImageUrl,
     this.extraSections = const <Widget>[],
@@ -21,7 +20,6 @@ class OrderDetailsCard extends StatelessWidget {
   final OrderModel order;
   final List<Map<String, dynamic>> paints;
   final List<Map<String, dynamic>> files;
-  final bool loadingFiles;
   final String? stageTemplateName;
   final String? formImageUrl;
   final List<Widget> extraSections;
@@ -464,9 +462,7 @@ class OrderDetailsCard extends StatelessWidget {
                             children: [
                               if (files.isEmpty)
                                 Text(
-                                  loadingFiles
-                                      ? 'Загрузка файлов…'
-                                      : 'Нет приложенных файлов',
+                                  'Нет приложенных файлов',
                                 ),
                               ...files
                                   .map((f) => _fileTile(context, f, compact: true))

--- a/lib/modules/orders/view_order_screen.dart
+++ b/lib/modules/orders/view_order_screen.dart
@@ -160,7 +160,6 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
                         order: o,
                         paints: _paints,
                         files: _files,
-                        loadingFiles: _loadingFiles,
                         stageTemplateName: _stageTemplateName,
                         formImageUrl: _formImageUrl,
                       ),


### PR DESCRIPTION
### Motivation
- Prevent visible blinking in the "Файлы" row when attachments are being loaded but none are present by removing the transient loading text.

### Description
- Removed the `loadingFiles` parameter and field from `OrderDetailsCard` and its constructor.
- Always render the fixed message `'Нет приложенных файлов'` when the `files` list is empty, instead of switching between `'Загрузка файлов…'` and the empty message.
- Updated the `ViewOrderDialog` call site to stop passing the removed `loadingFiles` argument.
- Modified files: `lib/modules/orders/order_details_card.dart`, `lib/modules/orders/view_order_screen.dart`.

### Testing
- Attempted to run `dart format` on the modified files via `dart format lib/modules/orders/order_details_card.dart lib/modules/orders/view_order_screen.dart`, which failed because the `dart` binary is not available in the environment.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d665b890832fa2e49a3cfa7dbef0)