### PR TITLE
Добавить поле «Доп. информация» для формы в создании/редактировании заказа и поиск по ней

### DIFF
--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -370,6 +370,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   final TextEditingController _newFormNameCtl = TextEditingController();
   final TextEditingController _newFormSizeCtl = TextEditingController();
   final TextEditingController _newFormColorsCtl = TextEditingController();
+  final TextEditingController _newFormExtraInfoCtl = TextEditingController();
   // Фото новой формы (при создании)
   Uint8List? _newFormImageBytes;
   // Выбранный номер старой формы
@@ -636,6 +637,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _newFormNameCtl.dispose();
     _newFormSizeCtl.dispose();
     _newFormColorsCtl.dispose();
+    _newFormExtraInfoCtl.dispose();
     super.dispose();
   }
 
@@ -2321,11 +2323,15 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             final name = _newFormNameCtl.text.trim();
             final size = _newFormSizeCtl.text.trim();
             final colors = _newFormColorsCtl.text.trim();
-            series = name.isNotEmpty ? name : 'F';
+            final extraInfo = _newFormExtraInfoCtl.text.trim();
+            final customer = _customerController.text.trim();
+            final baseSeries = name.isNotEmpty ? name : (customer.isNotEmpty ? customer : 'F');
+            series = extraInfo.isNotEmpty ? '$baseSeries (${extraInfo})' : baseSeries;
             final created = await wp.createFormAndReturn(
               series: series,
               title: size.isNotEmpty ? size : null,
-              description: colors.isNotEmpty ? colors : null,
+              formColors: colors.isNotEmpty ? colors : null,
+              description: extraInfo.isNotEmpty ? extraInfo : null,
               imageBytes: _newFormImageBytes,
             );
             selectedFormNumber = ((created['number'] ?? 0) as num).toInt();
@@ -2567,6 +2573,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                       _newFormNameCtl.clear();
                       _newFormSizeCtl.clear();
                       _newFormColorsCtl.clear();
+                      _newFormExtraInfoCtl.clear();
                       _newFormNoCtl.clear();
                       _newFormImageBytes = null;
                     } else {
@@ -2582,7 +2589,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 TextField(
                   controller: _formSearchCtl,
                   decoration: const InputDecoration(
-                    hintText: 'Поиск формы (название или номер)',
+                    hintText: 'Поиск формы (название, номер, доп. инфо)',
                     prefixIcon: Icon(Icons.search),
                     border: OutlineInputBorder(),
                   ),
@@ -2647,6 +2654,15 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                   controller: _newFormColorsCtl,
                   decoration: const InputDecoration(
                     labelText: 'Цвета',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: _newFormExtraInfoCtl,
+                  decoration: const InputDecoration(
+                    labelText: 'Доп. информация',
+                    hintText: 'Необязательно',
                     border: OutlineInputBorder(),
                   ),
                 ),


### PR DESCRIPTION
### Motivation
- Добавить возможность указывать необязательную «Доп. информацию» при создании/редактировании формы в заказе и сохранять её вместе с формой, чтобы сотрудники могли уточнять и потом находить формы по этим данным.
- Перенести отображение/ввод доп. информации в блок «Форма» (а не под «Заказчик») и обеспечить, чтобы при создании новой формы это поле использовалось при формировании записи на складе форм.
- Обеспечить корректный поиск старых форм по названию, номеру и доп. информации из UI выбора старой формы.

### Description
- Добавлен контроллер ` _newFormExtraInfoCtl` и его `dispose` в `lib/modules/production_planning/form_editor_screen.dart` для хранения поля «Доп. информация» при создании новой формы. 
- В UI секции «Форма» добавлено текстовое поле «Доп. информация» рядом с полями `Название`, `Размер` и `Цвета`, и при переключении на «Старая форма» это поле теперь очищается. 
- Логика создания новой формы обновлена: `formColors` теперь используется для цветов, а доп. информация сохраняется в `description`; если доп. информация заполнена, серия форм формируется как `Название` или `Заказчик` с добавлением ` (ДОП ИНФА)` — это значение передаётся в `createFormAndReturn`. 
- Подсказка поля поиска старых форм изменена на `Поиск формы (название, номер, доп. инфо)`; изменения затронули файл `lib/modules/production_planning/form_editor_screen.dart`.

### Testing
- Выполнен поиск по коду (`rg`/`sed`) чтобы найти места интеграции и обновить вызовы — команды успешно выполнились. 
- Просмотрен `git diff` изменений и выполнён `git commit` с сообщением, оба шага прошли успешно. 
- Попытка запустить `dart format` завершилась неудачно, так как `dart` отсутствует в окружении (`/bin/bash: line 1: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84217e108832f95bcd0faf27a220f)