### PR TITLE
Компактные комментарии при изменении бумаги и fallback для Ш/К в блоке «Было»

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1255,6 +1255,10 @@ class _TasksScreenState extends State<TasksScreen>
     required List<MaterialModel> before,
     required List<MaterialModel> after,
     required String reason,
+    double? beforePrimaryWidthB,
+    String? beforePrimaryBlQuantity,
+    double? afterPrimaryWidthB,
+    String? afterPrimaryBlQuantity,
   }) {
     String paperLabel(MaterialModel material) {
       final format = (material.format ?? '').trim();
@@ -1270,19 +1274,26 @@ class _TasksScreenState extends State<TasksScreen>
       return parts.join(', ');
     }
 
-    String qtyText(MaterialModel material) {
+    String paperMetrics(
+      MaterialModel material, {
+      double? fallbackWidthB,
+      String? fallbackBlQuantity,
+    }) {
       double? asDouble(dynamic raw) {
         if (raw is num) return raw.toDouble();
         return double.tryParse((raw ?? '').toString().replaceAll(',', '.'));
       }
 
-      final widthB = asDouble(material.extra?['widthB']);
-      final blQuantity = (material.extra?['blQuantity'] ?? '').toString().trim();
-      final widthText = widthB == null || widthB <= 0
+      final parsedWidthB = asDouble(material.extra?['widthB']) ?? 0;
+      final widthB = parsedWidthB > 0 ? parsedWidthB : (fallbackWidthB ?? 0);
+      final blQuantity = (material.extra?['blQuantity'] ?? fallbackBlQuantity ?? '')
+          .toString()
+          .trim();
+      final widthText = widthB <= 0
           ? '—'
           : (widthB % 1 == 0 ? widthB.toStringAsFixed(0) : widthB.toStringAsFixed(2));
       final quantityText = blQuantity.isEmpty ? '—' : blQuantity;
-      return 'Ш $widthText, К $quantityText, Длина L ${material.quantity.toStringAsFixed(2)} м';
+      return 'Ш $widthText, К $quantityText, L ${material.quantity.toStringAsFixed(2)} м';
     }
 
     final lines = <String>[
@@ -1297,17 +1308,21 @@ class _TasksScreenState extends State<TasksScreen>
         final delta = newMaterial.quantity - oldMaterial.quantity;
         final deltaPrefix = delta >= 0 ? '+' : '';
         lines.add(
-          'Бумага №$slot: было ${paperLabel(oldMaterial)} (${qtyText(oldMaterial)}), '
-          'стало ${paperLabel(newMaterial)} (${qtyText(newMaterial)}), '
-          'изменение $deltaPrefix${delta.toStringAsFixed(2)} м.',
+          'Бумага №$slot Было: ${paperLabel(oldMaterial)} '
+          '${paperMetrics(oldMaterial, fallbackWidthB: i == 0 ? beforePrimaryWidthB : null, fallbackBlQuantity: i == 0 ? beforePrimaryBlQuantity : null)}. '
+          'Стало: ${paperLabel(newMaterial)} '
+          '${paperMetrics(newMaterial, fallbackWidthB: i == 0 ? afterPrimaryWidthB : null, fallbackBlQuantity: i == 0 ? afterPrimaryBlQuantity : null)}. '
+          'Δ $deltaPrefix${delta.toStringAsFixed(2)} м.',
         );
       } else if (oldMaterial == null && newMaterial != null) {
         lines.add(
-          'Бумага №$slot добавлена: ${paperLabel(newMaterial)} (${qtyText(newMaterial)}).',
+          'Бумага №$slot Добавлена: ${paperLabel(newMaterial)} '
+          '${paperMetrics(newMaterial, fallbackWidthB: i == 0 ? afterPrimaryWidthB : null, fallbackBlQuantity: i == 0 ? afterPrimaryBlQuantity : null)}.',
         );
       } else if (oldMaterial != null && newMaterial == null) {
         lines.add(
-          'Бумага №$slot удалена: ${paperLabel(oldMaterial)} (${qtyText(oldMaterial)}).',
+          'Бумага №$slot Удалена: ${paperLabel(oldMaterial)} '
+          '${paperMetrics(oldMaterial, fallbackWidthB: i == 0 ? beforePrimaryWidthB : null, fallbackBlQuantity: i == 0 ? beforePrimaryBlQuantity : null)}.',
         );
       }
     }
@@ -1787,6 +1802,11 @@ class _TasksScreenState extends State<TasksScreen>
                             before: currentMaterials,
                             after: nextMaterials,
                             reason: reasonController.text,
+                            beforePrimaryWidthB: latest.product.widthB,
+                            beforePrimaryBlQuantity: latest.product.blQuantity,
+                            afterPrimaryWidthB: primaryWidthB ?? latest.product.widthB,
+                            afterPrimaryBlQuantity:
+                                primaryBlQuantity ?? latest.product.blQuantity,
                           );
                           await _addWorkspacePaperChangeComment(
                             orderId: latest.id,


### PR DESCRIPTION
### Motivation
- Исправить ситуацию, когда в комментарии рабочего пространства в блоке «Было» для первой бумаги не отображались значения ширины (`Ш`) и количества (`К`).
- Сделать текст комментариев по изменению бумаги более компактным и читабельным (короткие метки «Было/Стало/Добавлена/Удалена»).

### Description
- Изменён сигнатурный метод ` _buildWorkspacePaperChangeComment` — добавлены параметры `beforePrimaryWidthB`, `beforePrimaryBlQuantity`, `afterPrimaryWidthB`, `afterPrimaryBlQuantity` для передачи первичных значений `widthB`/`blQuantity` до и после изменений.
- Заменён внутренний формат сборки метрик бумаги: `qtyText` -> `paperMetrics` с поддержкой `fallbackWidthB` и `fallbackBlQuantity`, которые используются когда значения отсутствуют в `extra` у материала.
- Упрощён текст комментариев: теперь используются короткие строки вида `Бумага №N Было: ... Стало: ...` / `Добавлена` / `Удалена` и укороченная метка длины `L` вместо `Длина L`.
- Обновлён вызов сборщика комментария в месте сохранения изменений бумаги — теперь передаём до/после-значения `widthB`/`blQuantity` (используются `latest.product` и `primaryWidthB`/`primaryBlQuantity`).

### Testing
- Проверен дифф файла `lib/modules/tasks/tasks_screen.dart` и внесённые изменения (успешно). 
- Попытки выполнить `dart format lib/modules/tasks/tasks_screen.dart` и `flutter --version` не удались из-за отсутствия `dart`/`flutter` в окружении (`command not found`).
- Автоматические тесты/форматирование не запускались по той же причине (инструменты недоступны).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e670cb3c50832fa4242896c7b602e5)