### PR TITLE
Fix `nameFor` scope in tasks screen controls

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4329,6 +4329,26 @@ class _TasksScreenState extends State<TasksScreen>
                       .where((id) =>
                           _execModeForUser(task, id) != ExecutionMode.separate)
                       .toList();
+                  final personnel = context.read<PersonnelProvider>();
+                  final nameFor = (String uid) {
+                    final emp = personnel.employees.firstWhere(
+                      (e) => e.id == uid,
+                      orElse: () => EmployeeModel(
+                          id: uid,
+                          firstName: 'Сотр.',
+                          lastName:
+                              uid.substring(0, uid.length > 4 ? 4 : uid.length),
+                          patronymic: '',
+                          iin: '',
+                          photoUrl: null,
+                          positionIds: const [],
+                          isFired: false,
+                          comments: '',
+                          login: '',
+                          password: ''),
+                    );
+                    return '${emp.firstName} ${emp.lastName}'.trim();
+                  };
 
                   Widget buildControlsFor(String? label,
                       {List<String>? jointGroup, String? userId}) {
@@ -5457,27 +5477,6 @@ class _TasksScreenState extends State<TasksScreen>
                       ],
                     );
                   }
-
-                  final personnel = context.read<PersonnelProvider>();
-                  final nameFor = (String uid) {
-                    final emp = personnel.employees.firstWhere(
-                      (e) => e.id == uid,
-                      orElse: () => EmployeeModel(
-                          id: uid,
-                          firstName: 'Сотр.',
-                          lastName:
-                              uid.substring(0, uid.length > 4 ? 4 : uid.length),
-                          patronymic: '',
-                          iin: '',
-                          photoUrl: null,
-                          positionIds: const [],
-                          isFired: false,
-                          comments: '',
-                          login: '',
-                          password: ''),
-                    );
-                    return '${emp.firstName} ${emp.lastName}'.trim();
-                  };
 
                   final rows = <Widget>[];
                   final shouldShowOnlyCurrentUserRow =


### PR DESCRIPTION
### Motivation
- Fix Dart compile errors where `nameFor` was referenced before its declaration or reported as undefined inside the tasks controls builder, causing build failures during Windows compilation.

### Description
- Move the `personnel` lookup and `nameFor` helper closure to be declared before `buildControlsFor` inside the `Builder`, so `nameFor` is in scope for all uses. 
- Remove the later duplicate declaration of `nameFor` to avoid redeclaration and ordering conflicts. 
- Change applied in `lib/modules/tasks/tasks_screen.dart` to resolve the scope/order issue between `nameFor` and `buildControlsFor`.

### Testing
- Attempted to run `flutter analyze lib/modules/tasks/tasks_screen.dart`, but the check failed because the environment lacks the Flutter SDK (`flutter: command not found`).
- Attempted to run `dart analyze lib/modules/tasks/tasks_screen.dart`, but the check failed because the environment lacks the Dart SDK (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e661373fc0832f83063774393db357)