### PR TITLE
Fix workspace paper edit comments and field order

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -562,7 +562,7 @@ class OrdersProvider with ChangeNotifier {
       product: nextProduct,
       paperMaterials: prepared,
       material: prepared.first,
-      comments: trimmedReason,
+      comments: prev.comments,
     );
 
     if (!_hasPaperCompositionChanged(previous: prev, updated: updated)) {
@@ -1635,6 +1635,33 @@ class OrdersProvider with ChangeNotifier {
       return suffix.isEmpty ? m.name : '${m.name} ($suffix)';
     }
 
+    double _paperWidthB(MaterialModel m) {
+      final raw = m.extra?['widthB'];
+      if (raw is num) return raw.toDouble();
+      return double.tryParse((raw ?? '').toString().replaceAll(',', '.')) ?? 0;
+    }
+
+    String _paperBlQuantity(MaterialModel m, {String fallback = ''}) =>
+        (m.extra?['blQuantity'] ?? fallback).toString().trim();
+
+    String _paperMetrics(
+      MaterialModel m, {
+      double? fallbackWidthB,
+      String? fallbackBlQuantity,
+    }) {
+      final parsedWidthB = _paperWidthB(m);
+      final widthB = parsedWidthB > 0 ? parsedWidthB : (fallbackWidthB ?? 0);
+      final blQuantity = _paperBlQuantity(
+        m,
+        fallback: (fallbackBlQuantity ?? '').trim(),
+      );
+      final lengthL = m.quantity;
+      final widthText =
+          widthB > 0 ? widthB.toStringAsFixed(widthB % 1 == 0 ? 0 : 2) : '—';
+      final quantityText = blQuantity.isNotEmpty ? blQuantity : '—';
+      return 'Ш $widthText, К $quantityText, Длина L ${lengthL.toStringAsFixed(2)} м';
+    }
+
     final user = (AuthHelper.currentUserName ?? 'Сотрудник').trim();
     final timestamp = fmtDate(DateTime.now());
     final maxCount = before.length > after.length ? before.length : after.length;
@@ -1648,17 +1675,17 @@ class OrdersProvider with ChangeNotifier {
         final delta = next.quantity - old.quantity;
         final deltaPrefix = delta >= 0 ? '+' : '';
         buffer.writeln(
-          'Бумага №$slot: было ${materialName(old)} — ${old.quantity.toStringAsFixed(2)} м, '
-          'стало ${materialName(next)} — ${next.quantity.toStringAsFixed(2)} м '
+          'Бумага №$slot: было ${materialName(old)} — ${_paperMetrics(old, fallbackWidthB: i == 0 ? previous.product.widthB : null, fallbackBlQuantity: i == 0 ? previous.product.blQuantity : null)}, '
+          'стало ${materialName(next)} — ${_paperMetrics(next, fallbackWidthB: i == 0 ? updated.product.widthB : null, fallbackBlQuantity: i == 0 ? updated.product.blQuantity : null)} '
           '($deltaPrefix${delta.toStringAsFixed(2)} м)',
         );
       } else if (old == null && next != null) {
         buffer.writeln(
-          'Добавлена бумага №$slot: ${materialName(next)} — ${next.quantity.toStringAsFixed(2)} м',
+          'Добавлена бумага №$slot: ${materialName(next)} — ${_paperMetrics(next, fallbackWidthB: i == 0 ? updated.product.widthB : null, fallbackBlQuantity: i == 0 ? updated.product.blQuantity : null)}',
         );
       } else if (old != null && next == null) {
         buffer.writeln(
-          'Удалена бумага №$slot: ${materialName(old)} — ${old.quantity.toStringAsFixed(2)} м',
+          'Удалена бумага №$slot: ${materialName(old)} — ${_paperMetrics(old, fallbackWidthB: i == 0 ? previous.product.widthB : null, fallbackBlQuantity: i == 0 ? previous.product.blQuantity : null)}',
         );
       }
     }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1266,8 +1266,20 @@ class _TasksScreenState extends State<TasksScreen>
       return parts.join(', ');
     }
 
-    String qtyText(MaterialModel material) =>
-        '${material.quantity.toStringAsFixed(2)} м';
+    String qtyText(MaterialModel material) {
+      double? asDouble(dynamic raw) {
+        if (raw is num) return raw.toDouble();
+        return double.tryParse((raw ?? '').toString().replaceAll(',', '.'));
+      }
+
+      final widthB = asDouble(material.extra?['widthB']);
+      final blQuantity = (material.extra?['blQuantity'] ?? '').toString().trim();
+      final widthText = widthB == null || widthB <= 0
+          ? '—'
+          : (widthB % 1 == 0 ? widthB.toStringAsFixed(0) : widthB.toStringAsFixed(2));
+      final quantityText = blQuantity.isEmpty ? '—' : blQuantity;
+      return 'Ш $widthText, К $quantityText, Длина L ${material.quantity.toStringAsFixed(2)} м';
+    }
 
     final lines = <String>[
       'Изменение бумаги из рабочего пространства.',
@@ -1554,27 +1566,6 @@ class _TasksScreenState extends State<TasksScreen>
                                 const SizedBox(width: 12),
                                 Expanded(
                                   child: TextFormField(
-                                    controller: qtyControllers[i],
-                                    keyboardType: const TextInputType.numberWithOptions(
-                                      decimal: true,
-                                    ),
-                                    decoration: const InputDecoration(
-                                      labelText: 'Длина L (м)',
-                                    ),
-                                    validator: (value) {
-                                      final normalized =
-                                          (value ?? '').trim().replaceAll(',', '.');
-                                      final qty = double.tryParse(normalized);
-                                      if (qty == null || qty <= 0) {
-                                        return 'Введите > 0';
-                                      }
-                                      return null;
-                                    },
-                                  ),
-                                ),
-                                const SizedBox(width: 12),
-                                Expanded(
-                                  child: TextFormField(
                                     controller: widthBControllers[i],
                                     keyboardType: const TextInputType.numberWithOptions(
                                       decimal: true,
@@ -1591,6 +1582,27 @@ class _TasksScreenState extends State<TasksScreen>
                                     decoration: const InputDecoration(
                                       labelText: 'Количество бумаги',
                                     ),
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: qtyControllers[i],
+                                    keyboardType: const TextInputType.numberWithOptions(
+                                      decimal: true,
+                                    ),
+                                    decoration: const InputDecoration(
+                                      labelText: 'Длина L (м)',
+                                    ),
+                                    validator: (value) {
+                                      final normalized =
+                                          (value ?? '').trim().replaceAll(',', '.');
+                                      final qty = double.tryParse(normalized);
+                                      if (qty == null || qty <= 0) {
+                                        return 'Введите > 0';
+                                      }
+                                      return null;
+                                    },
                                   ),
                                 ),
                                 if (i > 0)


### PR DESCRIPTION
### Motivation
- Preserve the existing order-level `comments` when a paper edit is performed from the workplace so the employee-entered reason does not overwrite the order comment field.
- Make workspace paper edit UI fields appear in the requested order: `Ширина b`, `Количество бумаги`, then `Длина L`.
- Include paper metrics (width `Ш`, count `К`, and `Длина L`) in generated workspace and order-change comments so the history and workplace messages contain the missing values.

### Description
- In `lib/modules/orders/orders_provider.dart` stop overwriting `orders.comments` by using `comments: prev.comments` when building the updated order, and add helpers `_paperWidthB`, `_paperBlQuantity`, and `_paperMetrics` to render paper metrics and use product-level fallbacks for the primary paper.
- Replace numeric-only length output in `_describePaperChanges` with the new `Ш <width>, К <count>, Длина L <length>` format and wire fallbacks for the first-paper `widthB`/`blQuantity` to show proper values when extras are missing.
- In `lib/modules/tasks/tasks_screen.dart` change `_buildWorkspacePaperChangeComment` to include the `Ш/К/Длина L` metric string and update its internal `qtyText` helper accordingly.
- Reorder the paper-edit dialog fields and controllers so the visible order and labels are `Ширина b` (uses `widthBControllers`), `Количество бумаги` (uses `blQuantityControllers`), and `Длина L (м)` (uses `qtyControllers`), and move the validation to the length input.

### Testing
- Ran `git diff --check` to validate whitespace/diff issues and it succeeded.
- Attempted to run `dart format` for the modified files but `dart`/`flutter` is not available in this environment so auto-formatting/analysis was not executed.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e209af8c8c832f90e666ffb8addc9f)