### PR TITLE
Allow stage queue assembly without mandatory template selection

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1393,10 +1393,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   }
 
   void _buildStageQueue() {
-    final next = _stagePreviewStages
+    var next = _stagePreviewStages
         .map((s) => Map<String, dynamic>.from(s))
         .where((s) => ((s['stageId'] ?? s['id'] ?? '').toString()) != kPackagingStageId)
         .toList(growable: true);
+    if (next.isEmpty) {
+      next = _applyBaseStageRulesForQueuePreview();
+    }
     final productTypeId = _product.type.trim();
     Map<String, dynamic>? productStage;
     if (kVTypeProducts.contains(productTypeId)) {
@@ -1422,6 +1425,27 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       _stagePreviewStages = queue;
       _isStageQueueBuilt = true;
     });
+  }
+
+  List<Map<String, dynamic>> _applyBaseStageRulesForQueuePreview() {
+    final stages = <Map<String, dynamic>>[];
+    if (_trimming) {
+      stages.add({
+        'stageId': _canonicalBobbinWorkplaceId,
+        'workplaceId': _canonicalBobbinWorkplaceId,
+        'stageName': 'Бобинорезка',
+        'workplaceName': 'Бобинорезка',
+      });
+    }
+    if (_hasAnyPaints()) {
+      stages.add({
+        'stageId': _canonicalFlexoWorkplaceId,
+        'workplaceId': _canonicalFlexoWorkplaceId,
+        'stageName': 'Флексопечать',
+        'workplaceName': 'Флексопечать',
+      });
+    }
+    return stages;
   }
 
   List<Map<String, dynamic>> _decodeAndSortStageMaps(dynamic stagesData) {
@@ -1647,7 +1671,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   void _scheduleStagePreviewUpdate({bool immediate = false}) {
     if (!mounted) return;
-    if (_stageTemplateId == null || _stageTemplateId!.isEmpty) return;
+    if ((_stageTemplateId == null || _stageTemplateId!.isEmpty) &&
+        _stagePreviewStages.isNotEmpty) {
+      return;
+    }
     if (immediate) {
       _stagePreviewScheduled = false;
       _rebuildStagePreview();
@@ -1667,9 +1694,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (templateId == null || templateId.isEmpty) {
       if (mounted) {
         setState(() {
-          _stagePreviewStages = <Map<String, dynamic>>[];
+          _stagePreviewStages = _applyBaseStageRulesForQueuePreview();
           _stagePreviewLoading = false;
           _stagePreviewError = null;
+          _stagePreviewInitialized = true;
+          _stageOrderManuallyChanged = false;
+          _isStageQueueBuilt = false;
         });
       }
       return;


### PR DESCRIPTION
### Motivation
- Enable building and launching production orders based on order factors (подрезка/краски) without forcing the employee to choose a stage template first.
- Make the stage preview and queue assembly behave sensibly when no `stageTemplateId` is selected so users can press `Собрать очередь` and proceed.

### Description
- Implemented factor-driven base stage generation for queue preview by adding `_applyBaseStageRulesForQueuePreview` and using it when the preview is empty in `lib/modules/orders/edit_order_screen.dart`.
- Updated `_buildStageQueue` to fall back to factor-generated base stages when `_stagePreviewStages` is empty and still apply product-type insertion and default packaging (`kPackagingStageId`).
- Adjusted preview scheduling and rebuilding logic in `_scheduleStagePreviewUpdate` and `_rebuildStagePreview` so preview is populated from base rules when no template is selected and flags like `_stageOrderManuallyChanged` and `_isStageQueueBuilt` are managed consistently.
- Preserved existing product-stage toggle behavior (`Фри/Окно`, `Автомат большой/маленький/Труба`, `Листорезка`) and packaging placement logic.

### Testing
- Ran `git commit` which succeeded and recorded the change. (succeeded)
- Inspected the produced diff with `git diff` to verify the modifications to `lib/modules/orders/edit_order_screen.dart`. (succeeded)
- Attempted to run `dart format lib/modules/orders/edit_order_screen.dart` but it failed because the environment lacks `dart` (`/bin/bash: line 1: dart: command not found`). (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ca2098c8832fb81f729478065cc8)