### PR TITLE
Fix shift handoff resume, in-app PDF viewer, and helper removal handling

### DIFF
--- a/lib/modules/common/pdf_view_screen.dart
+++ b/lib/modules/common/pdf_view_screen.dart
@@ -2,13 +2,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
+import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:pdfx/pdfx.dart';
 
 class PdfViewScreen extends StatefulWidget {
-  final String url;
+  final String? url;
+  final Uint8List? bytes;
   final String title;
-  const PdfViewScreen({super.key, required this.url, required this.title});
+  const PdfViewScreen({
+    super.key,
+    this.url,
+    this.bytes,
+    required this.title,
+  }) : assert(url != null || bytes != null);
 
   @override
   State<PdfViewScreen> createState() => _PdfViewScreenState();
@@ -32,12 +39,17 @@ class _PdfViewScreenState extends State<PdfViewScreen> {
 
   Future<void> _load() async {
     try {
-      final res = await http.get(Uri.parse(widget.url));
-      if (res.statusCode != 200) {
-        setState(() => _error = 'HTTP ${res.statusCode}');
-        return;
+      final Future<PdfDocument> doc;
+      if (widget.bytes != null) {
+        doc = PdfDocument.openData(widget.bytes!);
+      } else {
+        final res = await http.get(Uri.parse(widget.url!));
+        if (res.statusCode != 200) {
+          setState(() => _error = 'HTTP ${res.statusCode}');
+          return;
+        }
+        doc = PdfDocument.openData(res.bodyBytes);
       }
-      final Future<PdfDocument> doc = PdfDocument.openData(res.bodyBytes);
       setState(() {
         if (_usePlainOnThisPlatform) {
           _plainController = PdfController(document: doc);

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -10,8 +10,6 @@ import 'package:uuid/uuid.dart';
 import '../../services/app_auth.dart';
 import '../../utils/auth_helper.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:open_filex/open_filex.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../services/storage_service.dart';
 import 'package:image_picker/image_picker.dart';
@@ -29,6 +27,7 @@ import '../warehouse/warehouse_provider.dart';
 import '../warehouse/stock_tables.dart';
 import '../warehouse/tmc_model.dart';
 import '../personnel/personnel_provider.dart';
+import '../common/pdf_view_screen.dart';
 import '../../utils/media_viewer.dart';
 import '../../utils/enter_key_behavior.dart';
 
@@ -2416,11 +2415,29 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   }
 
   Future<void> _openPdf() async {
-    if (_pickedPdf != null && _pickedPdf!.path != null) {
-      await OpenFilex.open(_pickedPdf!.path!);
+    if (_pickedPdf != null) {
+      final bytes = _pickedPdf!.bytes;
+      if (bytes == null) return;
+      if (!mounted) return;
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => PdfViewScreen(
+            bytes: bytes,
+            title: _pickedPdf!.name.isEmpty ? 'PDF' : _pickedPdf!.name,
+          ),
+        ),
+      );
     } else if (widget.order?.pdfUrl != null) {
       final url = await getSignedUrl(widget.order!.pdfUrl!);
-      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+      if (!mounted) return;
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => PdfViewScreen(
+            url: url,
+            title: widget.order!.pdfUrl!.split('/').last,
+          ),
+        ),
+      );
     }
   }
 

--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../services/storage_service.dart' as storage;
+import '../common/pdf_view_screen.dart';
 import 'material_model.dart';
 import 'order_model.dart';
 
@@ -768,30 +768,13 @@ class OrderDetailsCard extends StatelessWidget {
                       );
                       return;
                     }
-                    showDialog(
-                      context: context,
-                      builder: (_) => AlertDialog(
-                        title: Text(fileName),
-                        content:
-                            const Text('Открыть PDF во внешнем просмотрщике?'),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.pop(context),
-                            child: const Text('Отмена'),
-                          ),
-                          TextButton(
-                            onPressed: () async {
-                              Navigator.pop(context);
-                              try {
-                                await launchUrl(
-                                  Uri.parse(url),
-                                  mode: LaunchMode.externalApplication,
-                                );
-                              } catch (_) {}
-                            },
-                            child: const Text('Открыть'),
-                          ),
-                        ],
+                    if (!context.mounted) return;
+                    await Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => PdfViewScreen(
+                          url: url,
+                          title: fileName.isEmpty ? 'PDF' : fileName,
+                        ),
                       ),
                     );
                   },

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:open_filex/open_filex.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../services/storage_service.dart';
 import 'package:image_picker/image_picker.dart';
@@ -23,6 +21,7 @@ import '../warehouse/stock_tables.dart';
 import '../warehouse/tmc_model.dart';
 import '../personnel/personnel_provider.dart';
 import '../tasks/task_provider.dart';
+import '../common/pdf_view_screen.dart';
 
 const String _canonicalFlexoWorkplaceId =
     '0571c01c-f086-47e4-81b2-5d8b2ab91218';
@@ -1299,11 +1298,29 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   }
 
   Future<void> _openPdf() async {
-    if (_pickedPdf != null && _pickedPdf!.path != null) {
-      await OpenFilex.open(_pickedPdf!.path!);
+    if (_pickedPdf != null) {
+      final bytes = _pickedPdf!.bytes;
+      if (bytes == null) return;
+      if (!mounted) return;
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => PdfViewScreen(
+            bytes: bytes,
+            title: _pickedPdf!.name.isEmpty ? 'PDF' : _pickedPdf!.name,
+          ),
+        ),
+      );
     } else if (widget.order?.pdfUrl != null) {
       final url = await getSignedUrl(widget.order!.pdfUrl!);
-      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+      if (!mounted) return;
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => PdfViewScreen(
+            url: url,
+            title: widget.order!.pdfUrl!.split('/').last,
+          ),
+        ),
+      );
     }
   }
 

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1930,6 +1930,12 @@ class _TasksScreenState extends State<TasksScreen>
             : 'Комментарий к завершению: ${comment.text}';
       case 'joined':
         return 'Присоединился(лась) к этапу';
+      case 'helper_removed':
+        return comment.text.isNotEmpty ? comment.text : 'Помощник удалён с этапа';
+      case 'helper_removed_qty':
+        return comment.text.isNotEmpty
+            ? 'Количество удалённого помощника: ${comment.text}'
+            : 'Количество удалённого помощника зафиксировано';
       case 'exec_mode':
       case 'exec_mode_stage':
         final parsed = _parseExecutionModeLabel(comment.text);
@@ -4673,8 +4679,15 @@ class _TasksScreenState extends State<TasksScreen>
                       final taskProvider = context.read<TaskProvider>();
                       var separateAllDone = false;
                       if (jointGroup != null) {
-                        final helperIds = jointGroup
-                            .where((id) => id != widget.employeeId)
+                        final latestTask = taskProvider.tasks.firstWhere(
+                          (t) => t.id == task.id,
+                          orElse: () => task,
+                        );
+                        final helperIds = latestTask.assignees
+                            .where((id) =>
+                                id != widget.employeeId &&
+                                _execModeForUser(latestTask, id) ==
+                                    ExecutionMode.joint)
                             .toList();
                         for (final id in helperIds) {
                           await taskProvider.addComment(
@@ -4758,7 +4771,8 @@ class _TasksScreenState extends State<TasksScreen>
                         // Для режима "Отдельный исполнитель" финальное закрытие
                         // этапа выполняется только через отдельную кнопку
                         // "Завершить задание" (ниже в карточке этапа).
-                        final shouldCloseStage = jointGroup != null;
+                        final shouldCloseStage =
+                            jointGroup != null || (jointGroup == null && separateAllDone);
                         if (_isInkConfirmationStage(task)) {
                           await _finalizeTask(task, initialQtyInput: qtyInput);
                           return;
@@ -4771,7 +4785,10 @@ class _TasksScreenState extends State<TasksScreen>
                             task.id, nextStatus,
                             spentSeconds: _secs,
                             startedAt: null);
-                        if (context.mounted && separateAllDone && jointGroup == null) {
+                        if (context.mounted &&
+                            separateAllDone &&
+                            jointGroup == null &&
+                            nextStatus != TaskStatus.completed) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(
                               content: Text(
@@ -4899,6 +4916,84 @@ class _TasksScreenState extends State<TasksScreen>
                       );
                     }
 
+                    Future<void> onRemoveHelper(String helperId) async {
+                      final taskProvider = context.read<TaskProvider>();
+                      final latestTask = taskProvider.tasks.firstWhere(
+                        (t) => t.id == task.id,
+                        orElse: () => task,
+                      );
+                      final isOwner = latestTask.assignees.isNotEmpty &&
+                          latestTask.assignees.first == widget.employeeId;
+                      if (!isOwner) return;
+                      if (!latestTask.assignees.contains(helperId)) return;
+
+                      final helper = personnel.employees.firstWhere(
+                        (e) => e.id == helperId,
+                        orElse: () => EmployeeModel(
+                          id: helperId,
+                          firstName: 'Сотр.',
+                          lastName: helperId.substring(
+                              0, helperId.length > 4 ? 4 : helperId.length),
+                          patronymic: '',
+                          iin: '',
+                          positionIds: const [],
+                        ),
+                      );
+                      final helperName =
+                          '${helper.firstName} ${helper.lastName}'.trim();
+                      final confirmed = await showDialog<bool>(
+                            context: context,
+                            builder: (ctx) => AlertDialog(
+                              title: const Text('Удалить помощника'),
+                              content: Text(
+                                'Убрать сотрудника «$helperName» с этапа?',
+                              ),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.of(ctx).pop(false),
+                                  child: const Text('Отмена'),
+                                ),
+                                FilledButton(
+                                  onPressed: () => Navigator.of(ctx).pop(true),
+                                  child: const Text('Удалить'),
+                                ),
+                              ],
+                            ),
+                          ) ??
+                          false;
+                      if (!confirmed) return;
+
+                      final unitLabel = _workplaceUnit(personnel, task.stageId);
+                      final qtyInput =
+                          await _askQuantity(context, unit: unitLabel);
+                      if (qtyInput == null) return;
+
+                      await taskProvider.closeOpenTimeEvent(
+                        task: latestTask,
+                        initiatedBy: widget.employeeId,
+                        subjectUserId: helperId,
+                        note: 'helper_removed',
+                      );
+
+                      final updatedAssignees = List<String>.from(
+                        latestTask.assignees.where((id) => id != helperId),
+                      );
+                      await taskProvider.updateAssignees(task.id, updatedAssignees);
+
+                      await taskProvider.addCommentAutoUser(
+                        taskId: task.id,
+                        type: 'helper_removed',
+                        text: 'Помощник удалён: $helperName',
+                        userIdOverride: widget.employeeId,
+                      );
+                      await taskProvider.addCommentAutoUser(
+                        taskId: task.id,
+                        type: 'helper_removed_qty',
+                        text: '$helperName: ${qtyInput.displayText}',
+                        userIdOverride: widget.employeeId,
+                      );
+                    }
+
                     Future<void> onShift() async {
                       final confirmed = await showDialog<bool>(
                             context: context,
@@ -4971,8 +5066,11 @@ class _TasksScreenState extends State<TasksScreen>
                         if (qtyInput == null) return;
                         final qtyText = qtyInput.displayText;
                         final helperIds = jointGroup != null && isMyRow
-                            ? jointGroup
-                                .where((id) => id != latestTask.assignees.first)
+                            ? latestTask.assignees
+                                .where((id) =>
+                                    id != latestTask.assignees.first &&
+                                    _execModeForUser(latestTask, id) ==
+                                        ExecutionMode.joint)
                                 .toList()
                             : const <String>[];
                         final hasPendingSetup =
@@ -4983,15 +5081,15 @@ class _TasksScreenState extends State<TasksScreen>
                         );
                         final stageProductionStarted =
                             _hasProductionStartedForStage(latestTask);
-                        final shiftResumeState = (!stageProductionStarted &&
-                                (isSetupActiveForRow ||
-                                    isSetupInProgress ||
-                                    hasPendingSetup))
-                            ? 'setup'
+                        final shiftResumeState = stateRowUser == UserRunState.problem
+                            ? 'problem'
                             : stateRowUser == UserRunState.paused
                                 ? 'paused'
-                                : stateRowUser == UserRunState.problem
-                                    ? 'problem'
+                                : (!stageProductionStarted &&
+                                        (isSetupActiveForRow ||
+                                            isSetupInProgress ||
+                                            hasPendingSetup))
+                                    ? 'setup'
                                     : 'production';
 
                         await taskProvider.addCommentAutoUser(
@@ -5300,6 +5398,25 @@ class _TasksScreenState extends State<TasksScreen>
                                       icon: const Icon(Icons.person_add_alt_1),
                                       label: const Text('Добавить помощника'),
                                     ),
+                                  if (stageExecMode == ExecutionMode.joint &&
+                                      task.assignees.isNotEmpty &&
+                                      task.assignees.first == widget.employeeId)
+                                    ...[
+                                      for (final helperId in _helperIds(task))
+                                        ElevatedButton.icon(
+                                          onPressed: shiftPaused
+                                              ? null
+                                              : () => onRemoveHelper(helperId),
+                                          style: ElevatedButton.styleFrom(
+                                            textStyle: TextStyle(
+                                                fontSize: scaled(11.5)),
+                                          ),
+                                          icon: const Icon(Icons.person_remove),
+                                          label: Text(
+                                            'Удалить ${nameFor(helperId)}',
+                                          ),
+                                        ),
+                                    ],
                                   SizedBox(width: gapMedium),
                                   // Обновляем отображение времени для каждой строки каждую секунду
                                   StreamBuilder<DateTime>(


### PR DESCRIPTION
### Motivation
- Prevent resuming a task after a shift handoff from incorrectly starting with machine setup instead of restoring the real previous state (paused/problem/production).  
- Make PDF attachments open inside the application instead of launching an external browser/app so staff can view PDFs without leaving the UI.  
- Allow the main operator to remove helpers reliably and record the removed helper's performed quantity while avoiding stale helper attribution that can cause tasks to hang.

### Description
- Adjusted shift-resume decision order in `lib/modules/tasks/tasks_screen.dart` so `problem` and `paused` states take precedence over the `setup` fallback when restoring after a handoff.  
- Added in-app PDF viewer `PdfViewScreen` (now accepts either a signed `url` or in-memory `bytes`) in `lib/modules/common/pdf_view_screen.dart`.  
- Replaced external `launchUrl`/`OpenFilex` usage with navigation to `PdfViewScreen` in `lib/modules/orders/order_details_card.dart`, `lib/modules/orders/edit_order_screen.dart`, and `lib/modules/production_planning/form_editor_screen.dart`.  
- Implemented helper removal flow in `lib/modules/tasks/tasks_screen.dart` including per-helper delete buttons for the owner, confirmation dialog, quantity prompt via `_askQuantity`, closing helper open time events, updating `assignees`, and writing `helper_removed` and `helper_removed_qty` comments; also updated comments display for these types.  
- Improved finish/shift logic to use the latest task snapshot (fresh `assignees`) when attributing quantities and to allow automatic stage completion for separate-mode when all performers are done to avoid tasks getting stuck.

### Testing
- Ran `git diff --check` which reported no issues.  
- Attempted code formatting via `dart format` but the environment lacks Dart/Flutter tooling so `dart`/`flutter` commands returned `command not found`.  
- No automated unit/integration tests were executed in this environment due to missing Flutter tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6587d5294832fa951d321af51a5fe)