### PR TITLE
Fix race side-effects when multiple employees start same stage

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4555,6 +4555,22 @@ class _TasksScreenState extends State<TasksScreen>
                             _isSetupInProgressForUser(task, widget.employeeId) &&
                                 !_hasProductionStartedForStage(task);
 
+                        final startedAtTs =
+                            task.startedAt ?? DateTime.now().millisecondsSinceEpoch;
+                        final started = await taskProvider.updateStatus(
+                          task.id,
+                          TaskStatus.inProgress,
+                          startedAt: startedAtTs,
+                        );
+                        if (!started) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                              content: Text(
+                                  'Этап уже запущен другим сотрудником. Обновите список и продолжите работу в активном этапе.'),
+                            ));
+                          }
+                          return;
+                        }
                         final ExecutionMode? selectedMode = stageExecMode;
                         final alreadyAssigned =
                             task.assignees.contains(widget.employeeId);
@@ -4588,22 +4604,6 @@ class _TasksScreenState extends State<TasksScreen>
                             !_isSetupCompletedForUser(task, widget.employeeId) &&
                             !setupInProgressForCurrentUser) {
                           await _finishSetup(task, provider);
-                        }
-                        final startedAtTs =
-                            task.startedAt ?? DateTime.now().millisecondsSinceEpoch;
-                        final started = await taskProvider.updateStatus(
-                          task.id,
-                          TaskStatus.inProgress,
-                          startedAt: startedAtTs,
-                        );
-                        if (!started) {
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                              content: Text(
-                                  'Этап уже запущен другим сотрудником. Обновите список и продолжите работу в активном этапе.'),
-                            ));
-                          }
-                          return;
                         }
                         final isResumeAction = stateRowUser == UserRunState.paused ||
                             stateRowUser == UserRunState.problem;
@@ -5765,12 +5765,6 @@ class _TasksScreenState extends State<TasksScreen>
       return;
     }
 
-    await provider.addCommentAutoUser(
-      taskId: task.id,
-      type: 'setup_start',
-      text: 'Начал(а) настройку станка',
-      userIdOverride: widget.employeeId,
-    );
     if (latestTask.status != TaskStatus.inProgress) {
       final startedAtTs =
           latestTask.startedAt ?? DateTime.now().millisecondsSinceEpoch;
@@ -5785,6 +5779,12 @@ class _TasksScreenState extends State<TasksScreen>
         return;
       }
     }
+    await provider.addCommentAutoUser(
+      taskId: task.id,
+      type: 'setup_start',
+      text: 'Начал(а) настройку станка',
+      userIdOverride: widget.employeeId,
+    );
     final participants = _participantsSnapshot(latestTask, widget.employeeId);
     final execMode = _stageExecutionMode(latestTask);
     await provider.recordTimeEvent(


### PR DESCRIPTION
### Motivation
- There was a race when several employees pressed "Start" (or started setup) for the same order stage/group: losers could still write `start`/`setup_start` comments, assignee/execution-mode changes and time events, leaving inconsistent history and sometimes breaking completion logic. 

### Description
- Move the `updateStatus(..., TaskStatus.inProgress)` CAS call earlier in the start flow so the attempt to mark the task as started succeeds (or fails) before any side effects are written. 
- Only after a successful start the code now writes `exec_mode_stage`/`exec_mode` comments, updates assignees, auto-finishes setup (`_finishSetup`), and writes `start`/`resume` comments and production time events. 
- Apply the same pattern to `_startSetup`: attempt `updateStatus(..., inProgress)` first and only then write the `setup_start` comment and record setup time events. 
- Changes are implemented in `lib/modules/tasks/tasks_screen.dart` (reordering and small control-flow adjustments). 

### Testing
- Inspected the resulting diff of `lib/modules/tasks/tasks_screen.dart` to verify reordering and side-effect gating, which matched the intended changes. 
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but the environment lacks the `dart` tool so formatting could not be executed. 
- Attempted to run `flutter --version` but the environment lacks the `flutter` tool so no Flutter validation was performed. 
- No unit/integration tests were executed in this environment; manual code inspection and targeted line checks were performed to confirm the logic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63784c374832f8cd66d9fddeb9b3a)