### PR TITLE
Handle storage paths and cache-busting for form images in order details

### DIFF
--- a/lib/modules/orders/view_order_screen.dart
+++ b/lib/modules/orders/view_order_screen.dart
@@ -24,6 +24,26 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
   String? _stageTemplateName;
   String? _formImageUrl;
 
+  String? _buildFormImageUrl(String? rawUrl, {String? updatedAt}) {
+    final trimmed = rawUrl?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+
+    String resolvedUrl = trimmed;
+    if (!(trimmed.startsWith('http://') || trimmed.startsWith('https://'))) {
+      resolvedUrl = Supabase.instance.client.storage.from('tmc').getPublicUrl(trimmed);
+    }
+
+    final dt = DateTime.tryParse(updatedAt ?? '');
+    if (dt == null) return resolvedUrl;
+
+    final uri = Uri.tryParse(resolvedUrl);
+    if (uri == null) return resolvedUrl;
+
+    final query = Map<String, String>.from(uri.queryParameters);
+    query['v'] = dt.millisecondsSinceEpoch.toString();
+    return uri.replace(queryParameters: query).toString();
+  }
+
   @override
   void initState() {
     super.initState();
@@ -50,7 +70,7 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
       if (formCode != null && formCode.isNotEmpty) {
         final res = await Supabase.instance.client
             .from('forms')
-            .select('image_url')
+            .select('image_url, updated_at')
             .eq('code', formCode)
             .maybeSingle();
         if (res != null && res is Map) {
@@ -63,7 +83,7 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
           formNo != null) {
         final res = await Supabase.instance.client
             .from('forms')
-            .select('image_url')
+            .select('image_url, updated_at')
             .eq('series', formSeries)
             .eq('number', formNo)
             .maybeSingle();
@@ -71,10 +91,10 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
           form = Map<String, dynamic>.from(res);
         }
       }
-      final imageUrl = (form?['image_url'] ?? '').toString().trim();
-      if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
-        formImageUrl = imageUrl;
-      }
+      formImageUrl = _buildFormImageUrl(
+        form?['image_url']?.toString(),
+        updatedAt: form?['updated_at']?.toString(),
+      );
       String? stageTemplateName;
       final tplId = widget.order.stageTemplateId;
       if (tplId != null && tplId.isNotEmpty) {


### PR DESCRIPTION
### Motivation
- Form photos in the workspace order details could be missing when `forms.image_url` contains a storage-relative path instead of a full HTTP URL, and replacing an image at the same path could leave clients showing a cached old picture.

### Description
- Added `_buildFormImageUrl` which normalizes `image_url` values and converts storage-relative paths to a public URL via `Supabase.instance.client.storage.from('tmc').getPublicUrl(...)`.
- Modified `forms` queries to select `updated_at` together with `image_url` and appended a cache-busting `v` query parameter derived from `updated_at` to the image URL.
- Replaced the previous ad-hoc image URL handling in `_load()` with the new helper and wire the resolved URL into `_formImageUrl` used by `OrderDetailsCard`.

### Testing
- Tried to run `dart format lib/modules/orders/view_order_screen.dart`, but the command failed because `dart` is not installed in this environment.
- Tried `flutter --version` to validate tooling, but the command failed because `flutter` is not installed in this environment.
- Code changes were committed locally; no runtime or Flutter automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1da2ce0dc832f9a3ac534fdb2055d)