### PR TITLE
Hide inactive stages in production assignment list

### DIFF
--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -283,6 +283,9 @@ class _ProductionScreenState extends State<ProductionScreen>
 
     for (final group in groups) {
       final tasksForStage = tasksByGroup[group.key] ?? const <TaskModel>[];
+      if (tasksForStage.isEmpty) {
+        continue;
+      }
       final status = _groupStatus(tasksForStage);
       final color = _stageColor(status);
       final label = group.label;
@@ -308,6 +311,13 @@ class _ProductionScreenState extends State<ProductionScreen>
           ],
         ),
       ));
+    }
+
+    if (chips.isEmpty) {
+      return const Text(
+        'Этапы не назначены',
+        style: TextStyle(color: Colors.black54),
+      );
     }
 
     return SingleChildScrollView(
@@ -340,9 +350,25 @@ class _ProductionScreenState extends State<ProductionScreen>
 
     final workplaces = List.of(personnelProvider.workplaces)
       ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+
+    final tasksByOrder = <String, List<TaskModel>>{};
+    for (final task in tasks) {
+      tasksByOrder.putIfAbsent(task.orderId, () => []).add(task);
+    }
+
+    final activeWorkplaceIds = <String>{};
+    for (final order in orders) {
+      final orderTasks = tasksByOrder[order.id] ?? const <TaskModel>[];
+      final grouping = _groupingForOrder(order, orderTasks);
+      if (grouping.isCompleted) continue;
+      activeWorkplaceIds.addAll(grouping.visibleWorkplaceIds);
+    }
+
     final tabs = [
       const _ProductionTabInfo(id: _allTabId, label: _allLabel, isAll: true),
-      for (final w in workplaces) _ProductionTabInfo(id: w.id, label: w.name),
+      for (final w in workplaces)
+        if (activeWorkplaceIds.contains(w.id))
+          _ProductionTabInfo(id: w.id, label: w.name),
       const _ProductionTabInfo(
         id: _completedTabId,
         label: _completedLabel,


### PR DESCRIPTION
### Motivation
- Убрать из основного списка производственных заданий визуальные элементы для этапов, которые сейчас неактивны и не имеют задач, чтобы рабочие места и этапы без реальной активности не засоряли интерфейс.

### Description
- В `lib/modules/production/production_screen.dart` при построении строки этапов (`_buildStageRow`) пропускаются группы этапов, для которых в `tasksByGroup` нет задач, и если после фильтрации ничего не осталось — показывается текст `Этапы не назначены`.
- В том же файле добавлен расчёт `activeWorkplaceIds` на основе текущих заказов и задач, и вкладки рабочих мест в главном списке теперь включают только те рабочие места, у которых есть активные (незавершённые) видимые этапы.
- Сохранён порядок групп этапов (используется порядок из шаблона/плана), изменена только визуальная фильтрация отображения этапов и вкладок.

### Testing
- Выполнены командные проверки `git diff` и `git status` и изменения зафиксированы в репозитории (коммит прошёл успешно). 
- Попытка запустить `dart format` завершилась неудачей из окружения — `dart: command not found`, поэтому автоформатирование не проверялось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8792f4574832f890d201279cb7804)