### PR TITLE
Fix resuming stage after reporting a problem

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4353,12 +4353,15 @@ class _TasksScreenState extends State<TasksScreen>
                             task.comments.any((c) => c.type == 'shift_resume');
                     final bool hasOpenStartIntentForRowUser =
                         _hasOpenStartIntentForUser(task, currentRowUserId);
+                    final bool shouldBlockStartByOpenIntent =
+                        hasOpenStartIntentForRowUser &&
+                            stateRowUser == UserRunState.idle;
                     final bool canStartButtonRow = isMyRow &&
                         canStart &&
                         !_startingTaskIds.contains(task.id) &&
                         !requiresSetupBeforeStart &&
                         !stageStartedBeforeShiftResume &&
-                        !hasOpenStartIntentForRowUser &&
+                        !shouldBlockStartByOpenIntent &&
                         // Для отдельных исполнителей разрешаем возобновлять этап
                         // после личного завершения (до финальной кнопки
                         // "Завершить задание").


### PR DESCRIPTION
### Motivation
- Employees who reported a problem could not resume the stage because an existing "open start intent" blocked the row-level start control even when the user was in resumable states (e.g., `problem`); this change makes resuming possible.

### Description
- Add a local flag `shouldBlockStartByOpenIntent` and update `canStartButtonRow` in `lib/modules/tasks/tasks_screen.dart` so an open start intent only blocks new starts when the user's run state is `idle`.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` and `flutter test test/stage_sequence_utils_test.dart`, but the environment lacks the `dart`/Flutter SDK so automated tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1fe1769fc832f9c75833b760429b2)