### PR TITLE
Вставка продуктовых этапов после бобинорезки/флексопечати и добавление теста

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -17,11 +17,33 @@ List<Map<String, dynamic>> insertProductStageAfterBaseStages(
   List<Map<String, dynamic>> queue,
   Map<String, dynamic> productStage,
 ) {
-  final ids = queue.map((e) => (e['stageId'] ?? e['id'] ?? '').toString()).toList();
-  final baseIds = <String>{'w_bobiner', 'w_bobbin', 'w_flexoprint'};
+  bool isBaseStage(Map<String, dynamic> stage) {
+    final id = (stage['stageId'] ?? stage['id'] ?? '').toString().toLowerCase();
+    final name = (stage['stageName'] ??
+            stage['workplaceName'] ??
+            stage['title'] ??
+            stage['name'] ??
+            '')
+        .toString()
+        .toLowerCase();
+    const baseIds = <String>{
+      'w_bobiner',
+      'w_bobbin',
+      'w_flexoprint',
+      'b92a89d1-8e95-4c6d-b990-e308486e4bf1', // canonical bobbin id
+      '0571c01c-f086-47e4-81b2-5d8b2ab91218', // canonical flexo id
+    };
+    if (baseIds.contains(id)) return true;
+    return name.contains('бобин') ||
+        name.contains('бобтн') ||
+        name.contains('флексо') ||
+        name.contains('flexo') ||
+        name.contains('печать');
+  }
+
   var insertAt = -1;
-  for (var i = 0; i < ids.length; i++) {
-    if (baseIds.contains(ids[i])) insertAt = i;
+  for (var i = 0; i < queue.length; i++) {
+    if (isBaseStage(queue[i])) insertAt = i;
   }
   final next = List<Map<String, dynamic>>.from(queue);
   next.insert(insertAt + 1, productStage);

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/stage_queue_builder.dart';
+
+void main() {
+  test('inserts product stage after bobbin/flexo base stages', () {
+    final queue = [
+      {'stageId': 'b92a89d1-8e95-4c6d-b990-e308486e4bf1', 'stageName': 'Бобинорезка'},
+      {'stageId': '0571c01c-f086-47e4-81b2-5d8b2ab91218', 'stageName': 'Флексопечать'},
+    ];
+
+    final result = insertProductStageAfterBaseStages(
+      queue,
+      {'stageId': kFriStageId, 'stageName': 'Фри'},
+    );
+
+    expect(result[2]['stageId'], kFriStageId);
+  });
+
+  test('inserts product stage first when base stages are missing', () {
+    final result = insertProductStageAfterBaseStages(
+      const [],
+      {'stageId': kSheetCutStageId, 'stageName': 'Листорезка'},
+    );
+
+    expect(result.first['stageId'], kSheetCutStageId);
+  });
+}


### PR DESCRIPTION
### Motivation

- Сделать поведение вставки этапов для специфичных типов продукта (Фри, Автомат большой, Листорезка) надёжным и предсказуемым: когда в очереди присутствуют Бобинорезка/Флексопечать — вставлять после них, иначе — ставить на первое место.

### Description

- Переработана `insertProductStageAfterBaseStages` в `lib/modules/orders/stage_queue_builder.dart` чтобы определять базовые этапы по UUID (включая canonical IDs), legacy-алиасам и по названиям (рус./англ.) и вставлять продуктовый этап сразу после найденного базового этапа.
- Оставлена и использована существующая логика переключения этапов `toggleProductStage` (Фри↔Окно, Автомат большой→Автомат маленький→Труба→Автомат большой) для быстрого изменения нажатиями в UI.
- Добавлен модульный тест `test/stage_queue_builder_test.dart`, который покрывает поведение вставки как при наличии базовых этапов, так и при их отсутствии.

### Testing

- Добавлен и проверен логический юнит-тест `test/stage_queue_builder_test.dart` в кодовой базе, покрывающий сценарии вставки после базовых этапов и вставки в пустую очередь.
- Попытка выполнить `flutter test test/stage_queue_builder_test.dart` завершилась неудачей в CI/локальной среде из-за отсутствия бинарника `flutter` (`/bin/bash: flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9cd82a1d8832fb8de2c460db26bb0)