### PR TITLE
Render technical order comments as human-readable Russian in timeline

### DIFF
--- a/lib/modules/orders/order_timeline_dialog.dart
+++ b/lib/modules/orders/order_timeline_dialog.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../personnel/personnel_provider.dart';
+import '../tasks/task_model.dart';
 import 'id_format.dart';
 import 'order_model.dart';
 
@@ -65,7 +66,62 @@ class OrderTimelineDialog extends StatelessWidget {
     return trimmed;
   }
 
-  String _describeComment(String type, String text, double? quantity) {
+  String _executionModeLabel(String? rawMode) {
+    final mode = (rawMode ?? '').trim().toLowerCase();
+    if (mode.contains('separ') || mode.contains('single') || mode.contains('отдель')) {
+      return 'отдельный исполнитель';
+    }
+    if (mode.contains('joint') || mode.contains('team') || mode.contains('совмест')) {
+      return 'совместная работа';
+    }
+    return '';
+  }
+
+  String _timeTypeLabel(TaskTimeType type) {
+    switch (type) {
+      case TaskTimeType.production:
+        return 'Производство';
+      case TaskTimeType.pause:
+        return 'Пауза';
+      case TaskTimeType.problem:
+        return 'Проблема';
+      case TaskTimeType.shiftChange:
+        return 'Пересмена';
+      case TaskTimeType.setup:
+        return 'Наладка';
+    }
+  }
+
+  String? _describeTaskTimePayload(String text, PersonnelProvider personnel) {
+    final parsed = TaskTimeEvent.fromPayload(text, '', 0, '');
+    if (parsed == null) return null;
+
+    final started = _formatTimestamp(parsed.startTime);
+    final ended = parsed.endTime == null ? 'в процессе' : _formatTimestamp(parsed.endTime);
+    final subject = _userDisplay(personnel, parsed.subjectUserId);
+    final initiator = _userDisplay(personnel, parsed.initiatedBy);
+    final mode = _executionModeLabel(parsed.executionMode);
+    final note = (parsed.note ?? '').trim();
+
+    final List<String> details = [
+      '${_timeTypeLabel(parsed.type)}: ${started.isEmpty ? '—' : started} — $ended',
+      if (subject.isNotEmpty) 'Исполнитель: $subject',
+      if (initiator.isNotEmpty && initiator != subject) 'Инициатор: $initiator',
+      if (mode.isNotEmpty) 'Режим: $mode',
+      if (note.isNotEmpty) 'Комментарий: $note',
+    ];
+    return details.join(' · ');
+  }
+
+  String _describeComment(
+    String type,
+    String text,
+    double? quantity,
+    PersonnelProvider personnel,
+  ) {
+    final taskTimeDescription = _describeTaskTimePayload(text, personnel);
+    if (taskTimeDescription != null) return taskTimeDescription;
+
     switch (type) {
       case 'start':
         return 'Начал(а) этап';
@@ -235,7 +291,7 @@ class OrderTimelineDialog extends StatelessWidget {
     final String bodyText = isChat
         ? (description.isEmpty ? 'Сообщение в чате' : description)
         : isComment
-        ? _describeComment(eventType, description, quantity)
+        ? _describeComment(eventType, description, quantity, personnel)
         : _describeOrderEvent(eventType, description);
 
     final List<Widget> subtitleWidgets = [];


### PR DESCRIPTION
### Motivation
- Сделать технические JSON-комментарии в таймлайне заказов читаемыми для операторов, заменив показ «сырого» payload на человекочитаемый русский текст.
- Упростить просмотр истории выполнения заказа в модулях управления производственными заданиями и архиве заказов, показывая тип события, период, исполнителя, инициатора, режим и примечание.

### Description
- Добавлен импорт `TaskTimeEvent` из `lib/modules/tasks/task_model.dart` и парсер сервисных payload-ов в `lib/modules/orders/order_timeline_dialog.dart`.
- Реализована функция `_describeTaskTimePayload` для декодирования `TaskTimeEvent` и сборки строкового описания с датой/временем, исполнителем, инициатором, режимом выполнения и заметкой.
- Добавлена нормализация и локализация режима выполнения в `_executionModeLabel` и русские метки типов времени в `_timeTypeLabel`.
- Интегрировано новое форматирование в существующую логику рендера комментариев: `_describeComment` теперь сначала пытается распарсить структуру и вернуть человекочитаемый текст, иначе откатывается на прежние шаблоны.

### Testing
- Выполнены локальные проверки диффа и внесённых изменений через `git status`/`git diff`, коммит прошёл успешно.
- Попытки запустить автоформатирование через `dart format` и проверку `flutter --version` завершились неудачно из-за отсутствия `dart`/`flutter` в окружении (`/bin/bash: line 1: dart: command not found`, `/bin/bash: line 1: flutter: command not found`).
- Юнит/видовые тесты не запускались в этой среде по причине отсутствия CLI-инструментов; изменения покрыты ручным просмотром патча в кодовой базе.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65fb5bdd0832fa82eb84d0866c835)