### PR TITLE
Prefer material length for paper reserve (use material.quantity before product length)

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1441,10 +1441,13 @@ class OrdersProvider with ChangeNotifier {
       return perPaperLength;
     }
 
+    // Приоритет: если в материале уже есть длина (например, из поля "Длина L"),
+    // используем её до общих размеров продукта.
+    if (paper.quantity > 0) return paper.quantity;
+
     final double length = (order.product.length ?? 0).toDouble();
     if (length > 0) return length;
 
-    if (paper.quantity > 0) return paper.quantity;
     if (paper.weight != null && paper.weight! > 0) return paper.weight!;
     return 0;
   }


### PR DESCRIPTION
### Motivation
- Prevent incorrect paper reservation when launching orders where the material-level length (field "Длина L") was ignored and the product-level length was used instead (for example, entering `23` reserved as `10`).

### Description
- Modify `_requiredPaperReserveQty` in `lib/modules/orders/orders_provider.dart` to check `paper.quantity` immediately after `_paperExtraLength(paper)`, keeping the existing fallback chain to `order.product.length` and then `paper.weight`.

### Testing
- Attempted to run `dart format lib/modules/orders/orders_provider.dart` but `dart` is not available in the environment, so no formatter/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f838d2bdf4832f919f3f3f680f824c)