### PR TITLE
Allow progressing to next stage after marking previous as problem

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -606,15 +606,19 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
   // Сгруппировать по этапу; фиксируем и незавершённые, и уже завершённые
   // альтернативы, чтобы не блокировать последующие этапы, когда одна из
   // альтернатив завершена.
-  final stages = <String, Map<String, bool>>{}; // stageId -> {pending, completed}
+  final stages = <String, Map<String, bool>>{}; // stageId -> {pending, completed, problem}
   for (final t in all) {
     final completed = _isEffectivelyCompleted(t);
     final pending = !completed;
+    final problem = t.status == TaskStatus.problem ||
+        t.comments.any((c) => c.type == 'problem');
     final key = _groupKey(t.stageId);
-    final current = stages[key] ?? {'pending': false, 'completed': false};
+    final current = stages[key] ??
+        {'pending': false, 'completed': false, 'problem': false};
     stages[key] = {
       'pending': current['pending'] == true || pending,
       'completed': current['completed'] == true || completed,
+      'problem': current['problem'] == true || problem,
     };
   }
 
@@ -641,11 +645,13 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
 
       // Ищем ближайший реально существующий предыдущий этап.
       final hasPending = prevState['pending'] == true;
+      final hasProblem = prevState['problem'] == true;
       if (!hasPending && prevState['completed'] == true) {
         continue;
       }
-      // Следующий этап нельзя запускать, пока предыдущий не завершён.
-      return prevState['completed'] == true;
+      // Следующий этап нельзя запускать, пока предыдущий не завершён,
+      // кроме случаев, когда предыдущий переведён в "Проблему".
+      return prevState['completed'] == true || hasProblem;
     }
     return true;
   }


### PR DESCRIPTION
### Motivation
- Fix the issue where after an employee marks a stage as `problem` they cannot continue to the next stage, by treating a previous stage in `problem` state as allowable for unlocking the next stage. 

### Description
- Updated `_isFirstPendingStage` in `lib/modules/tasks/tasks_screen.dart` to aggregate a `problem` flag per stage group and include comments of type `problem` when determining group state. 
- Adjusted the ordered-stage check to treat a previous group's `problem` state as equivalent to allowing progression even if it is not `completed`. 
- Kept existing completion and pending checks intact so only the intended exception (previous `problem`) is added.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart`, but the `dart` CLI is not available in the current environment (failed). 
- Attempted to run `flutter --version` to validate toolchain availability, but the `flutter` CLI is not available in the current environment (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1fe1769fc832f9c75833b760429b2)