### PR TITLE
Fix paper editing/representation, compact paper-change comments, and shift-change paper-edit flow

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -289,7 +289,9 @@ class OrderDetailsCard extends StatelessWidget {
       return value == null ? '' : _fmtNum(value);
     }
     final value = _paperExtraDouble(material, 'lengthL');
-    return value == null ? '' : _fmtNum(value);
+    if (value != null) return _fmtNum(value);
+    if (material.quantity > 0) return _fmtNum(material.quantity);
+    return '';
   }
 
   String _paperQuantityValue(MaterialModel material, int index) {
@@ -501,7 +503,14 @@ class OrderDetailsCard extends StatelessWidget {
                             }
                             if (material.grammage != null &&
                                 material.grammage!.isNotEmpty) {
-                              parts.add('${material.grammage} гр');
+                              final formattedGrammage =
+                                  '${material.grammage} гр';
+                              if (parts.isNotEmpty) {
+                                final last = parts.removeLast();
+                                parts.add('$last / $formattedGrammage');
+                              } else {
+                                parts.add(formattedGrammage);
+                              }
                             }
                             final materialLine =
                                 parts.isEmpty ? '—' : parts.join(' ');
@@ -514,7 +523,7 @@ class OrderDetailsCard extends StatelessWidget {
                             }
                             if (qtyValue.isNotEmpty || lenValue.isNotEmpty) {
                               if (qtyValue.isNotEmpty && lenValue.isNotEmpty) {
-                                details.add('Д: $qtyValue * $lenValue L');
+                                details.add('Д: $qtyValue (L: $lenValue)');
                               } else if (qtyValue.isNotEmpty) {
                                 details.add('Д: $qtyValue');
                               } else {

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1629,9 +1629,9 @@ class OrdersProvider with ChangeNotifier {
       final format = (m.format ?? '').trim();
       final grammage = (m.grammage ?? '').trim();
       final suffix = [
-        if (format.isNotEmpty) format,
-        if (grammage.isNotEmpty) grammage,
-      ].join(', ');
+        if (format.isNotEmpty) 'Ф $format',
+        if (grammage.isNotEmpty) 'Гр $grammage',
+      ].join(' / ');
       return suffix.isEmpty ? m.name : '${m.name} ($suffix)';
     }
 

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1247,12 +1247,15 @@ class _TasksScreenState extends State<TasksScreen>
     required String reason,
   }) {
     String paperLabel(MaterialModel material) {
+      final format = (material.format ?? '').trim();
+      final grammage = (material.grammage ?? '').trim();
+      final shortMeta = <String>[
+        if (format.isNotEmpty) 'Ф $format',
+        if (grammage.isNotEmpty) 'Гр $grammage',
+      ].join(' / ');
       final parts = <String>[
         material.name.trim().isEmpty ? 'Без названия' : material.name.trim(),
-        if ((material.format ?? '').trim().isNotEmpty)
-          'формат ${(material.format ?? '').trim()}',
-        if ((material.grammage ?? '').trim().isNotEmpty)
-          'грамаж ${(material.grammage ?? '').trim()}',
+        if (shortMeta.isNotEmpty) shortMeta,
       ];
       return parts.join(', ');
     }
@@ -1711,6 +1714,11 @@ class _TasksScreenState extends State<TasksScreen>
                               nextExtra.remove('blQuantity');
                             } else {
                               nextExtra['blQuantity'] = parsedBlQuantity;
+                            }
+                            if (qty <= 0) {
+                              nextExtra.remove('lengthL');
+                            } else {
+                              nextExtra['lengthL'] = qty;
                             }
                             nextLengthL ??= qty;
                             if (i == 0) {
@@ -4911,12 +4919,30 @@ class _TasksScreenState extends State<TasksScreen>
                         );
                         final unitLabel =
                             _workplaceUnit(personnel, task.stageId);
-                        final qtyInput =
-                            await _askQuantity(
-                          context,
-                          unit: unitLabel,
-                          allowPaperEdit: true,
-                        );
+                        _QuantityInput? qtyInput;
+                        while (true) {
+                          qtyInput = await _askQuantity(
+                            context,
+                            unit: unitLabel,
+                            allowPaperEdit: true,
+                          );
+                          if (qtyInput == null) return;
+                          if (!qtyInput.openPaperEditor) break;
+                          final order = _orderById(task.orderId);
+                          if (order == null) {
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                  content: Text(
+                                    'Не удалось найти заказ для редактирования бумаги.',
+                                  ),
+                                ),
+                              );
+                            }
+                            return;
+                          }
+                          await _openPaperEditDialog(order);
+                        }
                         if (qtyInput == null) return;
                         final qtyText = qtyInput.displayText;
                         final helperIds = jointGroup != null && isMyRow
@@ -4978,8 +5004,7 @@ class _TasksScreenState extends State<TasksScreen>
                                 rel.id, TaskStatus.paused);
                           }
                         }
-                        await recordTimeEventForUser(TaskTimeType.shiftChange,
-                            includeHelpers: false);
+                        await recordTimeEventForUser(TaskTimeType.shiftChange);
                         await taskProvider.addCommentAutoUser(
                             taskId: task.id,
                             type: 'shift_pause_state',


### PR DESCRIPTION
### Motivation
- Устранить неконсистентное поведение при редактировании бумаги в рабочих пространствах: длина/метраж не должна интерпретироваться как множитель и не должна теряться при добавлении бумаги. 
- Сделать комментарии об изменении бумаги компактнее и читаемее для производства и логов. 
- Исправить баг пересмены: при выборе «Изменить бумагу» диалог пересмены должен корректно возвращать пользователя в ввод количества и правильно учитывать помощников.

### Description
- Всю логику записи метаданных бумаги в рабочем редакторе обновил так, что при сохранении в `extra` для слота всегда устанавливается `lengthL` (если qty>0) или удаляется (если qty<=0), чтобы длина не терялась при переходе в управление/резерв (файл: `lib/modules/tasks/tasks_screen.dart`).
- Изменил форматирование комментариев об изменении бумаги на компактные метки `Ф <format>` и `Гр <grammage>` в рабочем пространстве и в логе заказа (файлы: `lib/modules/tasks/tasks_screen.dart`, `lib/modules/orders/orders_provider.dart`).
- В карточке деталей заказа изменил отображение бумаги: между форматом и граммажем используется слеш `/`, при показе длины для дополнительных слотов используется fallback на `material.quantity` если `lengthL` отсутствует, и визуал убрал символ `*` (теперь `Д: <qty> (L: <len>)`) (файл: `lib/modules/orders/order_details_card.dart`).
- Исправил поток пересмены в `tasks_screen.dart`: при выборе «Изменить бумагу» диалог теперь заново открывает редактор бумаги и после возврата повторно запрашивает количество (вместо прежнего поведения, которое могло продолжить пересмену без корректного ввода); также вызов `recordTimeEventForUser` теперь вызывается без `includeHelpers: false`, чтобы учитывать помощников при записи времени.

### Testing
- Попытка прогнать автоформаттер: `dart format lib/modules/tasks/tasks_screen.dart lib/modules/orders/order_details_card.dart lib/modules/orders/orders_provider.dart` не выполнена из-за отсутствия `dart` в окружении (`/bin/bash: dart: command not found`).
- Попытка запустить тесты: `flutter test` не выполнена из-за отсутствия `flutter` в окружении (`/bin/bash: flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ecdc36b4832faf4979e3ef3c4a30)