### PR TITLE
Extract and surface form extra info; rename controller and adjust form UI

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -106,6 +106,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         .replaceFirst(RegExp(r'\.$'), '');
   }
 
+  String _extractFormExtraInfoFromSeries(String? seriesValue) {
+    final series = (seriesValue ?? '').trim();
+    if (series.isEmpty) return '';
+    final match = RegExp(r'\(([^()]*)\)\s*$').firstMatch(series);
+    return (match?.group(1) ?? '').trim();
+  }
+
   Future<void> _pickFormImage() async {
     final picker = ImagePicker();
     final img = await picker.pickImage(source: ImageSource.gallery);
@@ -181,6 +188,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           _formStateInitialized = true;
         }
       });
+      final extractedFormExtra = _extractFormExtraInfoFromSeries(series);
+      if (_formExtraInfoController.text.trim() != extractedFormExtra) {
+        _formExtraInfoController.value = TextEditingValue(
+          text: extractedFormExtra,
+          selection:
+              TextSelection.collapsed(offset: extractedFormExtra.length),
+        );
+      }
 
       // Загрузка дополнительных деталей формы (размер, цвета, изображение)
       try {
@@ -461,7 +476,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   List<String> _managerNames = [];
   // Клиент и комментарии
   late TextEditingController _customerController;
-  late TextEditingController _customerExtraInfoController;
+  late TextEditingController _formExtraInfoController;
   late TextEditingController _commentsController;
   late TextEditingController _packagingController;
   late final TextEditingController _lengthController;
@@ -622,7 +637,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     }
     _updateManagerDisplayController();
     _customerController = TextEditingController(text: template?.customer ?? '');
-    _customerExtraInfoController = TextEditingController();
+    _formExtraInfoController = TextEditingController();
     _commentsController = TextEditingController(text: template?.comments ?? '');
     _orderDate = template?.orderDate;
     _dueDate = template?.dueDate;
@@ -1800,7 +1815,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   @override
   void dispose() {
     _customerController.dispose();
-    _customerExtraInfoController.dispose();
+    _formExtraInfoController.dispose();
     _commentsController.dispose();
     _packagingController.dispose();
     _lengthController.dispose();
@@ -3553,7 +3568,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             !hadFormBefore;
         if (hasNewFormPayload) {
           final customer = _customerController.text.trim();
-          final extraInfo = _customerExtraInfoController.text.trim();
+          final extraInfo = _formExtraInfoController.text.trim();
           String series = customer.isNotEmpty ? customer : 'F';
           if (extraInfo.isNotEmpty) {
             series = '$series ($extraInfo)';
@@ -3894,10 +3909,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                       label: 'Заказчик',
                       labelWidth: labelWidth,
                       child: _buildCustomerField(),
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: _buildCustomerExtraInfoField(),
                     ),
                     _buildLabelRow(
                       label: 'Тип',
@@ -5336,8 +5347,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         _buildFieldGrid([
           _buildManagerField(),
           _buildCustomerField(),
-          const SizedBox(height: 8),
-          _buildCustomerExtraInfoField(),
           _buildDatePickerField(
             label: 'Дата заказа',
             value: _orderDate,
@@ -5654,11 +5663,11 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     );
   }
 
-  Widget _buildCustomerExtraInfoField() {
+  Widget _buildFormExtraInfoField() {
     return TextFormField(
-      controller: _customerExtraInfoController,
+      controller: _formExtraInfoController,
       decoration: const InputDecoration(
-        labelText: 'Доп. информация',
+        labelText: 'Доп. информация формы',
         hintText: 'Необязательно',
         border: OutlineInputBorder(),
       ),
@@ -6713,7 +6722,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         controller: _formSearchCtl,
         focusNode: _formSearchFocusNode,
         decoration: const InputDecoration(
-          hintText: 'Поиск формы (название или код)',
+          hintText: 'Поиск формы (название, код или доп. информация)',
           prefixIcon: Icon(Icons.search),
           border: OutlineInputBorder(),
         ),
@@ -6745,6 +6754,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       }
     } else {
       widgets.add(const SizedBox(height: 4));
+      widgets.add(_buildFormExtraInfoField());
+      widgets.add(const SizedBox(height: 8));
       if (_newFormImageBytes != null) {
         widgets.add(Padding(
           padding: const EdgeInsets.only(bottom: 8),


### PR DESCRIPTION
### Motivation
- Keep "form extra info" in sync between form series strings and the form editor fields so extra info is preserved and editable.
- Consolidate the previous `customerExtraInfo` usage into a dedicated form-specific field to avoid confusion between customer and form metadata.
- Improve search and creation flows to support searching by and storing the extra info that can be embedded in a form series like `F (extra)`.

### Description
- Added `_extractFormExtraInfoFromSeries` to parse trailing parentheses from a series string and return the inner content as the form extra info. 
- Replaced `customerExtraInfo` controller with `formExtraInfo` by renaming ` _customerExtraInfoController` to `_formExtraInfoController` and updating all references, `initState`, and `dispose` accordingly.
- When loading a form series, populate `_formExtraInfoController` with the extracted extra info if it differs from the current text. 
- Use `_formExtraInfoController` value when creating new forms so the created series is formatted as `series (extraInfo)` when appropriate. 
- Updated UI: removed the old customer-extra field placements and added `_buildFormExtraInfoField` inside the new-form block, changed search hint to include extra info, and adjusted label/hint text to `Доп. информация формы`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84217e108832f95bcd0faf27a220f)