### PR TITLE
Очистка зависших резервов бумаги и фикс завершения этапа после проблемы

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -208,13 +208,10 @@ class OrdersProvider with ChangeNotifier {
 
     // Бизнес-правило: доступный остаток бумаги = складской остаток - активный резерв.
     try {
-      final reserveRows = await _supabase
-          .from('order_paper_reservations')
-          .select('qty')
-          .eq('paper_id', id);
-      if (reserveRows is List && reserveRows.isNotEmpty) {
+      final reserveRows = await _activePaperReservationsByPaper(id);
+      if (reserveRows.isNotEmpty) {
         double reserved = 0;
-        for (final raw in reserveRows.whereType<Map>()) {
+        for (final raw in reserveRows) {
           final value = raw['qty'];
           if (value is num) {
             reserved += value.toDouble();
@@ -228,6 +225,62 @@ class OrdersProvider with ChangeNotifier {
       // Если таблица резервов ещё не развёрнута, используем старый расчёт.
     }
     return baseQty;
+  }
+
+  Future<List<Map<String, dynamic>>> _activePaperReservationsByPaper(
+    String paperId,
+  ) async {
+    final normalizedId = paperId.trim();
+    if (normalizedId.isEmpty) return const [];
+    final reserveRows = await _supabase
+        .from('order_paper_reservations')
+        .select('order_id, qty')
+        .eq('paper_id', normalizedId);
+    if (reserveRows is! List || reserveRows.isEmpty) return const [];
+
+    final rows = reserveRows
+        .whereType<Map>()
+        .map((raw) => Map<String, dynamic>.from(raw as Map))
+        .toList(growable: false);
+    final orderIds = rows
+        .map((row) => (row['order_id'] ?? '').toString().trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (orderIds.isEmpty) return rows;
+
+    final activeOrderIds = <String>{};
+    final orderRows = await _supabase
+        .from('orders')
+        .select('id, status, shipped_at')
+        .inFilter('id', orderIds);
+    if (orderRows is List) {
+      for (final raw in orderRows.whereType<Map>()) {
+        final row = Map<String, dynamic>.from(raw as Map);
+        final orderId = (row['id'] ?? '').toString().trim();
+        if (orderId.isEmpty) continue;
+        final status = (row['status'] ?? '').toString().toLowerCase().trim();
+        final shippedAt = row['shipped_at'];
+        final isClosed =
+            status == 'completed' || status == 'shipped' || shippedAt != null;
+        if (!isClosed) activeOrderIds.add(orderId);
+      }
+    }
+
+    final staleOrderIds = orderIds
+        .where((orderId) => !activeOrderIds.contains(orderId))
+        .toList(growable: false);
+    if (staleOrderIds.isNotEmpty) {
+      // Жёсткая проверка: чистим "зависший" резерв для закрытых заказов.
+      await _supabase
+          .from('order_paper_reservations')
+          .delete()
+          .inFilter('order_id', staleOrderIds);
+    }
+
+    return rows
+        .where((row) => activeOrderIds.contains((row['order_id'] ?? '').toString().trim()))
+        .toList(growable: false);
   }
 
   Future<bool> _hasEnoughMaterialForLaunch(OrderModel order) async {

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4729,6 +4729,12 @@ class _TasksScreenState extends State<TasksScreen>
                           (t) => t.id == task.id,
                           orElse: () => task,
                         );
+                        final doneUsers = latestTask.comments
+                            .where((c) => c.type == 'user_done')
+                            .map((c) => c.userId)
+                            .where((id) => id.isNotEmpty)
+                            .toSet();
+                        doneUsers.add(widget.employeeId);
                         final separateIds = latestTask.assignees
                             .where((id) {
                               final mode = _execModeForUser(latestTask, id);
@@ -4742,8 +4748,7 @@ class _TasksScreenState extends State<TasksScreen>
 
                         bool allDone = true;
                         for (final id in separateIds) {
-                          final has = latestTask.comments.any(
-                              (c) => c.type == 'user_done' && c.userId == id);
+                          final has = doneUsers.contains(id);
                           if (!has) {
                             allDone = false;
                             break;

--- a/lib/modules/warehouse/warehouse_provider.dart
+++ b/lib/modules/warehouse/warehouse_provider.dart
@@ -97,13 +97,10 @@ class WarehouseProvider with ChangeNotifier {
   Future<double> paperReservedQty(String paperId) async {
     final id = paperId.trim();
     if (id.isEmpty) return 0;
-    final rows = await _sb
-        .from('order_paper_reservations')
-        .select('qty')
-        .eq('paper_id', id);
-    if (rows is! List) return 0;
+    final rows = await _activePaperReservationRows(paperId: id);
+    if (rows.isEmpty) return 0;
     double total = 0;
-    for (final raw in rows.whereType<Map>()) {
+    for (final raw in rows) {
       final value = raw['qty'];
       if (value is num) {
         total += value.toDouble();
@@ -117,16 +114,7 @@ class WarehouseProvider with ChangeNotifier {
   Future<List<Map<String, dynamic>>> paperReserveDetails(String paperId) async {
     final id = paperId.trim();
     if (id.isEmpty) return const [];
-    final rows = await _sb
-        .from('order_paper_reservations')
-        .select('order_id, qty, created_at')
-        .eq('paper_id', id)
-        .order('created_at', ascending: false);
-    if (rows is! List) return const [];
-    final parsedRows = rows
-        .whereType<Map>()
-        .map((row) => Map<String, dynamic>.from(row as Map))
-        .toList(growable: false);
+    final parsedRows = await _activePaperReservationRows(paperId: id);
     final orderIds = parsedRows
         .map((row) => (row['order_id'] ?? '').toString().trim())
         .where((id) => id.isNotEmpty)
@@ -217,6 +205,70 @@ class WarehouseProvider with ChangeNotifier {
       }
       return next;
     }).toList(growable: false);
+  }
+
+  Future<List<Map<String, dynamic>>> _activePaperReservationRows({
+    String? paperId,
+  }) async {
+    var query = _sb
+        .from('order_paper_reservations')
+        .select('order_id, paper_id, qty, created_at');
+    final normalizedPaperId = (paperId ?? '').trim();
+    if (normalizedPaperId.isNotEmpty) {
+      query = query.eq('paper_id', normalizedPaperId);
+    }
+    final rows = await query.order('created_at', ascending: false);
+    if (rows is! List || rows.isEmpty) return const [];
+    final parsedRows = rows
+        .whereType<Map>()
+        .map((row) => Map<String, dynamic>.from(row as Map))
+        .toList(growable: false);
+
+    final orderIds = parsedRows
+        .map((row) => (row['order_id'] ?? '').toString().trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (orderIds.isEmpty) return parsedRows;
+
+    final activeOrderIds = <String>{};
+    try {
+      final orderRows = await _sb
+          .from('orders')
+          .select('id, status, shipped_at')
+          .inFilter('id', orderIds);
+      if (orderRows is List) {
+        for (final raw in orderRows.whereType<Map>()) {
+          final row = Map<String, dynamic>.from(raw as Map);
+          final orderId = (row['id'] ?? '').toString().trim();
+          if (orderId.isEmpty) continue;
+          final status = (row['status'] ?? '').toString().toLowerCase().trim();
+          final shippedAt = row['shipped_at'];
+          final isClosed =
+              status == 'completed' || status == 'shipped' || shippedAt != null;
+          if (!isClosed) activeOrderIds.add(orderId);
+        }
+      }
+    } catch (_) {
+      return parsedRows;
+    }
+
+    final staleOrderIds = orderIds
+        .where((orderId) => !activeOrderIds.contains(orderId))
+        .toList(growable: false);
+    if (staleOrderIds.isNotEmpty) {
+      try {
+        await _sb
+            .from('order_paper_reservations')
+            .delete()
+            .inFilter('order_id', staleOrderIds);
+      } catch (_) {}
+    }
+
+    return parsedRows
+        .where(
+            (row) => activeOrderIds.contains((row['order_id'] ?? '').toString().trim()))
+        .toList(growable: false);
   }
 
   static const Map<String, Map<String, String>> _arrMap = {


### PR DESCRIPTION
### Motivation
- Закрытые или отгруженные заказы продолжали влиять на активные резервы бумаги, из‑за чего в UI и в расчётах оставались неактуальные резервы и не происходило списание; это нужно жёстко предотвратить.
- В сценарии «пометил проблему → нажал завершить» в режиме «отдельный исполнитель» этап мог застревать, так как локальное завершение пользователя не учитывалось немедленно.

### Description
- Добавлена фильтрация и проверка активности заказа при чтении резервов: введены ` _activePaperReservationsByPaper` в `lib/modules/orders/orders_provider.dart` и `_activePaperReservationRows` в `lib/modules/warehouse/warehouse_provider.dart`, которые возвращают только резервы от незакрытых/неотгруженных заказов и при обнаружении «зависших» строк удаляют их из `order_paper_reservations`.
- Переписан подсчёт резерва в `paperReservedQty` и получение деталей в `paperReserveDetails` чтобы использовать новый фильтр, исключающий резервы закрытых заказов и обеспечивающий автоочистку пустых/сталеющих записей.
- Исправлена логика завершения для режима `separate` в `lib/modules/tasks/tasks_screen.dart`: при вычислении завершённости теперь учитывается локально добавленный текущим пользователем `user_done` через временный `doneUsers` (включая `widget.employeeId`), чтобы случай «проблема → завершить» корректно закрывал этап.

### Testing
- Выполнена проверка изменения индекса с `git diff --check`, проверка прошла успешно.`
- Изменения закоммичены в репозитории (см. сообщение коммита).`
- Форматирование через `dart format` не было выполнено в CI‑окружении, потому что `dart` отсутствует в `PATH` (не выполнено).`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65de51814832fb8f52202f1f8ccfa)