### PR TITLE
Удаление неактуальных этапов заказа по выбранным опциям

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -15,6 +15,7 @@ import '../../services/storage_service.dart';
 import 'package:image_picker/image_picker.dart';
 import 'dart:typed_data';
 import 'orders_provider.dart';
+import 'order_stage_filter.dart';
 import 'orders_repository.dart';
 import 'order_model.dart';
 import 'product_model.dart';
@@ -966,6 +967,19 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _scheduleStagePreviewUpdate(immediate: true);
   }
 
+
+  OrderHandleType _resolveSelectedHandleType() {
+    if (_selectedHandleDescription.trim().isEmpty ||
+        _selectedHandleDescription.trim() == '-') {
+      return OrderHandleType.none;
+    }
+    final normalized = _selectedHandleDescription.toLowerCase();
+    if (normalized.contains('круч') || normalized.contains('twist')) {
+      return OrderHandleType.twisted;
+    }
+    return OrderHandleType.flat;
+  }
+
   Future<_StageRuleOutcome> _applyStageRules(
       List<Map<String, dynamic>> rawStages) async {
     final List<Map<String, dynamic>> stageMaps = rawStages
@@ -1306,8 +1320,15 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       normalized.add(map);
     }
 
-    return _StageRuleOutcome(
+    final filteredStages = filterOrderStagesByOptions(
       stages: normalized,
+      selectedHandleType: _resolveSelectedHandleType(),
+      hasCardboard: _cardboardChecked,
+      hasCutting: _trimming,
+    );
+
+    return _StageRuleOutcome(
+      stages: filteredStages,
       shouldCompleteBobbin: shouldCompleteBobbin,
       bobbinId: bobbinId,
     );
@@ -5453,13 +5474,17 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                   onChanged: (val) => setState(() {
                     _cardboardChecked = val ?? false;
                     _selectedCardboard = _cardboardChecked ? 'есть' : 'нет';
+                    _scheduleStagePreviewUpdate(immediate: true);
                   }),
                   label: 'Картон',
                   width: 100,
                 ),
                 _buildCompactCheckboxTile(
                   value: _trimming,
-                  onChanged: (val) => setState(() => _trimming = val ?? false),
+                  onChanged: (val) => setState(() {
+                    _trimming = val ?? false;
+                    _scheduleStagePreviewUpdate(immediate: true);
+                  }),
                   label: 'Подрезка',
                   width: 100,
                 ),
@@ -5498,6 +5523,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                             desc.isEmpty ? '-' : matches.first.description;
                       }
                     }
+                    _scheduleStagePreviewUpdate(immediate: true);
                   });
                 },
               ),

--- a/lib/modules/orders/order_stage_filter.dart
+++ b/lib/modules/orders/order_stage_filter.dart
@@ -1,0 +1,46 @@
+enum OrderHandleType { none, flat, twisted }
+
+const String flatHandleStageId = '6fdff2d9-3f57-45ca-9fad-dd700ac5c320';
+const String twistedHandleStageId = 'c5c1eb2e-dac8-4068-9e4c-ced8fb975626';
+const String cuttingStageId = 'c828062f-a6a6-4fe5-b01b-c51e36fe5fba';
+const String cardboardStageId = 'ce15da53-34bb-4a48-acef-610dddfad42e';
+
+List<Map<String, dynamic>> filterOrderStagesByOptions({
+  required List<Map<String, dynamic>> stages,
+  required OrderHandleType selectedHandleType,
+  required bool hasCardboard,
+  required bool hasCutting,
+}) {
+  bool shouldKeepStage(String stageId) {
+    if (stageId == flatHandleStageId) {
+      return selectedHandleType == OrderHandleType.flat;
+    }
+    if (stageId == twistedHandleStageId) {
+      return selectedHandleType == OrderHandleType.twisted;
+    }
+    if (stageId == cardboardStageId) {
+      return hasCardboard;
+    }
+    if (stageId == cuttingStageId) {
+      return hasCutting;
+    }
+    return true;
+  }
+
+  final filtered = <Map<String, dynamic>>[];
+  for (final stage in stages) {
+    final map = Map<String, dynamic>.from(stage);
+    final stageId = (map['stageId'] ??
+            map['stage_id'] ??
+            map['stageid'] ??
+            map['workplaceId'] ??
+            map['workplace_id'] ??
+            map['id'])
+        ?.toString()
+        .trim();
+    if (stageId == null || stageId.isEmpty || shouldKeepStage(stageId)) {
+      filtered.add(map);
+    }
+  }
+  return filtered;
+}

--- a/test/order_stage_filter_test.dart
+++ b/test/order_stage_filter_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/order_stage_filter.dart';
+
+Map<String, dynamic> _stage(String id) => {'stageId': id, 'stageName': id};
+
+void main() {
+  final baseStages = [
+    _stage(flatHandleStageId),
+    _stage(twistedHandleStageId),
+    _stage(cardboardStageId),
+    _stage(cuttingStageId),
+    _stage('other-stage'),
+  ];
+
+  test('removes optional stages when options disabled', () {
+    final filtered = filterOrderStagesByOptions(
+      stages: baseStages,
+      selectedHandleType: OrderHandleType.none,
+      hasCardboard: false,
+      hasCutting: false,
+    );
+
+    expect(filtered.map((s) => s['stageId']), ['other-stage']);
+  });
+
+  test('keeps only twisted handle stage', () {
+    final filtered = filterOrderStagesByOptions(
+      stages: baseStages,
+      selectedHandleType: OrderHandleType.twisted,
+      hasCardboard: false,
+      hasCutting: false,
+    );
+
+    expect(filtered.map((s) => s['stageId']), [twistedHandleStageId, 'other-stage']);
+  });
+
+  test('keeps only flat handle stage and enabled flags', () {
+    final filtered = filterOrderStagesByOptions(
+      stages: baseStages,
+      selectedHandleType: OrderHandleType.flat,
+      hasCardboard: true,
+      hasCutting: true,
+    );
+
+    expect(filtered.map((s) => s['stageId']), [
+      flatHandleStageId,
+      cardboardStageId,
+      cuttingStageId,
+      'other-stage',
+    ]);
+  });
+}


### PR DESCRIPTION
### Motivation
- Нужно исключать из очереди этапов те этапы шаблона, которые не соответствуют текущим опциям заказа (тип ручек, картон, подрезка), а не просто скрывать их в UI. 
- Функция должна работать при создании и при редактировании заказа и гарантировать, что в БД не сохранятся лишние этапы.

### Description
- Добавлена чистая функция `filterOrderStagesByOptions(...)` в `lib/modules/orders/order_stage_filter.dart`, содержащая жёсткие правила по ID этапов для плоских/крученых ручек, картон и резка. 
- Интегрирована фильтрация в пайплайн нормализации этапов `_applyStageRules` в `lib/modules/orders/edit_order_screen.dart`, так что перед возвратом `_StageRuleOutcome` список этапов очищается по опциям заказа. 
- Добавлена логика определения типа ручек через `_resolveSelectedHandleType()` и триггеры пересчёта preview при изменении полей ручек, чекбоксов `Картон` и `Подрезка`, чтобы очередь этапов в форме и сохраняемые данные оставались синхронизированы. 
- Добавлены unit-тесты `test/order_stage_filter_test.dart`, покрывающие ключевые сценарии: без опций, только крученые ручки, плоские ручки с включёнными флагами картон/подрезка.

### Testing
- Добавлены автоматические unit-тесты в `test/order_stage_filter_test.dart`, которые проверяют удаление/сохранение этапов в трёх ключевых сценариях. 
- Попытка запустить `flutter test test/order_stage_filter_test.dart` в этом окружении завершилась неудачей из‑за отсутствия Flutter (`flutter: command not found`). 
- Рекомендуется запустить тесты в CI или локально с установленным Flutter; в таком окружении добавленные тесты должны успешно пройти (тестовые проверки на фильтрацию реализованы и локально не зависят от внешних сервисов).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f873801234832fb2aebf8d1c5530d4)