### PR TITLE
Добавить два режима ввода количества и корректный расчет фактического количества (пачки)

### DIFF
--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -1458,10 +1458,28 @@ class TaskProvider with ChangeNotifier {
     if (v is num) return v.toDouble();
     if (v is String) {
       final normalized = v.replaceAll(',', '.').trim();
+      final totalFromFormula =
+          RegExp(r'=\s*(-?\d+(?:\.\d+)?)').firstMatch(normalized);
+      if (totalFromFormula != null) {
+        return double.tryParse(totalFromFormula.group(1) ?? '') ?? 0;
+      }
+      final packsMatch =
+          RegExp(r'(-?\d+(?:\.\d+)?)\s*пач', caseSensitive: false)
+              .firstMatch(normalized);
+      final inPackMatch = RegExp(r'[x×*]\s*(-?\d+(?:\.\d+)?)')
+          .firstMatch(normalized);
+      if (packsMatch != null && inPackMatch != null) {
+        final packs = double.tryParse(packsMatch.group(1) ?? '') ?? 0;
+        final inPack = double.tryParse(inPackMatch.group(1) ?? '') ?? 0;
+        return packs * inPack;
+      }
       final parsed = double.tryParse(normalized);
       if (parsed != null) return parsed;
-      final digits = normalized.replaceAll(RegExp(r'[^0-9.-]'), '');
-      return double.tryParse(digits) ?? 0;
+      final firstNumber = RegExp(r'-?\d+(?:\.\d+)?').firstMatch(normalized);
+      if (firstNumber != null) {
+        return double.tryParse(firstNumber.group(0) ?? '') ?? 0;
+      }
+      return 0;
     }
     return 0;
   }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -709,11 +709,15 @@ class _QuantityInput {
   final int quantity;
   final String displayText;
   final bool openPaperEditor;
+  final int? packsCount;
+  final int? unitsPerPack;
 
   const _QuantityInput({
     required this.quantity,
     required this.displayText,
     this.openPaperEditor = false,
+    this.packsCount,
+    this.unitsPerPack,
   });
 }
 
@@ -2944,6 +2948,18 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   int _parseQuantity(String text) {
+    final totalFromFormula = RegExp(r'=\s*(\d+)').firstMatch(text);
+    if (totalFromFormula != null) {
+      return int.tryParse(totalFromFormula.group(1) ?? '') ?? 0;
+    }
+    final packMatch =
+        RegExp(r'(\d+)\s*пач', caseSensitive: false).firstMatch(text);
+    final inPackMatch = RegExp(r'[x×*]\s*(\d+)').firstMatch(text);
+    if (packMatch != null && inPackMatch != null) {
+      final packs = int.tryParse(packMatch.group(1) ?? '') ?? 0;
+      final inPack = int.tryParse(inPackMatch.group(1) ?? '') ?? 0;
+      return packs * inPack;
+    }
     final match = RegExp(r'(\d+)').firstMatch(text);
     if (match == null) return 0;
     return int.tryParse(match.group(1) ?? '') ?? 0;
@@ -6540,50 +6556,138 @@ Future<_QuantityInput?> _askQuantity(
   String? unit,
   bool allowPaperEdit = false,
 }) async {
-  final controller = TextEditingController();
+  final totalController = TextEditingController();
+  final packsController = TextEditingController();
+  final inPackController = TextEditingController();
   final unitLabel = (unit ?? '').trim();
   const paperEditValue = '__open_paper_edit__';
-  final v = await showDialog<String>(
+  final v = await showDialog<_QuantityInput?>(
     context: context,
-    builder: (ctx) => AlertDialog(
-      title: const Text('Количество выполнено'),
-      content: TextField(
-        controller: controller,
-        autofocus: true,
-        keyboardType: TextInputType.number,
-        decoration: InputDecoration(
-          hintText: unitLabel.isNotEmpty
-              ? 'Введите количество в ${unitLabel}'
-              : 'Введите количество экземпляров',
-          border: const OutlineInputBorder(),
-        ),
-      ),
-      actions: [
-        if (allowPaperEdit)
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, paperEditValue),
-            child: const Text('Изменить бумагу'),
+    builder: (ctx) {
+      var usePacksMode = false;
+      return StatefulBuilder(
+        builder: (context, setStateDialog) => AlertDialog(
+          title: const Text('Количество выполнено'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SegmentedButton<bool>(
+                segments: const [
+                  ButtonSegment<bool>(
+                    value: false,
+                    label: Text('Общее количество'),
+                  ),
+                  ButtonSegment<bool>(
+                    value: true,
+                    label: Text('Пачками'),
+                  ),
+                ],
+                selected: <bool>{usePacksMode},
+                onSelectionChanged: (selection) {
+                  setStateDialog(() {
+                    usePacksMode = selection.first;
+                  });
+                },
+              ),
+              const SizedBox(height: 12),
+              if (!usePacksMode)
+                TextField(
+                  controller: totalController,
+                  autofocus: true,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    hintText: unitLabel.isNotEmpty
+                        ? 'Введите количество в $unitLabel'
+                        : 'Введите количество экземпляров',
+                    border: const OutlineInputBorder(),
+                  ),
+                )
+              else ...[
+                TextField(
+                  controller: packsController,
+                  autofocus: true,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'Количество пачек',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: inPackController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'Количество в пачке',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ],
+            ],
           ),
-        TextButton(
-            onPressed: () => Navigator.pop(ctx), child: const Text('Отмена')),
-        ElevatedButton(
-            onPressed: () => Navigator.pop(ctx, controller.text.trim()),
-            child: const Text('OK')),
-      ],
-    ),
+          actions: [
+            if (allowPaperEdit)
+              TextButton(
+                onPressed: () => Navigator.pop(
+                  ctx,
+                  const _QuantityInput(
+                    quantity: 0,
+                    displayText: paperEditValue,
+                    openPaperEditor: true,
+                  ),
+                ),
+                child: const Text('Изменить бумагу'),
+              ),
+            TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Отмена')),
+            ElevatedButton(
+              onPressed: () {
+                if (!usePacksMode) {
+                  final raw = totalController.text.trim();
+                  final n = int.tryParse(raw);
+                  if (n == null) return;
+                  final display =
+                      unitLabel.isNotEmpty ? '$n $unitLabel' : n.toString();
+                  Navigator.pop(
+                    ctx,
+                    _QuantityInput(quantity: n, displayText: display),
+                  );
+                  return;
+                }
+
+                final packs = int.tryParse(packsController.text.trim());
+                final inPack = int.tryParse(inPackController.text.trim());
+                if (packs == null || inPack == null) return;
+                final total = packs * inPack;
+                final display =
+                    '$packs пачек × $inPack в пачке = $total ${unitLabel.isNotEmpty ? unitLabel : 'шт'}';
+                Navigator.pop(
+                  ctx,
+                  _QuantityInput(
+                    quantity: total,
+                    displayText: display,
+                    packsCount: packs,
+                    unitsPerPack: inPack,
+                  ),
+                );
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    },
   );
-  if (v == null || v.isEmpty) return null;
-  if (v == paperEditValue) {
+  if (v == null) return null;
+  if (v.openPaperEditor || v.displayText == paperEditValue) {
     return const _QuantityInput(
       quantity: 0,
       displayText: '',
       openPaperEditor: true,
     );
   }
-  final n = int.tryParse(v);
-  if (n == null) return null;
-  final display = unitLabel.isNotEmpty ? '$n $unitLabel' : n.toString();
-  return _QuantityInput(quantity: n, displayText: display);
+  return v;
 }
 
 Duration _setupElapsed(TaskModel task, String userId) {


### PR DESCRIPTION
### Motivation
- Упростить ввод фактического количества для исполнителей, позволяя выбирать между вводом общего числа и вводом «пачками» (число пачек + количество в пачке). 
- Сделать комментарии более информативными: сохранять в них исходные значения и расчет (сколько пачек, сколько в пачке и итог). 
- Исправить некорректное суммирование/разбор чисел из комментариев, чтобы повторные циклы «завершил/продолжил» в режиме «Отдельный исполнитель» корректно отражались в `orders.actual_qty`.

### Description
- В `lib/modules/tasks/tasks_screen.dart` добавлен выбор режима ввода в диалог `Количеcтво выполнено` с `SegmentedButton`: `Общее количество` и `Пачками`, и реализованы поля `Количество пачек` и `Количество в пачке`, плюс сохранение детализированного `displayText` вида `N пачек × M в пачке = K ...`.
- В `lib/modules/tasks/tasks_screen.dart` расширена модель `_QuantityInput` новыми полями `packsCount` и `unitsPerPack`, и `_askQuantity` теперь возвращает подробный объект вместо строки; обработан вариант `openPaperEditor`.
- В `lib/modules/tasks/tasks_screen.dart` обновлён парсер `_parseQuantity` для поддержки формата с `=` (итог) и формата «пачек × в пачке», с сохранением fallback для старых простых форматов.
- В `lib/modules/tasks/task_provider.dart` улучшен `_parseQtySafe` для корректного извлечения чисел из сложных текстов (поддержка `= итог` и «пачек × в пачке») и для избежания «склеивания» чисел из текста при суммировании перед записи `orders.actual_qty`.

### Testing
- Попытка запустить автоформатирование: `dart format lib/modules/tasks/tasks_screen.dart lib/modules/tasks/task_provider.dart` не удалась, потому что `dart` отсутствует в окружении (`/bin/bash: line 1: dart: command not found`).
- Попытка проверить окружение Flutter: `flutter --version` не удалась, потому что `flutter` отсутствует в окружении (`/bin/bash: line 1: flutter: command not found`).
- Изменения проверены локальным просмотром diffs и точек интеграции (вызовы `quantity_done`, суммирование на экране и `_maybeUpdateActualQtyAfterStage`) в кодовой базе, без выполнения Dart/Flutter тестов из-за ограничений окружения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21d27bec0832fb2aabe91036ec722)