### PR TITLE
Use ProductModel.type in stage queue builder to fix compile error

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1397,7 +1397,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         .map((s) => Map<String, dynamic>.from(s))
         .where((s) => ((s['stageId'] ?? s['id'] ?? '').toString()) != kPackagingStageId)
         .toList(growable: true);
-    final productTypeId = _product.productTypeId;
+    final productTypeId = _product.type.trim();
     Map<String, dynamic>? productStage;
     if (kVTypeProducts.contains(productTypeId)) {
       productStage = {'stageId': kFriStageId, 'stageName': 'Фри'};


### PR DESCRIPTION
### Motivation
- Fix a compile error in `lib/modules/orders/edit_order_screen.dart` where `_buildStageQueue()` referenced a non-existent getter `ProductModel.productTypeId`.

### Description
- Replace `_product.productTypeId` with `_product.type.trim()` in `_buildStageQueue()` so the code uses the existing `ProductModel.type` field.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c5cc4160832fab918619055d22a0)