### PR TITLE
Fix pdfx API incompatibilities in PdfViewScreen

### DIFF
--- a/lib/modules/common/pdf_view_screen.dart
+++ b/lib/modules/common/pdf_view_screen.dart
@@ -93,12 +93,6 @@ class _PdfViewScreenState extends State<PdfViewScreen> {
               if (!mounted) return;
               setState(() => _pagesCount = document.pagesCount);
             },
-            renderer: (page) => page.render(
-              width: page.width * 2,
-              height: page.height * 2,
-              format: PdfPageImageFormat.png,
-              backgroundColor: '#FFFFFF',
-            ),
           )
         : (!_usePlainOnThisPlatform && controller != null
             ? PdfViewPinch(
@@ -112,12 +106,6 @@ class _PdfViewScreenState extends State<PdfViewScreen> {
                   if (!mounted) return;
                   setState(() => _pagesCount = document.pagesCount);
                 },
-                renderer: (page) => page.render(
-                  width: page.width * 2,
-                  height: page.height * 2,
-                  format: PdfPageImageFormat.png,
-                  backgroundColor: '#FFFFFF',
-                ),
               )
             : null);
 
@@ -176,7 +164,7 @@ class _PdfViewScreenState extends State<PdfViewScreen> {
         );
       } else if (_pinchController != null) {
         await _pinchController!.animateToPage(
-          target,
+          pageNumber: target,
           duration: const Duration(milliseconds: 180),
           curve: Curves.easeOut,
         );


### PR DESCRIPTION
### Motivation
- The project failed to build due to upstream `pdfx` API changes: the `renderer` named parameter was removed from viewer widgets and `animateToPage` now expects a named `pageNumber` argument. 
- Update the PDF viewer usage to match the current `pdfx` package so the app can compile on desktop platforms.

### Description
- Removed unsupported `renderer` parameter usage from `PdfView` and `PdfViewPinch` in `lib/modules/common/pdf_view_screen.dart` to match the new `pdfx` viewer API.
- Replaced the positional call to `PdfControllerPinch.animateToPage(target)` with the named form `animateToPage(pageNumber: target)`.
- Changes are confined to `lib/modules/common/pdf_view_screen.dart` and are aimed at resolving the reported build errors.

### Testing
- Attempted to run `dart analyze lib/modules/common/pdf_view_screen.dart`, but `dart` is not available in this execution environment so static analysis could not be executed (analysis was not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6699fe46c832fa76cc3e22ca42838)