### PR TITLE
Fix production_screen.dart build error by removing undefined _groupingForOrder call

### DIFF
--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -359,9 +359,15 @@ class _ProductionScreenState extends State<ProductionScreen>
     final activeWorkplaceIds = <String>{};
     for (final order in orders) {
       final orderTasks = tasksByOrder[order.id] ?? const <TaskModel>[];
-      final grouping = _groupingForOrder(order, orderTasks);
-      if (grouping.isCompleted) continue;
-      activeWorkplaceIds.addAll(grouping.visibleWorkplaceIds);
+      final hasActiveTasks = orderTasks.any((task) => task.status != TaskStatus.completed);
+      if (!hasActiveTasks) continue;
+      for (final task in orderTasks) {
+        final stageId = task.stageId.trim();
+        if (stageId.isEmpty) continue;
+        if (task.status != TaskStatus.completed) {
+          activeWorkplaceIds.add(stageId);
+        }
+      }
     }
 
     final tabs = [


### PR DESCRIPTION
### Motivation
- Fix a Windows build error caused by `The method '_groupingForOrder' isn't defined for the type '_ProductionScreenState'` in `production_screen.dart`.
- Ensure active workplace tabs are derived from current order/task state in a way that does not rely on the missing method.

### Description
- Replaced the call to `_groupingForOrder(order, orderTasks)` when collecting `activeWorkplaceIds` with a local iteration over `orderTasks` that adds non-empty `stageId` values for tasks whose `status` is not `TaskStatus.completed`.
- Added an early skip for orders without any active tasks using `orderTasks.any((task) => task.status != TaskStatus.completed)` to avoid including completed orders.
- Kept the subsequent tab construction logic unchanged so the `_completed` tab behavior remains intact.

### Testing
- Attempted `flutter analyze lib/modules/production/production_screen.dart`, but the command failed because `flutter` is not available in this environment. No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87c843d4c832fa47586e64baf7407)