### PR TITLE
Fix Supabase query builder type mismatch in task status update

### DIFF
--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -897,14 +897,14 @@ class TaskProvider with ChangeNotifier {
 
     Map<String, dynamic>? persistedRow;
     try {
-      PostgrestFilterBuilder<List<Map<String, dynamic>>> query =
-          _supabase.from('tasks').update(updates).eq('id', id);
-      if (capturedAt != null) {
-        query = query.or(
-          'captured_by_workplace_id.is.null,captured_by_workplace_id.eq.${current.stageId}',
-        );
-      }
-      final rows = await query.select();
+      final baseQuery = _supabase.from('tasks').update(updates).eq('id', id);
+      final rows = await (capturedAt != null
+          ? baseQuery
+              .or(
+                'captured_by_workplace_id.is.null,captured_by_workplace_id.eq.${current.stageId}',
+              )
+              .select()
+          : baseQuery.select());
       if (rows.isEmpty) return false;
       persistedRow = Map<String, dynamic>.from(rows.first);
     } catch (e, st) {


### PR DESCRIPTION
### Motivation
- The Windows build failed with a type error caused by assigning a `PostgrestFilterBuilder<dynamic>` to a `PostgrestFilterBuilder<List<Map<String, dynamic>>>` when updating task status, so the update logic needed to be made type-safe.

### Description
- Replaced the strongly-typed mutable `query` variable with a `final baseQuery = _supabase.from('tasks').update(updates).eq('id', id)` and used a conditional expression to call either `baseQuery.or(...).select()` or `baseQuery.select()` to avoid unsafe assignments.
- Preserved the existing captured-at guard and `or(...)` branch that constrains `captured_by_workplace_id` when a task becomes in-progress.
- Changes are confined to `lib/modules/tasks/task_provider.dart` inside the `updateStatus` method and do not alter business logic or returned row handling.

### Testing
- Attempted to run `flutter analyze lib/modules/tasks/task_provider.dart`, but it failed because `flutter` is not available in this environment (`/bin/bash: flutter: command not found`).
- Attempted to run `dart --version`, but it failed because `dart` is not available in this environment (`/bin/bash: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20b6c8858832fbbf355b428d4afa2)