### PR TITLE
Fix production queue to append new orders at end

### DIFF
--- a/lib/modules/production/production_queue_provider.dart
+++ b/lib/modules/production/production_queue_provider.dart
@@ -296,7 +296,7 @@ class ProductionQueueProvider with ChangeNotifier {
     // This guarantees that a freshly created order never jumps to the top,
     // even if upstream lists are sorted by "newest first".
     final missingIds = <String>[];
-    for (final id in normalizedIds) {
+    for (final id in normalizedIds.reversed) {
       if (!sequence.contains(id)) {
         missingIds.add(id);
       }


### PR DESCRIPTION
### Motivation
- Ensure that newly created orders are appended to the end of the production queue so a new order does not jump to the top when upstream lists are provided in "newest-first" order (affects production task ordering UX). 

### Description
- In `lib/modules/production/production_queue_provider.dart` updated `ProductionQueueProvider.syncOrders` to collect missing IDs by iterating `normalizedIds.reversed` before calling `sequence.addAll(missingIds)`, so previously unseen orders are appended to the tail in the intended order.

### Testing
- Committed the change and verified the modified file in the working tree with `git status --short` and a successful `git commit`; change is present in `lib/modules/production/production_queue_provider.dart`.
- Attempted to run `dart format lib/modules/production/production_queue_provider.dart` but it failed due to missing `dart` in the environment (`/bin/bash: line 1: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8462c41c8832f9a17e5d0e5505685)