### PR TITLE
Добавить поле доп. информации для форм и поиск по нему

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -461,6 +461,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   List<String> _managerNames = [];
   // Клиент и комментарии
   late TextEditingController _customerController;
+  late TextEditingController _customerExtraInfoController;
   late TextEditingController _commentsController;
   late TextEditingController _packagingController;
   late final TextEditingController _lengthController;
@@ -621,6 +622,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     }
     _updateManagerDisplayController();
     _customerController = TextEditingController(text: template?.customer ?? '');
+    _customerExtraInfoController = TextEditingController();
     _commentsController = TextEditingController(text: template?.comments ?? '');
     _orderDate = template?.orderDate;
     _dueDate = template?.dueDate;
@@ -1798,6 +1800,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   @override
   void dispose() {
     _customerController.dispose();
+    _customerExtraInfoController.dispose();
     _commentsController.dispose();
     _packagingController.dispose();
     _lengthController.dispose();
@@ -3550,7 +3553,11 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             !hadFormBefore;
         if (hasNewFormPayload) {
           final customer = _customerController.text.trim();
+          final extraInfo = _customerExtraInfoController.text.trim();
           String series = customer.isNotEmpty ? customer : 'F';
+          if (extraInfo.isNotEmpty) {
+            series = '$series ($extraInfo)';
+          }
           wp ??= WarehouseProvider();
           final created = await wp.createFormAndReturn(
             series: series,
@@ -3887,6 +3894,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                       label: 'Заказчик',
                       labelWidth: labelWidth,
                       child: _buildCustomerField(),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: _buildCustomerExtraInfoField(),
                     ),
                     _buildLabelRow(
                       label: 'Тип',
@@ -5325,6 +5336,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         _buildFieldGrid([
           _buildManagerField(),
           _buildCustomerField(),
+          const SizedBox(height: 8),
+          _buildCustomerExtraInfoField(),
           _buildDatePickerField(
             label: 'Дата заказа',
             value: _orderDate,
@@ -5638,6 +5651,17 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         }
         return null;
       },
+    );
+  }
+
+  Widget _buildCustomerExtraInfoField() {
+    return TextFormField(
+      controller: _customerExtraInfoController,
+      decoration: const InputDecoration(
+        labelText: 'Доп. информация',
+        hintText: 'Необязательно',
+        border: OutlineInputBorder(),
+      ),
     );
   }
 

--- a/lib/modules/warehouse/forms_provider.dart
+++ b/lib/modules/warehouse/forms_provider.dart
@@ -172,6 +172,8 @@ class FormsProvider with ChangeNotifier {
           ',series.ilike.' +
           ilike +
           ',code.ilike.' +
+          ilike +
+          ',description.ilike.' +
           ilike);
       final rows =
           await filtered.order('updated_at', ascending: false).limit(limit);

--- a/lib/modules/warehouse/forms_screen.dart
+++ b/lib/modules/warehouse/forms_screen.dart
@@ -99,6 +99,8 @@ class _FormsScreenState extends State<FormsScreen> {
         TextEditingController(text: row?['title']?.toString() ?? '');
     final colorsCtl = TextEditingController(
         text: (row?['colors'] ?? row?['description'] ?? '').toString());
+    final extraInfoCtl =
+        TextEditingController(text: (row?['description'] ?? '').toString());
 // Существующее изображение (для режима редактирования)
     final String? existingImageUrl = (row?['image_url'] as String?);
     sizeCtl.text = ([
@@ -107,8 +109,7 @@ class _FormsScreenState extends State<FormsScreen> {
       if ((row?['product_type'] ?? '').toString().isNotEmpty)
         (" / " + (row?['product_type'] ?? '').toString())
     ].join('').toString());
-    colorsCtl.text =
-        ((row?['colors'] ?? row?['description'] ?? '')?.toString() ?? '');
+    colorsCtl.text = (row?['colors'] ?? '').toString();
     Uint8List? pickedImageBytes;
     bool numberManuallyEdited = isEditing;
 
@@ -213,6 +214,15 @@ class _FormsScreenState extends State<FormsScreen> {
                       ),
                     ),
                     const SizedBox(height: 8),
+                    TextField(
+                      controller: extraInfoCtl,
+                      decoration: const InputDecoration(
+                        labelText: 'Доп. информация',
+                        hintText: 'Необязательно',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
 
                     const SizedBox(height: 8),
                     // Предпросмотр изображения: если есть выбранное — показываем его; иначе для редактирования показываем существующее
@@ -263,6 +273,7 @@ class _FormsScreenState extends State<FormsScreen> {
                     final size = _sizeOnly ?? '';
                     final typeVal = _typeOnly ?? '';
                     final colors = colorsCtl.text.trim();
+                    final extraInfo = extraInfoCtl.text.trim();
                     if (name.isEmpty || numberText.isEmpty) {
                       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                           content: Text(
@@ -285,6 +296,7 @@ class _FormsScreenState extends State<FormsScreen> {
                           formSize: size.isNotEmpty ? size : null,
                           formProductType: typeVal.isNotEmpty ? typeVal : null,
                           formColors: colors.isNotEmpty ? colors : null,
+                          description: extraInfo.isNotEmpty ? extraInfo : '',
                           imageBytes: pickedImageBytes,
                         );
                       }
@@ -295,6 +307,7 @@ class _FormsScreenState extends State<FormsScreen> {
                         formSize: size.isNotEmpty ? size : null,
                         formProductType: typeVal.isNotEmpty ? typeVal : null,
                         formColors: colors.isNotEmpty ? colors : null,
+                        description: extraInfo.isNotEmpty ? extraInfo : '',
                         imageBytes: pickedImageBytes,
                       );
                     }
@@ -505,7 +518,7 @@ class _FormsScreenState extends State<FormsScreen> {
                 TextField(
                   controller: _searchCtl,
                   decoration: const InputDecoration(
-                    hintText: 'Поиск формы (название или номер)',
+                    hintText: 'Поиск формы (название, номер, доп. инфо)',
                     prefixIcon: Icon(Icons.search),
                     border: OutlineInputBorder(),
                   ),
@@ -615,10 +628,14 @@ class _FormsScreenState extends State<FormsScreen> {
                         _cleanSizeLabel((row['size'] ?? '').toString());
                     final typeStr = (row['product_type'] ?? '').toString();
                     final colorsStr = (row['colors'] ?? '').toString();
+                    final extraInfoStr = (row['description'] ?? '').toString();
                     final subtitleParts = <String>[];
                     if (sizeStr.isNotEmpty) subtitleParts.add('Размер: $sizeStr');
                     if (typeStr.isNotEmpty) subtitleParts.add('Тип: $typeStr');
                     if (colorsStr.isNotEmpty) subtitleParts.add('Цвета: $colorsStr');
+                    if (extraInfoStr.isNotEmpty) {
+                      subtitleParts.add('Доп. инфо: $extraInfoStr');
+                    }
                     final subtitleText =
                         subtitleParts.isEmpty ? null : subtitleParts.join('  |  ');
 


### PR DESCRIPTION
### Motivation
- Нужно позволить сотрудникам добавлять необязательную «Доп. информация» при создании/редактировании заказа и при создании/редактировании форм на складе для более точной идентификации форм.
- При создании новой формы из заказа требуется сохранять эту доп. информацию так, чтобы её можно было видеть в карточке формы и использовать при поиске старых форм.
- Поиск по складу форм должен находить записи не только по названию/коду/номеру, но и по доп. информации, чтобы облегчить поиск совпадающих/старых форм.

### Description
- В `edit_order_screen.dart` добавлен контроллер `_customerExtraInfoController`, поле ввода `Доп. информация` в UI, и учтена очистка в `dispose` для управления памятью.
- При создании новой формы из заказа в `_processFormAssignment` теперь, если поле заполнено, серия форм формируется как `Заказчик (ДОП ИНФА)` и передаётся в `createFormAndReturn`.
- В `forms_screen.dart` в диалоге создания/редактирования формы добавлено поле `Доп. информация`, значение сохраняется в параметре `description` при вызове провайдера, и отображается в списке форм как `Доп. инфо: ...` в подписи.
- В `forms_provider.dart` расширен поиск в `searchForms` — добавлена фильтрация по полю `description`, и в UI обновлена подсказка поиска (`Поиск формы (название, номер, доп. инфо)`).

### Testing
- Выполнена проверка изменений через `git diff` и `git status` и просмотр изменённых хунков, что подтвердило внесённые правки (успешно).
- Запуск форматирования командой `dart format` не выполнен из-за отсутствия `dart` в окружении (неудачно).
- Запуск `flutter format` не выполнен из-за отсутствия `flutter` в окружении (неудачно).
- Автоматизированных unit/integration тестов не запускалось в этом патче (нет изменений в тестовом коде).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83e82cf5c832f80f0c5fa91067680)