### PR TITLE
Prevent concurrent start/setup race for shared stages

### DIFF
--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -897,7 +897,13 @@ class TaskProvider with ChangeNotifier {
 
     Map<String, dynamic>? persistedRow;
     try {
-      final baseQuery = _supabase.from('tasks').update(updates).eq('id', id);
+      var baseQuery = _supabase.from('tasks').update(updates).eq('id', id);
+      // CAS-защита для старта этапа:
+      // если другой сотрудник успел поменять статус первым,
+      // повторный "старт" с устаревшего клиента не должен проходить.
+      if (becameInProgress) {
+        baseQuery = baseQuery.eq('status', current.status.name);
+      }
       final rows = await (capturedAt != null
           ? baseQuery
               .or(
@@ -905,7 +911,12 @@ class TaskProvider with ChangeNotifier {
               )
               .select()
           : baseQuery.select());
-      if (rows.isEmpty) return false;
+      if (rows.isEmpty) {
+        if (becameInProgress) {
+          await refresh();
+        }
+        return false;
+      }
       persistedRow = Map<String, dynamic>.from(rows.first);
     } catch (e, st) {
       debugPrint('❌ tasks.updateStatus error: $e\n$st');

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5733,49 +5733,73 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   Future<void> _startSetup(TaskModel task, TaskProvider provider) async {
+    await provider.refresh();
+    final latestTask = provider.tasks.firstWhere(
+      (t) => t.id == task.id,
+      orElse: () => task,
+    );
+    if (_hasPendingSetupForStage(latestTask) ||
+        _isSetupCompletedForStage(latestTask) ||
+        _hasProductionStartedForStage(latestTask)) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+        content: Text(
+            'Наладка уже запущена другим сотрудником. Обновите список и продолжайте работу в активном этапе.'),
+      ));
+      return;
+    }
+
     await provider.addCommentAutoUser(
       taskId: task.id,
       type: 'setup_start',
       text: 'Начал(а) настройку станка',
       userIdOverride: widget.employeeId,
     );
-    if (task.status != TaskStatus.inProgress) {
+    if (latestTask.status != TaskStatus.inProgress) {
       final startedAtTs =
-          task.startedAt ?? DateTime.now().millisecondsSinceEpoch;
-      await provider.updateStatus(task.id, TaskStatus.inProgress,
+          latestTask.startedAt ?? DateTime.now().millisecondsSinceEpoch;
+      final started = await provider.updateStatus(task.id, TaskStatus.inProgress,
           startedAt: startedAtTs);
+      if (!started) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text(
+              'Этап уже запущен другим сотрудником. Наладка недоступна для второго запуска.'),
+        ));
+        return;
+      }
     }
-    final participants = _participantsSnapshot(task, widget.employeeId);
-    final execMode = _stageExecutionMode(task);
+    final participants = _participantsSnapshot(latestTask, widget.employeeId);
+    final execMode = _stageExecutionMode(latestTask);
     await provider.recordTimeEvent(
-      task: task,
+      task: latestTask,
       type: TaskTimeType.setup,
       initiatedBy: widget.employeeId,
       subjectUserId: widget.employeeId,
-      workplaceId: task.stageId,
+      workplaceId: latestTask.stageId,
       participantsSnapshot: participants,
       executionMode: execMode != null ? _executionModeCode(execMode) : null,
     );
-    final helpers = _helperIds(task);
-    if (helpers.isNotEmpty && task.assignees.first == widget.employeeId) {
+    final helpers = _helperIds(latestTask);
+    if (helpers.isNotEmpty && latestTask.assignees.first == widget.employeeId) {
       for (final helperId in helpers) {
         await provider.recordTimeEvent(
-          task: task,
+          task: latestTask,
           type: TaskTimeType.setup,
           initiatedBy: widget.employeeId,
           subjectUserId: helperId,
-          workplaceId: task.stageId,
+          workplaceId: latestTask.stageId,
           participantsSnapshot: participants,
           executionMode: execMode != null ? _executionModeCode(execMode) : null,
           helperId: helperId,
         );
       }
     }
-    if (!task.assignees.contains(widget.employeeId)) {
+    if (!latestTask.assignees.contains(widget.employeeId)) {
       try {
         await (provider as dynamic).addAssignee(task.id, widget.employeeId);
       } catch (_) {
-        final newAssignees = List<String>.from(task.assignees)
+        final newAssignees = List<String>.from(latestTask.assignees)
           ..add(widget.employeeId);
         await provider.updateAssignees(task.id, newAssignees);
       }


### PR DESCRIPTION
### Motivation
- На этапах с несколькими рабочими местами возникала гонка: если два сотрудника одновременно нажимали «Начать/Наладку», оба могли продолжить, что приводило к неконсистентному состоянию и «зависанию» второго пользователя. 
- Нужно было быстро сделать второй клиент «провалившимся» в случае проигрыша гонки и мгновенно синхронизировать UI, чтобы в комментариях/таймсобытиях оставался только один инициатор этапа.

### Description
- Добавлена CAS-проверка в `TaskProvider.updateStatus` при переходе в `inProgress`: обновление теперь требует, чтобы строка в БД всё ещё имела ожидаемый предыдущий статус, и в случае проигрыша гонки вызывается `refresh()` и метод возвращает `false`.
- Усилен `_startSetup` в `lib/modules/tasks/tasks_screen.dart`: перед стартом выполняется `provider.refresh()`, затем проверяется срез `latestTask` на уже запущенную наладку/производство, и при проигрыше гонки показывается уведомление и дальнейшие действия прекращаются.
- После успешного захвата используется свежий снимок задачи (`latestTask`) для записи time events и обновления `assignees`, чтобы избежать дублирования побочных эффектов при конкурентных обновлениях.
- Изменённые файлы: `lib/modules/tasks/task_provider.dart` и `lib/modules/tasks/tasks_screen.dart`.

### Testing
- `git diff --check` выполнен и не показал ошибок в диффе.
- Попытка форматирования через `dart format` завершилась ошибкой в окружении из-за отсутствия `dart` (вывод: `dart: command not found`).
- Попытка форматирования через `flutter format` завершилась ошибкой в окружении из-за отсутствия `flutter` (вывод: `flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20ef5d3e8832fbbb3a2ffad504330)