### PR TITLE
Показывать собранную очередь этапов без выбора шаблона

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -6277,7 +6277,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   Widget _buildStagePreviewSection(BuildContext context) {
     final theme = Theme.of(context);
-    if (_stageTemplateId == null || _stageTemplateId!.isEmpty) {
+    if ((_stageTemplateId == null || _stageTemplateId!.isEmpty) &&
+        _stagePreviewStages.isEmpty) {
       return Text(
         'Выберите очередь, чтобы просмотреть этапы производства',
         style: theme.textTheme.bodySmall,


### PR DESCRIPTION
### Motivation
- Исправить UX: после нажатия «Собрать очередь» собранная очередь должна отображаться даже если не выбран шаблон очереди, вместо постоянного показа подсказки «Выберите очередь…». 

### Description
- Изменён условный пропуск в `Widget _buildStagePreviewSection` так, чтобы подсказка отображалась только когда одновременно `(_stageTemplateId == null || _stageTemplateId!.isEmpty)` и `_stagePreviewStages.isEmpty`, что позволяет показывать автоматически собранный список этапов без выбора шаблона; файл изменён: `lib/modules/orders/edit_order_screen.dart`.

### Testing
- Попытка запустить `dart format lib/modules/orders/edit_order_screen.dart` завершилась неудачей в окружении из‑за отсутствия `dart`, но патч успешно применён и файл обновлён; никаких автоматических тестов в этой среде не выполнялось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c83e0154832fb5657d0ecbf1f7f2)