### PR TITLE
Ограничить переключение этапов для указанных типов продуктов

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -6390,6 +6390,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       children.add(GestureDetector(
         onTap: () {
           final id = (stage['stageId'] ?? stage['id'] ?? '').toString();
+          final productTypeId = _product.type.trim();
+          if (!canToggleProductStage(productTypeId: productTypeId, stageId: id)) {
+            return;
+          }
           final toggled = toggleProductStage(id);
           if (toggled == null) return;
           setState(() {

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -44,3 +44,19 @@ String? toggleProductStage(String stageId) {
       return null;
   }
 }
+
+bool canToggleProductStage({
+  required String productTypeId,
+  required String stageId,
+}) {
+  final normalizedProductTypeId = productTypeId.trim();
+  if (kVTypeProducts.contains(normalizedProductTypeId)) {
+    return stageId == kFriStageId || stageId == kWindowStageId;
+  }
+  if (normalizedProductTypeId == '71c889cb-b24c-4bda-9a69-ae312f9a4bbd') {
+    return stageId == kAutoBigStageId ||
+        stageId == kAutoSmallStageId ||
+        stageId == kTubeStageId;
+  }
+  return false;
+}


### PR DESCRIPTION
### Motivation
- Нужно, чтобы для перечисленных типов продуктов в очереди появлялись специальные этапы, которые сотрудник мог быстро переключать нажатием, а для остальных типов такое переключение было недоступно.
- Изменение должно обеспечить безопасное поведение предпросмотра этапов и предотвратить непреднамеренные переключения для неподходящих типов продуктов.

### Description
- Добавлена функция `canToggleProductStage(...)` в `lib/modules/orders/stage_queue_builder.dart`, которая возвращает `true` только для допустимых сочетаний `productTypeId` и `stageId` (В-образные типы: `Фри <-> Окно`, П-образный пакет: `Автомат большой -> Автомат маленький -> Труба -> Автомат большой`).
- Обновлён обработчик нажатия на карточку этапа в `lib/modules/orders/edit_order_screen.dart`, чтобы перед вызовом `toggleProductStage` проверять `canToggleProductStage` и отменять действие для остальных комбинаций.
- Логика переключений `toggleProductStage` оставлена без изменений и используется совместно с новой проверкой.

### Testing
- Попытка запустить: `flutter test test/stage_sequence_utils_test.dart test/order_stage_filter_test.dart test/planned_stage_decode_test.dart` завершилась ошибкой в окружении из-за отсутствия `flutter` (`/bin/bash: flutter: command not found`).
- Никакие другие автоматические тесты не были выполнены в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9cd82a1d8832fb8de2c460db26bb0)