### PR TITLE
Fix shipment category lookup for special product names

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1075,12 +1075,10 @@ class OrdersProvider with ChangeNotifier {
       return;
     }
 
-    final sanitizedProduct = productName.replaceAll("'", "''");
-    final category = await _supabase
-        .from('warehouse_categories')
-        .select('id, has_subtables')
-        .or('title.eq.$sanitizedProduct,code.eq.$sanitizedProduct')
-        .maybeSingle();
+    final category = await _findWarehouseCategoryByProductName(
+      productName,
+      columns: 'id, has_subtables',
+    );
 
     if (category == null || category['id'] == null) {
       throw Exception('Категория для "$productName" не найдена');
@@ -1218,12 +1216,10 @@ class OrdersProvider with ChangeNotifier {
       return null;
     }
 
-    final String sanitizedProduct = productName.replaceAll("'", "''");
-    final dynamic category = await _supabase
-        .from('warehouse_categories')
-        .select('id, title, code, has_subtables')
-        .or('title.eq.$sanitizedProduct,code.eq.$sanitizedProduct')
-        .maybeSingle();
+    final dynamic category = await _findWarehouseCategoryByProductName(
+      productName,
+      columns: 'id, title, code, has_subtables',
+    );
 
     if (category == null || category['id'] == null) {
       return null;
@@ -1245,6 +1241,36 @@ class OrdersProvider with ChangeNotifier {
       if (raw is Map) {
         return Map<String, dynamic>.from(raw as Map);
       }
+    }
+
+    return null;
+  }
+
+  Future<Map<String, dynamic>?> _findWarehouseCategoryByProductName(
+    String productName, {
+    required String columns,
+  }) async {
+    final String normalized = productName.trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+
+    final dynamic byTitle = await _supabase
+        .from('warehouse_categories')
+        .select(columns)
+        .eq('title', normalized)
+        .maybeSingle();
+    if (byTitle is Map && byTitle['id'] != null) {
+      return Map<String, dynamic>.from(byTitle);
+    }
+
+    final dynamic byCode = await _supabase
+        .from('warehouse_categories')
+        .select(columns)
+        .eq('code', normalized)
+        .maybeSingle();
+    if (byCode is Map && byCode['id'] != null) {
+      return Map<String, dynamic>.from(byCode);
     }
 
     return null;


### PR DESCRIPTION
### Motivation
- Shipment flow could fail when product names contain special characters because the PostgREST `or('title.eq...,code.eq...')` filter is parsed incorrectly.
- The goal is to make warehouse category lookup robust and consistent across shipment processing and snapshot loading.

### Description
- Added helper `Future<Map<String, dynamic>?> _findWarehouseCategoryByProductName(String productName, { required String columns })` that performs safe sequential `eq('title', ...)` and `eq('code', ...)` queries and returns a normalized `Map` when found.
- Replaced direct `or('title.eq...,code.eq...')` lookups with calls to the new helper in `_processCategoryShipment` and `loadCategoryItemSnapshot` to unify and harden lookup logic.
- The helper accepts a `columns` parameter so callers request only the needed fields and behavior for existing code paths is preserved.

### Testing
- Attempted to run `flutter test`, but the Flutter SDK is not available in this environment (`flutter: command not found`).
- Attempted to run `dart format lib/modules/orders/orders_provider.dart`, but the Dart SDK is not available in this environment (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21b01b428832f99ef61798be3de2b)