### PR TITLE
Remove obsolete `loadingFiles` argument from OrderDetailsCard usages

### DIFF
--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -864,7 +864,6 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                             order: widget.order,
                             paints: _paints,
                             files: _files,
-                            loadingFiles: _loadingFiles,
                             stageTemplateName: _stageTemplateName,
                           ),
                         ),

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3254,9 +3254,6 @@ class _TasksScreenState extends State<TasksScreen>
                 order: order,
                 paints: resolvedPaints,
                 files: resolvedFiles,
-                loadingFiles:
-                    snapshot.connectionState == ConnectionState.waiting &&
-                        resolvedFiles.isEmpty,
                 stageTemplateName: templateName,
                 formImageUrl: resolvedFormImageUrl,
                 extraSections: [


### PR DESCRIPTION
### Motivation
- Project build failed with errors like `No named parameter with the name 'loadingFiles'` because `OrderDetailsCard` no longer accepts a `loadingFiles` named argument.

### Description
- Removed the obsolete `loadingFiles` named argument from `OrderDetailsCard` usage in `lib/modules/tasks/tasks_screen.dart`.
- Removed the obsolete `loadingFiles` named argument from `OrderDetailsCard` usage in `lib/modules/production/production_details_screen.dart`.
- Ensures call sites match the current `OrderDetailsCard` constructor signature to fix compile-time errors.

### Testing
- Searched the codebase with `rg -n "loadingFiles\s*:" lib -g '*.dart'` and found no remaining `loadingFiles:` usages, indicating the problematic calls were removed.
- Attempted `flutter analyze` but it could not be run in this environment because `flutter` is not installed (`/bin/bash: flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d7e20b04832fb497b1a2cdc8c365)