### PR TITLE
Ensure new production orders are appended to queue tail

### DIFF
--- a/lib/modules/production/production_queue_provider.dart
+++ b/lib/modules/production/production_queue_provider.dart
@@ -292,10 +292,13 @@ class ProductionQueueProvider with ChangeNotifier {
         ..addAll(canonicalSequence);
     }
 
+    // Always append newly discovered orders to the tail of the queue.
+    // This guarantees that a freshly created order never jumps to the top,
+    // even if upstream lists are sorted by "newest first".
+    final missingIds = <String>[];
     for (final id in normalizedIds) {
       if (!sequence.contains(id)) {
-        sequence.add(id);
-        changed = true;
+        missingIds.add(id);
       }
     }
 
@@ -303,6 +306,11 @@ class ProductionQueueProvider with ChangeNotifier {
     if (toRemove.isNotEmpty) {
       sequence.removeWhere((id) => toRemove.contains(id));
       hidden.removeWhere((id) => toRemove.contains(id));
+      changed = true;
+    }
+
+    if (missingIds.isNotEmpty) {
+      sequence.addAll(missingIds);
       changed = true;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent newly created orders from jumping to the top of the production queue when workspace stage lists are sorted "newest first"; new orders must be appended to the end of the queue.

### Description
- Changed `syncOrders` in `lib/modules/production/production_queue_provider.dart` to collect missing order IDs into a `missingIds` list and append them after removing stale entries, ensuring new orders are placed at the tail.
- Kept the canonicalization step (whitespace deduplication) and removal of non-present IDs before appending new IDs to preserve existing ordering semantics.
- Added an inline comment documenting the guarantee that freshly discovered orders are appended to the queue tail.

### Testing
- Attempted to run `flutter test test/stage_sequence_utils_test.dart`, but the test run failed in this environment because `flutter` is not installed (`/bin/bash: line 1: flutter: command not found`).
- No other automated tests were executed successfully in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83bd6fd3c832fa3b9822652b35cf9)