### PR TITLE
Fix order duplication & form auto-assignment; improve PDF viewer quality/navigation

### DIFF
--- a/lib/modules/common/pdf_view_screen.dart
+++ b/lib/modules/common/pdf_view_screen.dart
@@ -25,6 +25,8 @@ class _PdfViewScreenState extends State<PdfViewScreen> {
   PdfControllerPinch? _pinchController;
   PdfController? _plainController;
   String? _error;
+  int _pagesCount = 0;
+  int _currentPage = 1;
 
   bool get _usePlainOnThisPlatform =>
       defaultTargetPlatform == TargetPlatform.windows ||
@@ -52,9 +54,15 @@ class _PdfViewScreenState extends State<PdfViewScreen> {
       }
       setState(() {
         if (_usePlainOnThisPlatform) {
-          _plainController = PdfController(document: doc);
+          _plainController = PdfController(
+            document: doc,
+            initialPage: _currentPage,
+          );
         } else {
-          _pinchController = PdfControllerPinch(document: doc);
+          _pinchController = PdfControllerPinch(
+            document: doc,
+            initialPage: _currentPage,
+          );
         }
       });
     } catch (e) {
@@ -74,17 +82,107 @@ class _PdfViewScreenState extends State<PdfViewScreen> {
     final controller =
         _usePlainOnThisPlatform ? _plainController : _pinchController;
     final viewer = _usePlainOnThisPlatform && controller != null
-        ? PdfView(controller: controller as PdfController)
+        ? PdfView(
+            controller: controller as PdfController,
+            onPageChanged: (page) {
+              if (page == null) return;
+              if (!mounted) return;
+              setState(() => _currentPage = page);
+            },
+            onDocumentLoaded: (document) {
+              if (!mounted) return;
+              setState(() => _pagesCount = document.pagesCount);
+            },
+            renderer: (page) => page.render(
+              width: page.width * 2,
+              height: page.height * 2,
+              format: PdfPageImageFormat.png,
+              backgroundColor: '#FFFFFF',
+            ),
+          )
         : (!_usePlainOnThisPlatform && controller != null
-            ? PdfViewPinch(controller: controller as PdfControllerPinch)
+            ? PdfViewPinch(
+                controller: controller as PdfControllerPinch,
+                onPageChanged: (page) {
+                  if (page == null) return;
+                  if (!mounted) return;
+                  setState(() => _currentPage = page);
+                },
+                onDocumentLoaded: (document) {
+                  if (!mounted) return;
+                  setState(() => _pagesCount = document.pagesCount);
+                },
+                renderer: (page) => page.render(
+                  width: page.width * 2,
+                  height: page.height * 2,
+                  format: PdfPageImageFormat.png,
+                  backgroundColor: '#FFFFFF',
+                ),
+              )
             : null);
 
     return Scaffold(
       appBar: AppBar(title: Text(widget.title)),
-      body: viewer ??
-          (_error != null
+      body: viewer == null
+          ? (_error != null
               ? Center(child: Text('Не удалось открыть PDF: $_error'))
-              : const Center(child: CircularProgressIndicator())),
+              : const Center(child: CircularProgressIndicator()))
+          : Column(
+              children: [
+                Expanded(child: viewer),
+                if (_pagesCount > 1)
+                  SafeArea(
+                    top: false,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+                      child: Row(
+                        children: [
+                          IconButton(
+                            tooltip: 'Предыдущая страница',
+                            onPressed: _currentPage > 1
+                                ? () => _goToPage(_currentPage - 1)
+                                : null,
+                            icon: const Icon(Icons.chevron_left),
+                          ),
+                          Expanded(
+                            child: Center(
+                              child: Text('Страница $_currentPage из $_pagesCount'),
+                            ),
+                          ),
+                          IconButton(
+                            tooltip: 'Следующая страница',
+                            onPressed: _currentPage < _pagesCount
+                                ? () => _goToPage(_currentPage + 1)
+                                : null,
+                            icon: const Icon(Icons.chevron_right),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
     );
+  }
+
+  Future<void> _goToPage(int page) async {
+    final target = page.clamp(1, _pagesCount == 0 ? 1 : _pagesCount);
+    try {
+      if (_usePlainOnThisPlatform && _plainController != null) {
+        await _plainController!.animateToPage(
+          target,
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+        );
+      } else if (_pinchController != null) {
+        await _pinchController!.animateToPage(
+          target,
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+        );
+      }
+    } catch (_) {
+      // no-op
+    }
   }
 }

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3405,14 +3405,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   Future<void> _processFormAssignment(OrderModel order,
       {required bool isCreating}) async {
-    final bool paintsFilled = _hasAnyPaints();
-    if (!_hasForm && paintsFilled) {
-      // Если добавлены краски, а форма не выбрана, автоматически создаём новую
-      // форму для текущего заказа по данным из заказа/красок.
-      _hasForm = true;
-      _isOldForm = false;
-    }
-
     bool persistedHasForm = false;
     bool? persistedIsOldForm;
     int? persistedFormNo;

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -52,6 +52,7 @@ class OrdersProvider with ChangeNotifier {
       _orders
         ..clear()
         ..addAll(rows.map((row) => OrderModel.fromMap(row)));
+      _dedupeOrdersById();
       notifyListeners();
     } catch (e, st) {
       debugPrint('❌ refresh orders error: $e\n$st');
@@ -134,6 +135,7 @@ class OrdersProvider with ChangeNotifier {
         _orders
           ..clear()
           ..addAll(rows.map((row) => OrderModel.fromMap(row)));
+        _dedupeOrdersById();
         notifyListeners();
       }
 
@@ -362,6 +364,7 @@ class OrdersProvider with ChangeNotifier {
         } else {
           _orders.add(updated);
         }
+        _dedupeOrdersById();
         notifyListeners();
         return;
       }
@@ -410,6 +413,7 @@ class OrdersProvider with ChangeNotifier {
       } else {
         _orders.add(newOrder);
       }
+      _dedupeOrdersById();
       notifyListeners();
 
       // Log creation (best effort)
@@ -491,6 +495,7 @@ class OrdersProvider with ChangeNotifier {
       // Replace optimistic row
       final idx = _orders.indexWhere((o) => o.id == tempLocalId);
       if (idx != -1) _orders[idx] = created;
+      _dedupeOrdersById();
       notifyListeners();
 
       // Log creation (best effort)
@@ -503,6 +508,19 @@ class OrdersProvider with ChangeNotifier {
       debugPrint('❌ createOrder error: $e\n$st');
       return null;
     }
+  }
+
+  void _dedupeOrdersById() {
+    final seen = <String>{};
+    _orders.removeWhere((order) {
+      final id = order.id.trim();
+      if (id.isEmpty) return false;
+      if (seen.contains(id)) {
+        return true;
+      }
+      seen.add(id);
+      return false;
+    });
   }
 
   /// Обновляет существующий заказ по ID (оптимистично).


### PR DESCRIPTION
### Motivation
- Prevent unexpected automatic form assignment when paints are added after initial save, which caused form numbers to jump (e.g. 141→142).
- Avoid duplicate order rows in the UI created by races between optimistic inserts and realtime updates.
- Improve PDF preview quality and make multi-page documents navigable from the viewer.

### Description
- Removed implicit auto-creation/assignment of a new form when paints are present inside `_processFormAssignment` in `lib/modules/orders/edit_order_screen.dart` so form state only changes by explicit controls.
- Added `_dedupeOrdersById()` to `lib/modules/orders/orders_provider.dart` and invoked it after `refresh`, in the realtime update handler, after `addOrder`, after `createOrder`, and during forced rechecks to deduplicate `_orders` by `id`.
- Enhanced `lib/modules/common/pdf_view_screen.dart` to render pages at higher resolution, track `_pagesCount` and `_currentPage`, provide `onDocumentLoaded`/`onPageChanged` hooks, add `Prev/Next` buttons with a "Страница X из Y" indicator, and implemented `_goToPage` navigation helper.

### Testing
- Ran `git diff --check` which reported no whitespace errors and succeeded.
- Attempted `dart format lib/...` but it could not run because `dart` binary is not available in the environment (`/bin/bash: dart: command not found`).
- Attempted `flutter --version` but `flutter` is not available in the environment (`/bin/bash: flutter: command not found`).
- No unit or integration tests were executed in this environment due to missing SDKs; runtime verification should be performed in a local environment with Flutter/Dart installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6662bbb58832f99508523683c80a8)