### PR TITLE
Prevent concurrent stage starts; allow resume after problem/shift

### DIFF
--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -863,14 +863,14 @@ class TaskProvider with ChangeNotifier {
     }
   }
 
-  Future<void> updateStatus(
+  Future<bool> updateStatus(
     String id,
     TaskStatus status, {
     int? spentSeconds,
     int? startedAt,
   }) async {
     final index = _tasks.indexWhere((t) => t.id == id);
-    if (index == -1) return;
+    if (index == -1) return false;
 
     final current = _tasks[index];
     final updated = current.copyWith(
@@ -880,31 +880,67 @@ class TaskProvider with ChangeNotifier {
       comments: current.comments,
       assignees: current.assignees,
     );
-    _tasks[index] = updated;
-    notifyListeners();
 
     final updates = <String, dynamic>{
       'status': status.name,
       'spent_seconds': updated.spentSeconds,
       'started_at': updated.startedAt,
-      'updated_at': 'now()',
     };
     final bool becameInProgress =
-        current.status == TaskStatus.waiting && status == TaskStatus.inProgress;
-    if (becameInProgress) {
-      final capturedAt = DateTime.now().millisecondsSinceEpoch;
+        current.status != TaskStatus.inProgress && status == TaskStatus.inProgress;
+    final int? capturedAt =
+        becameInProgress ? DateTime.now().millisecondsSinceEpoch : null;
+    if (capturedAt != null) {
       updates['captured_by_workplace_id'] = current.stageId;
       updates['captured_at'] = capturedAt;
-      _tasks[index] = updated.copyWith(
-        capturedByWorkplaceId: current.stageId,
-        capturedAt: capturedAt,
-      );
-      notifyListeners();
+    }
+
+    Map<String, dynamic>? persistedRow;
+    try {
+      PostgrestFilterBuilder<List<Map<String, dynamic>>> query =
+          _supabase.from('tasks').update(updates).eq('id', id);
+      if (capturedAt != null) {
+        query = query.or(
+          'captured_by_workplace_id.is.null,captured_by_workplace_id.eq.${current.stageId}',
+        );
+      }
+      final rows = await query.select();
+      if (rows.isEmpty) return false;
+      persistedRow = Map<String, dynamic>.from(rows.first);
+    } catch (e, st) {
+      debugPrint('❌ tasks.updateStatus error: $e\n$st');
+      return false;
+    }
+
+    _tasks[index] = _rowToTask(persistedRow);
+    notifyListeners();
+
+    if (capturedAt != null) {
       // Если этап состоит из нескольких рабочих мест (одна группа),
-      // первый старт фиксирует "захват" для всех задач группы.
+      // первый старт фиксирует "захват" для всех задач группы
+      // и валидирует, что параллельного запуска конкурирующего места не произошло.
       final groupKey = current.stageGroupKey.trim();
       if (groupKey.isNotEmpty) {
         try {
+          final conflicts = await _supabase
+              .from('tasks')
+              .select('id')
+              .eq('order_id', current.orderId)
+              .eq('stage_group_key', groupKey)
+              .not('captured_by_workplace_id', 'is', null)
+              .neq('captured_by_workplace_id', current.stageId)
+              .limit(1);
+          if ((conflicts as List).isNotEmpty) {
+            await _supabase.from('tasks').update({
+              'status': current.status.name,
+              'started_at': current.startedAt,
+              'captured_by_workplace_id': current.capturedByWorkplaceId,
+              'captured_at': current.capturedAt,
+            }).eq('id', current.id);
+            await refresh();
+            return false;
+          }
+
           await _supabase
               .from('tasks')
               .update({
@@ -931,23 +967,19 @@ class TaskProvider with ChangeNotifier {
         }
       }
     }
-    try {
-      await _supabase.from('tasks').update(updates).eq('id', id);
-      // if this task just became completed — check last-stage and update actual_qty
-      if (status == TaskStatus.completed) {
-        final orderId = updated.orderId;
-        final stageId = updated.stageId;
-        if (orderId.isNotEmpty && stageId.isNotEmpty) {
-          await _maybeUpdateActualQtyAfterStage(orderId, stageId);
-        }
+
+    // if this task just became completed — check last-stage and update actual_qty
+    if (status == TaskStatus.completed) {
+      final orderId = updated.orderId;
+      final stageId = updated.stageId;
+      if (orderId.isNotEmpty && stageId.isNotEmpty) {
+        await _maybeUpdateActualQtyAfterStage(orderId, stageId);
       }
-    } catch (e, st) {
-      debugPrint('❌ tasks.updateStatus error: $e\n$st');
     }
 
     // If all stage groups for order are finally completed — close the order
     final orderId = updated.orderId;
-    if (orderId != null && orderId.isNotEmpty) {
+    if (orderId.isNotEmpty) {
       try {
         final rows = await _supabase
             .from('tasks')
@@ -963,6 +995,8 @@ class TaskProvider with ChangeNotifier {
         }
       } catch (_) {}
     }
+
+    return true;
   }
 
   Future<void> addComment(

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4357,13 +4357,16 @@ class _TasksScreenState extends State<TasksScreen>
                     final bool stageStartedBeforeShiftResume =
                         _hasProductionStartedForStage(task) &&
                             task.comments.any((c) => c.type == 'shift_resume');
+                    final bool blockedByShiftResumeLock =
+                        stageStartedBeforeShiftResume &&
+                            stateRowUser == UserRunState.idle;
                     final bool hasOpenStartIntentForRowUser =
                         _hasOpenStartIntentForUser(task, currentRowUserId);
                     final bool canStartButtonRow = isMyRow &&
                         canStart &&
                         !_startingTaskIds.contains(task.id) &&
                         !requiresSetupBeforeStart &&
-                        !stageStartedBeforeShiftResume &&
+                        !blockedByShiftResumeLock &&
                         !hasOpenStartIntentForRowUser &&
                         // Для отдельных исполнителей разрешаем возобновлять этап
                         // после личного завершения (до финальной кнопки
@@ -4560,11 +4563,20 @@ class _TasksScreenState extends State<TasksScreen>
                         }
                         final startedAtTs =
                             task.startedAt ?? DateTime.now().millisecondsSinceEpoch;
-                        await taskProvider.updateStatus(
+                        final started = await taskProvider.updateStatus(
                           task.id,
                           TaskStatus.inProgress,
                           startedAt: startedAtTs,
                         );
+                        if (!started) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                              content: Text(
+                                  'Этап уже запущен другим сотрудником. Обновите список и продолжите работу в активном этапе.'),
+                            ));
+                          }
+                          return;
+                        }
                         final isResumeAction = stateRowUser == UserRunState.paused ||
                             stateRowUser == UserRunState.problem;
                         await taskProvider.addCommentAutoUser(


### PR DESCRIPTION
### Motivation
- Fix a workflow bug where reporting a `problem` then performing a shift handover could block the assignee from continuing production. 
- Prevent a race where two employees/workplaces could start the same stage simultaneously and leave the system in an inconsistent/unrecoverable state. 

### Description
- Change `TaskProvider.updateStatus` to return `bool` and perform a DB-first, conditional update to reliably gate starting a task when capturing `captured_by_workplace_id` (file: `lib/modules/tasks/task_provider.dart`).
- Add detection of conflicting stage-group captures by checking other tasks with the same `stage_group_key`, rollback local start state and call `refresh()` when a competing capture is detected (file: `lib/modules/tasks/task_provider.dart`).
- Update the UI start flow to check the boolean result from `updateStatus` and abort further side-effects (no comments/time events) and show a friendly `SnackBar` when the start lost the race (file: `lib/modules/tasks/tasks_screen.dart`).
- Relax the `shift_resume` blocking rule so that users in `paused` or `problem` states may resume production even if a `shift_resume` marker exists, while still preventing `idle` users from incorrectly starting (file: `lib/modules/tasks/tasks_screen.dart`).

### Testing
- Ran `git status --short` to confirm changed files were staged and committed (succeeded). 
- Attempted `dart format lib/modules/tasks/task_provider.dart lib/modules/tasks/tasks_screen.dart` but `dart` was not available in the environment (failed: `dart: command not found`).
- Attempted `flutter --version` to inspect SDK but `flutter` was not available in the environment (failed: `flutter: command not found`).
- No automated unit tests were executed in this environment; start flow and race handling were implemented defensively to return explicit success/failure for callers to act on.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e207afe418832fa5dd483a9574c4fc)