### PR TITLE
Убрать режим «по пачкам» и добавить поле «Упаковка» в заказ

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -463,6 +463,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   // Клиент и комментарии
   late TextEditingController _customerController;
   late TextEditingController _commentsController;
+  late TextEditingController _packagingController;
   late final TextEditingController _lengthController;
   late final TextEditingController _widthController;
   late final TextEditingController _depthController;
@@ -626,6 +627,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _dueDate = template?.dueDate;
     // Поля "договор/оплата" временно исключены из сценария создания/редактирования.
     _selectedParams = List<String>.from(template?.additionalParams ?? const []);
+    _packagingController = TextEditingController(
+      text: _extractPackagingFromParams(_selectedParams),
+    );
     _trimming = _selectedParams.contains('Подрезка');
     final initialHandle = template?.handle?.trim();
     if (initialHandle != null &&
@@ -1759,6 +1763,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   void dispose() {
     _customerController.dispose();
     _commentsController.dispose();
+    _packagingController.dispose();
     _lengthController.dispose();
     _widthController.dispose();
     _depthController.dispose();
@@ -2541,6 +2546,16 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _product.parameters = p.trim();
   }
 
+  String _extractPackagingFromParams(List<String> params) {
+    for (final param in params) {
+      final normalized = param.trim();
+      if (normalized.toLowerCase().startsWith('упаковка:')) {
+        return normalized.substring('Упаковка:'.length).trim();
+      }
+    }
+    return '';
+  }
+
   Future<void> _saveOrder() async {
     if (_isSavingOrder) return;
     setState(() => _isSavingOrder = true);
@@ -2555,6 +2570,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       params.add('Подрезка');
     } else {
       params.remove('Подрезка');
+    }
+    params.removeWhere(
+      (value) => value.trim().toLowerCase().startsWith('упаковка:'),
+    );
+    final packaging = _packagingController.text.trim();
+    if (packaging.isNotEmpty) {
+      params.add('Упаковка: $packaging');
     }
     _selectedParams = params.toList();
     if (_orderDate == null) {
@@ -5381,6 +5403,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                     }
                   });
                 },
+              ),
+              TextFormField(
+                controller: _packagingController,
+                decoration: const InputDecoration(
+                  labelText: 'Упаковка',
+                  hintText: 'Например: по 50 шт в термоусадке',
+                  border: OutlineInputBorder(),
+                ),
               ),
               extras,
             ],

--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -257,6 +257,17 @@ class OrderDetailsCard extends StatelessWidget {
     );
   }
 
+  String _packagingValue() {
+    for (final value in order.additionalParams) {
+      final normalized = value.trim();
+      if (normalized.toLowerCase().startsWith('упаковка:')) {
+        final parsed = normalized.substring('Упаковка:'.length).trim();
+        if (parsed.isNotEmpty) return parsed;
+      }
+    }
+    return '—';
+  }
+
   double? _paperExtraDouble(MaterialModel material, String key) {
     final value = material.extra?[key];
     if (value is num) return value.toDouble();
@@ -403,6 +414,11 @@ class OrderDetailsCard extends StatelessWidget {
                         _buildInfoRowWidget(
                           'Ручки',
                           _buildSingleLineValue(o.handle.isEmpty ? '—' : o.handle),
+                          compact: true,
+                        ),
+                        _buildInfoRowWidget(
+                          'Упаковка',
+                          _buildSingleLineValue(_packagingValue()),
                           compact: true,
                         ),
                         // Use a combined row for "Картон" and "Подрезка" to align them on one

--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -25,7 +25,7 @@ enum SortOption {
   quantityDesc,
 }
 
-enum ShipmentQuantityMode { tirage, custom, actual, packs }
+enum ShipmentQuantityMode { tirage, custom, actual }
 
 /// Главный экран модуля оформления заказа. Показывает список заказов с
 /// возможностью фильтрации по статусам, поиска и создания нового заказа.
@@ -505,15 +505,11 @@ class _OrdersScreenState extends State<OrdersScreen> {
     final double suggestedWriteoff =
         actualLessThanPlanned ? safeActual : plannedQty;
     double customQty = suggestedWriteoff;
-    double packsCount = 0;
-    double qtyPerPack = 0;
     ShipmentQuantityMode mode = actualLessThanPlanned
         ? ShipmentQuantityMode.actual
         : ShipmentQuantityMode.tirage;
     final TextEditingController customController =
         TextEditingController(text: _formatQuantity(customQty));
-    final TextEditingController packsCountController = TextEditingController();
-    final TextEditingController qtyPerPackController = TextEditingController();
     bool updatingCustomText = false;
 
     double sliderMax = math.max(plannedQty, safeActual);
@@ -532,7 +528,6 @@ class _OrdersScreenState extends State<OrdersScreen> {
             final double effectiveCustom = sliderEnabled
                 ? math.max(0, math.min(customQty, sliderMax))
                 : math.max(0, customQty);
-            final double computedPacksQty = packsCount * qtyPerPack;
             double currentWriteoff;
             switch (mode) {
               case ShipmentQuantityMode.tirage:
@@ -544,16 +539,8 @@ class _OrdersScreenState extends State<OrdersScreen> {
               case ShipmentQuantityMode.custom:
                 currentWriteoff = effectiveCustom;
                 break;
-              case ShipmentQuantityMode.packs:
-                currentWriteoff = computedPacksQty;
-                break;
             }
             if (currentWriteoff < 0) currentWriteoff = 0;
-            final bool packsInputIncomplete = mode == ShipmentQuantityMode.packs &&
-                (packsCountController.text.trim().isEmpty ||
-                    qtyPerPackController.text.trim().isEmpty);
-            final bool packsInvalid = mode == ShipmentQuantityMode.packs &&
-                (packsCount <= 0 || qtyPerPack <= 0 || currentWriteoff <= 0);
             final double leftoverQty =
                 safeActual > currentWriteoff ? (safeActual - currentWriteoff) : 0;
 
@@ -617,17 +604,6 @@ class _OrdersScreenState extends State<OrdersScreen> {
                         });
                       },
                     ),
-                    RadioListTile<ShipmentQuantityMode>(
-                      title: const Text('Списать по пачкам'),
-                      value: ShipmentQuantityMode.packs,
-                      groupValue: mode,
-                      onChanged: (value) {
-                        if (value == null) return;
-                        setDialogState(() {
-                          mode = value;
-                        });
-                      },
-                    ),
                     if (mode == ShipmentQuantityMode.custom) ...[
                       TextField(
                         controller: customController,
@@ -679,71 +655,9 @@ class _OrdersScreenState extends State<OrdersScreen> {
                             : null,
                       ),
                     ],
-                    if (mode == ShipmentQuantityMode.packs) ...[
-                      TextField(
-                        controller: packsCountController,
-                        keyboardType: const TextInputType.numberWithOptions(
-                          decimal: true,
-                        ),
-                        decoration: const InputDecoration(
-                          labelText: 'Количество пачек',
-                          border: OutlineInputBorder(),
-                        ),
-                        onChanged: (value) {
-                          final parsed = double.tryParse(
-                            value.trim().replaceAll(',', '.'),
-                          );
-                          setDialogState(() {
-                            packsCount = parsed != null && parsed >= 0 ? parsed : 0;
-                          });
-                        },
-                      ),
-                      const SizedBox(height: 8),
-                      TextField(
-                        controller: qtyPerPackController,
-                        keyboardType: const TextInputType.numberWithOptions(
-                          decimal: true,
-                        ),
-                        decoration: const InputDecoration(
-                          labelText: 'Количество в одной пачке',
-                          border: OutlineInputBorder(),
-                        ),
-                        onChanged: (value) {
-                          final parsed = double.tryParse(
-                            value.trim().replaceAll(',', '.'),
-                          );
-                          setDialogState(() {
-                            qtyPerPack = parsed != null && parsed >= 0 ? parsed : 0;
-                          });
-                        },
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        'Итог к списанию: ${_formatQuantity(computedPacksQty)} '
-                        '(пачек: ${_formatQuantity(packsCount)} × '
-                        '${_formatQuantity(qtyPerPack)})',
-                      ),
-                    ],
                     const Divider(),
                     Text('К списанию: ${_formatQuantity(currentWriteoff)}'),
                     Text('Остаток после отгрузки: ${_formatQuantity(leftoverQty)}'),
-                    if (mode == ShipmentQuantityMode.packs &&
-                        packsInputIncomplete)
-                      const Padding(
-                        padding: EdgeInsets.only(top: 8),
-                        child: Text(
-                          'Заполните оба поля для списания по пачкам.',
-                          style: TextStyle(color: Colors.red),
-                        ),
-                      ),
-                    if (mode == ShipmentQuantityMode.packs && packsInvalid)
-                      const Padding(
-                        padding: EdgeInsets.only(top: 8),
-                        child: Text(
-                          'Количество пачек и количество в пачке должны быть больше нуля.',
-                          style: TextStyle(color: Colors.red),
-                        ),
-                      ),
                   ],
                 ),
               ),
@@ -753,9 +667,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
                   child: const Text('Отмена'),
                 ),
                 ElevatedButton(
-                  onPressed: (currentWriteoff <= 0 ||
-                          (mode == ShipmentQuantityMode.packs &&
-                              (packsInputIncomplete || packsInvalid)))
+                  onPressed: currentWriteoff <= 0
                       ? null
                       : () => Navigator.pop(ctx, currentWriteoff),
                   style: ElevatedButton.styleFrom(
@@ -772,8 +684,6 @@ class _OrdersScreenState extends State<OrdersScreen> {
     );
 
     customController.dispose();
-    packsCountController.dispose();
-    qtyPerPackController.dispose();
 
     if (selectedWriteoff == null) {
       return;

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -6557,125 +6557,53 @@ Future<_QuantityInput?> _askQuantity(
   bool allowPaperEdit = false,
 }) async {
   final totalController = TextEditingController();
-  final packsController = TextEditingController();
-  final inPackController = TextEditingController();
   final unitLabel = (unit ?? '').trim();
   const paperEditValue = '__open_paper_edit__';
   final v = await showDialog<_QuantityInput?>(
     context: context,
     builder: (ctx) {
-      var usePacksMode = false;
-      return StatefulBuilder(
-        builder: (context, setStateDialog) => AlertDialog(
-          title: const Text('Количество выполнено'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SegmentedButton<bool>(
-                segments: const [
-                  ButtonSegment<bool>(
-                    value: false,
-                    label: Text('Общее количество'),
-                  ),
-                  ButtonSegment<bool>(
-                    value: true,
-                    label: Text('Пачками'),
-                  ),
-                ],
-                selected: <bool>{usePacksMode},
-                onSelectionChanged: (selection) {
-                  setStateDialog(() {
-                    usePacksMode = selection.first;
-                  });
-                },
-              ),
-              const SizedBox(height: 12),
-              if (!usePacksMode)
-                TextField(
-                  controller: totalController,
-                  autofocus: true,
-                  keyboardType: TextInputType.number,
-                  decoration: InputDecoration(
-                    hintText: unitLabel.isNotEmpty
-                        ? 'Введите количество в $unitLabel'
-                        : 'Введите количество экземпляров',
-                    border: const OutlineInputBorder(),
-                  ),
-                )
-              else ...[
-                TextField(
-                  controller: packsController,
-                  autofocus: true,
-                  keyboardType: TextInputType.number,
-                  decoration: const InputDecoration(
-                    labelText: 'Количество пачек',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                TextField(
-                  controller: inPackController,
-                  keyboardType: TextInputType.number,
-                  decoration: const InputDecoration(
-                    labelText: 'Количество в пачке',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-              ],
-            ],
+      return AlertDialog(
+        title: const Text('Количество выполнено'),
+        content: TextField(
+          controller: totalController,
+          autofocus: true,
+          keyboardType: TextInputType.number,
+          decoration: InputDecoration(
+            hintText: unitLabel.isNotEmpty
+                ? 'Введите количество в $unitLabel'
+                : 'Введите количество экземпляров',
+            border: const OutlineInputBorder(),
           ),
-          actions: [
-            if (allowPaperEdit)
-              TextButton(
-                onPressed: () => Navigator.pop(
-                  ctx,
-                  const _QuantityInput(
-                    quantity: 0,
-                    displayText: paperEditValue,
-                    openPaperEditor: true,
-                  ),
-                ),
-                child: const Text('Изменить бумагу'),
-              ),
-            TextButton(
-                onPressed: () => Navigator.pop(ctx),
-                child: const Text('Отмена')),
-            ElevatedButton(
-              onPressed: () {
-                if (!usePacksMode) {
-                  final raw = totalController.text.trim();
-                  final n = int.tryParse(raw);
-                  if (n == null) return;
-                  final display =
-                      unitLabel.isNotEmpty ? '$n $unitLabel' : n.toString();
-                  Navigator.pop(
-                    ctx,
-                    _QuantityInput(quantity: n, displayText: display),
-                  );
-                  return;
-                }
-
-                final packs = int.tryParse(packsController.text.trim());
-                final inPack = int.tryParse(inPackController.text.trim());
-                if (packs == null || inPack == null) return;
-                final total = packs * inPack;
-                final display =
-                    '$packs пачек × $inPack в пачке = $total ${unitLabel.isNotEmpty ? unitLabel : 'шт'}';
-                Navigator.pop(
-                  ctx,
-                  _QuantityInput(
-                    quantity: total,
-                    displayText: display,
-                    packsCount: packs,
-                    unitsPerPack: inPack,
-                  ),
-                );
-              },
-              child: const Text('OK'),
-            ),
-          ],
         ),
+        actions: [
+          if (allowPaperEdit)
+            TextButton(
+              onPressed: () => Navigator.pop(
+                ctx,
+                const _QuantityInput(
+                  quantity: 0,
+                  displayText: paperEditValue,
+                  openPaperEditor: true,
+                ),
+              ),
+              child: const Text('Изменить бумагу'),
+            ),
+          TextButton(
+              onPressed: () => Navigator.pop(ctx), child: const Text('Отмена')),
+          ElevatedButton(
+            onPressed: () {
+              final raw = totalController.text.trim();
+              final n = int.tryParse(raw);
+              if (n == null) return;
+              final display = unitLabel.isNotEmpty ? '$n $unitLabel' : n.toString();
+              Navigator.pop(
+                ctx,
+                _QuantityInput(quantity: n, displayText: display),
+              );
+            },
+            child: const Text('OK'),
+          ),
+        ],
       );
     },
   );


### PR DESCRIPTION
### Motivation
- Убрать ввод "по пачкам" при отгрузке и в рабочем пространстве, чтобы упростить сценарий списания и исключить ошибки при вводе пачек. 
- Добавить в форму создания/редактирования заказа поле `Упаковка` рядом с `Ручки` и `Картон`, чтобы хранить и отображать информацию об упаковке заказа. 
- Обеспечить корректное сохранение/обновление значения упаковки в составе `additionalParams` и правильное отображение в карточке деталей заказа и в деталях производственного задания.

### Description
- Убрал режим `packs` из `ShipmentQuantityMode` и удалил всю связанную UI/логики (радар/поля и валидации) в диалоге отгрузки: `lib/modules/orders/orders_screen.dart`.
- Упростил диалог ввода количества в рабочем пространстве сотрудника, оставив только ввод общего количества (удалены опции ввода "пачками"): `lib/modules/tasks/tasks_screen.dart`.
- Добавил поле `Упаковка` в форму дополнительных параметров на экране создания/редактирования заказа и контроллер `_packagingController`: `lib/modules/orders/edit_order_screen.dart`.
- Реализовал извлечение существующей упаковки при открытии (`_extractPackagingFromParams`), удаление старых `Упаковка: ...` записей при сохранении и добавление актуальной записи в `additionalParams` при сохранении заказа, а также корректный `dispose` контроллера: `lib/modules/orders/edit_order_screen.dart`.
- Добавил отображение упаковки в карточке деталей заказа (`OrderDetailsCard`) через helper `_packagingValue()` и показ этого поля в разделе «Основная информация»: `lib/modules/orders/order_details_card.dart`.
- Небольшая корректировка поведения кнопки/условий в диалоге отгрузки (убрана зависимость от пакетов), чтобы избежать неиспользуемой логики.

### Testing
- `git diff --check` выполнен — ошибок форматирования/whitespace не обнаружено (успешно).
- Попытка запустить `dart format` для затронутых файлов не выполнена, так как в окружении отсутствует `dart` в `PATH` (форматирование не проверено автоматически).
- Изменения просмотрены локально в диффе; автотесты/сборка приложения не запускались в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22cf59640832fb98f0890180cfc67)