### PR TITLE
Automatic stage queue builder and "Собрать очередь" action for order editor

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -16,6 +16,7 @@ import 'package:image_picker/image_picker.dart';
 import 'dart:typed_data';
 import 'orders_provider.dart';
 import 'order_stage_filter.dart';
+import 'stage_queue_builder.dart';
 import 'orders_repository.dart';
 import 'order_model.dart';
 import 'product_model.dart';
@@ -508,6 +509,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   String? _stagePreviewError;
   bool _stagePreviewScheduled = false;
   bool _stagePreviewInitialized = false;
+  bool _isStageQueueBuilt = false;
   bool _updatingStageTemplateText = false;
   bool _lastPreviewPaintsFilled = false;
   MaterialModel? _selectedMaterial;
@@ -962,6 +964,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       _stagePreviewInitialized = false;
       _stagePreviewScheduled = false;
       _stageOrderManuallyChanged = false;
+      _isStageQueueBuilt = false;
     });
 
     _scheduleStagePreviewUpdate(immediate: true);
@@ -1385,6 +1388,39 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       _stagePreviewStages = next;
       // Важно: после ручного swap больше не должны возвращать auto-порядок.
       _stageOrderManuallyChanged = true;
+      _isStageQueueBuilt = false;
+    });
+  }
+
+  void _buildStageQueue() {
+    final next = _stagePreviewStages
+        .map((s) => Map<String, dynamic>.from(s))
+        .where((s) => ((s['stageId'] ?? s['id'] ?? '').toString()) != kPackagingStageId)
+        .toList(growable: true);
+    final productTypeId = _product.productTypeId;
+    Map<String, dynamic>? productStage;
+    if (kVTypeProducts.contains(productTypeId)) {
+      productStage = {'stageId': kFriStageId, 'stageName': 'Фри'};
+    } else if (productTypeId == '71c889cb-b24c-4bda-9a69-ae312f9a4bbd') {
+      productStage = {'stageId': kAutoBigStageId, 'stageName': 'Автомат большой'};
+    } else if (productTypeId == 'aab3ed17-1688-43f0-b623-58dac264941f' ||
+        productTypeId == 'b07cd977-939c-4d4f-b68c-8d163341460e') {
+      productStage = {'stageId': kSheetCutStageId, 'stageName': 'Листорезка'};
+    }
+    var queue = next;
+    if (productStage != null) {
+      queue = insertProductStageAfterBaseStages(queue, productStage);
+    }
+    queue = queue.where((s) {
+      final id = (s['stageId'] ?? s['id'] ?? '').toString();
+      return id != kFriStageId && id != kWindowStageId && id != kAutoBigStageId && id != kAutoSmallStageId && id != kTubeStageId || s == productStage;
+    }).toList();
+    queue.add({'stageId': kPackagingStageId, 'stageName': 'Упаковка'});
+    final seen = <String>{};
+    queue = queue.where((s) => seen.add((s['stageId'] ?? s['id']).toString())).toList();
+    setState(() {
+      _stagePreviewStages = queue;
+      _isStageQueueBuilt = true;
     });
   }
 
@@ -1699,6 +1735,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         _stagePreviewError = null;
         _stagePreviewInitialized = true;
         _stageOrderManuallyChanged = false;
+        _isStageQueueBuilt = false;
       });
     } catch (e) {
       if (!mounted) return;
@@ -2725,8 +2762,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       return true;
     }
 
-    final bool hasStageQueueSelected =
-        _stageTemplateId != null && _stageTemplateId!.trim().isNotEmpty;
+    final bool hasStageQueueSelected = _isStageQueueBuilt;
     final bool canLaunchProductionNow =
         hasStageQueueSelected && hasEnoughPaperForLaunch();
     final bool wasAlreadyLaunched = widget.order?.assignmentCreated ?? false;
@@ -3269,7 +3305,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
-            'Заказ сохранён в черновиках: выберите очередь этапов для подготовки к запуску.',
+            'Сначала соберите очередь этапов',
           ),
         ),
       );
@@ -6091,6 +6127,16 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   Widget _buildProductionSection(BuildContext context,
       {bool wrapWithCard = true, bool includeMakeready = true}) {
     final children = <Widget>[];
+    children.add(
+      Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: FilledButton.icon(
+          onPressed: _buildStageQueue,
+          icon: const Icon(Icons.auto_fix_high),
+          label: const Text('Собрать очередь'),
+        ),
+      ),
+    );
 
     if (includeMakeready) {
       children.add(_buildMakereadyFields());
@@ -6310,7 +6356,18 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               '')
           .toString()
           .trim();
-      children.add(Container(
+      children.add(GestureDetector(
+        onTap: () {
+          final id = (stage['stageId'] ?? stage['id'] ?? '').toString();
+          final toggled = toggleProductStage(id);
+          if (toggled == null) return;
+          setState(() {
+            stage['stageId'] = toggled;
+            stage['id'] = toggled;
+            _isStageQueueBuilt = true;
+          });
+        },
+        child: Container(
         margin: EdgeInsets.only(top: i == 0 ? 0 : 8),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
@@ -6340,7 +6397,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             ),
           ],
         ),
-      ));
+      )));
     }
 
     return Column(

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -1,0 +1,46 @@
+const String kPackagingStageId = 'edeb85db-c7a3-4a24-8f33-70ccdd4aaae1';
+const String kFriStageId = '92d96ee9-0519-40b9-bd17-9bec475496b6';
+const String kWindowStageId = '8337f16e-c2d1-42dc-966d-6277ba3c1a50';
+const String kAutoBigStageId = 'fdbf1735-a67c-47c9-a7e1-90546e1fe6ed';
+const String kAutoSmallStageId = 'cbcbe469-b924-4064-ae05-885ccd1b842a';
+const String kTubeStageId = 'e62fc013-4785-43f3-b3ee-a3ca51777199';
+const String kSheetCutStageId = '19a67630-8374-4f9f-ae5b-f2f66828720b';
+
+const Set<String> kVTypeProducts = {
+  '448b731a-eafe-40f1-9268-bc5dd6ba57bc',
+  '688ce20b-2db5-43ed-a414-dda08443a06a',
+  'd2323dba-74c9-4e86-adfb-18cd47be9480',
+  'dfd3beb1-1afd-4c06-9b3b-5da680377b0d',
+};
+
+List<Map<String, dynamic>> insertProductStageAfterBaseStages(
+  List<Map<String, dynamic>> queue,
+  Map<String, dynamic> productStage,
+) {
+  final ids = queue.map((e) => (e['stageId'] ?? e['id'] ?? '').toString()).toList();
+  final baseIds = <String>{'w_bobiner', 'w_bobbin', 'w_flexoprint'};
+  var insertAt = -1;
+  for (var i = 0; i < ids.length; i++) {
+    if (baseIds.contains(ids[i])) insertAt = i;
+  }
+  final next = List<Map<String, dynamic>>.from(queue);
+  next.insert(insertAt + 1, productStage);
+  return next;
+}
+
+String? toggleProductStage(String stageId) {
+  switch (stageId) {
+    case kFriStageId:
+      return kWindowStageId;
+    case kWindowStageId:
+      return kFriStageId;
+    case kAutoBigStageId:
+      return kAutoSmallStageId;
+    case kAutoSmallStageId:
+      return kTubeStageId;
+    case kTubeStageId:
+      return kAutoBigStageId;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement automatic assembly of production stage queue from order parameters instead of requiring manual stage selection.  
- Ensure orders cannot be launched until the employee explicitly builds the queue by pressing `Собрать очередь`.  
- Support product-specific insertion and toggling rules (V-type products → Фри/Окно, P-package → Автомат variants, sheets → Листорезка) and always append packaging as the final stage.

### Description
- Added `lib/modules/orders/stage_queue_builder.dart` with stage ID constants, `insertProductStageAfterBaseStages(...)` to insert product stages after bobbin/flexo base stages (or at start), and `toggleProductStage(...)` to cycle/toggle product stage variants.  
- Updated `lib/modules/orders/edit_order_screen.dart` to track `_isStageQueueBuilt`, added `_buildStageQueue()` which: clears auto-packaging, inserts product stage according to product type, enforces packaging as the last stage, removes duplicates and non-relevant product-stage variants, and sets `_isStageQueueBuilt = true`.  
- Added a UI `Собрать очередь` button in the production section that calls `_buildStageQueue()`, and enabled tapping a stage to toggle product stages using `toggleProductStage(...)`.  
- Changed readiness/launch checks on save to depend on built queue state (`_isStageQueueBuilt`) and replaced the previous selection prompt with the error message `Сначала соберите очередь этапов` when the queue is not built.

### Testing
- Attempted to run static analysis with `flutter analyze lib/modules/orders/edit_order_screen.dart lib/modules/orders/stage_queue_builder.dart`, but it failed due to the environment lacking Flutter (`/bin/bash: flutter: command not found`).  
- No other automated tests were executed in this environment; changes were committed (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c1f61948832f8b3f4bb95370faa6)