### PR TITLE
Remove shipment writeoff blocking by available stock

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -968,18 +968,6 @@ class OrdersProvider with ChangeNotifier {
       throw Exception('Количество для списания должно быть больше нуля.');
     }
 
-    final snapshot = await loadCategoryItemSnapshot(orderData);
-    final double? snapshotQty = _toDoubleNullable(snapshot?['quantity']);
-    final double availableQty = snapshotQty != null
-        ? (snapshotQty < 0 ? 0 : snapshotQty)
-        : safeActual;
-    if (writeoffQty > availableQty) {
-      throw Exception(
-        'Итоговое количество (${_formatQty(writeoffQty)}) превышает '
-        'доступный остаток (${_formatQty(availableQty)}).',
-      );
-    }
-
     final double leftoverQty =
         safeActual > writeoffQty ? (safeActual - writeoffQty) : 0;
 

--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -524,9 +524,6 @@ class _OrdersScreenState extends State<OrdersScreen> {
     if (!sliderEnabled) {
       sliderMax = 1;
     }
-    final double availableQty =
-        warehouseExtraQty != null ? math.max(0, warehouseExtraQty) : safeActual;
-
     final double? selectedWriteoff = await showDialog<double>(
       context: context,
       builder: (ctx) {
@@ -557,7 +554,6 @@ class _OrdersScreenState extends State<OrdersScreen> {
                     qtyPerPackController.text.trim().isEmpty);
             final bool packsInvalid = mode == ShipmentQuantityMode.packs &&
                 (packsCount <= 0 || qtyPerPack <= 0 || currentWriteoff <= 0);
-            final bool exceedsStock = currentWriteoff > availableQty;
             final double leftoverQty =
                 safeActual > currentWriteoff ? (safeActual - currentWriteoff) : 0;
 
@@ -748,15 +744,6 @@ class _OrdersScreenState extends State<OrdersScreen> {
                           style: TextStyle(color: Colors.red),
                         ),
                       ),
-                    if (exceedsStock)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: Text(
-                          'Итоговое количество (${_formatQuantity(currentWriteoff)}) '
-                          'превышает доступный остаток (${_formatQuantity(availableQty)}).',
-                          style: const TextStyle(color: Colors.red),
-                        ),
-                      ),
                   ],
                 ),
               ),
@@ -768,8 +755,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
                 ElevatedButton(
                   onPressed: (currentWriteoff <= 0 ||
                           (mode == ShipmentQuantityMode.packs &&
-                              (packsInputIncomplete || packsInvalid)) ||
-                          exceedsStock)
+                              (packsInputIncomplete || packsInvalid)))
                       ? null
                       : () => Navigator.pop(ctx, currentWriteoff),
                   style: ElevatedButton.styleFrom(


### PR DESCRIPTION
### Motivation
- Users were unable to confirm shipments when the chosen writeoff exceeded the displayed "available" stock, so the change removes that blocking behaviour to allow writeoffs even when they exceed the snapshot/available value.

### Description
- Removed UI-side available stock calculation and the `exceedsStock` check and error message from the `Подтвердить отгрузку?` dialog in `lib/modules/orders/orders_screen.dart` so the "Отгрузить" button is no longer disabled for that reason.
- Removed provider-side guard that compared `writeoffQty` with the category snapshot (`snapshotQty`) and threw an exception if `writeoffQty > availableQty` from `lib/modules/orders/orders_provider.dart` so backend-side rejection no longer occurs for that condition.
- Kept other validations intact, including checks that the writeoff is > 0 and the existing "packs" mode validations.
- Changes affect `lib/modules/orders/orders_screen.dart` and `lib/modules/orders/orders_provider.dart`.

### Testing
- Attempted to run the Dart formatter with `dart format lib/modules/orders/orders_screen.dart lib/modules/orders/orders_provider.dart`, but the Dart SDK is not installed in this environment and the command failed with `dart: command not found`.
- No automated unit or integration tests were executed in this environment after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21ffda280832fb92616f2ab4ff9f9)