### PR TITLE
Use widths for bobbin cutting stage rules

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1114,25 +1114,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       return null;
     }
 
-    double? _parseLeadingNumber(String? source) {
-      if (source == null) return null;
-      final match = RegExp(r'[0-9]+(?:[.,][0-9]+)?')
-          .firstMatch(source.replaceAll(',', '.'));
-      if (match == null) return null;
-      return double.tryParse(match.group(0)!);
-    }
-
     double? formatWidth(MaterialModel paper, {required bool isMain}) {
-      final candidates = <String?>[
-        paper.format,
-        if (isMain &&
-            (paper.id ?? '').trim().isEmpty &&
-            (_matSelectedFormat ?? '').trim().isNotEmpty)
-          _matSelectedFormat,
-      ];
-      for (final candidate in candidates) {
-        final fmtWidth = _parseLeadingNumber(candidate);
-        if (fmtWidth != null) return fmtWidth;
+      final width = parseMaterialWidth(paper);
+      if (width != null) return width;
+      if (isMain &&
+          (paper.id ?? '').trim().isEmpty &&
+          (_matSelectedFormat ?? '').trim().isNotEmpty) {
+        return _parseLeadingNumber(_matSelectedFormat);
       }
       return null;
     }
@@ -1392,12 +1380,18 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     });
   }
 
+  MaterialModel? _mainMaterialForStageQueue() {
+    if (_selectedMaterial != null) return _selectedMaterial;
+    final selectedPapers = _collectSelectedPapers();
+    return selectedPapers.isNotEmpty ? selectedPapers.first : null;
+  }
+
   OrderStageQueueDraft _currentStageQueueDraft() {
+    final mainMaterial = _mainMaterialForStageQueue();
     return OrderStageQueueDraft(
       productTypeId: _product.type.trim(),
       orderWidthB: (_product.widthB ?? _product.width).toDouble(),
-      materialWidth:
-          _parseLeadingNumber(_matSelectedFormat ?? _matFormatCtl.text),
+      materialWidth: parseMaterialWidth(mainMaterial),
       hasPaint: _hasAnyPaints(),
       hasTrimming: _trimming,
       hasCardboard: _cardboardChecked,
@@ -1414,7 +1408,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       productTypeId: draft.productTypeId,
       hasCutting: draft.hasTrimming,
       hasCardboard: draft.hasCardboard,
-      hasBobbinCutting: draft.hasTrimming,
       hasFlexPrinting: draft.hasPaint,
       handleType: draft.handleType,
       orderWidthB: draft.orderWidthB,
@@ -1442,14 +1435,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   List<Map<String, dynamic>> _applyBaseStageRulesForQueuePreview() {
     final stages = <Map<String, dynamic>>[];
-    if (_trimming) {
-      stages.add({
-        'stageId': _canonicalBobbinWorkplaceId,
-        'workplaceId': _canonicalBobbinWorkplaceId,
-        'stageName': 'Бобинорезка',
-        'workplaceName': 'Бобинорезка',
-      });
-    }
     if (_hasAnyPaints()) {
       stages.add({
         'stageId': _canonicalFlexoWorkplaceId,
@@ -1654,16 +1639,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   }
 
   double? _paperFormatWidth(MaterialModel paper, {required bool isMain}) {
-    final candidates = <String?>[
-      paper.format,
-      if (isMain &&
-          (paper.id ?? '').trim().isEmpty &&
-          (_matSelectedFormat ?? '').trim().isNotEmpty)
-        _matSelectedFormat,
-    ];
-    for (final candidate in candidates) {
-      final width = _parseLeadingNumber(candidate);
-      if (width != null) return width;
+    final width = parseMaterialWidth(paper);
+    if (width != null) return width;
+    if (isMain &&
+        (paper.id ?? '').trim().isEmpty &&
+        (_matSelectedFormat ?? '').trim().isNotEmpty) {
+      return _parseLeadingNumber(_matSelectedFormat);
     }
     return null;
   }

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -1,4 +1,5 @@
 import 'order_stage_filter.dart';
+import 'material_model.dart';
 
 // Product type IDs from the production routing specification.
 const String kSheetProductTypeId = 'aab3ed17-1688-43f0-b623-58dac264941f';
@@ -51,6 +52,18 @@ const String kBottomGlueStageId = 'bottom_glue';
 
 const String kSwitchableVGroupKey = 'v_bottom_stage';
 const String kSwitchablePGroupKey = 'p_package_stage';
+
+double? _parseLeadingNumber(String? source) {
+  if (source == null) return null;
+  final match = RegExp(r'[0-9]+(?:[.,][0-9]+)?')
+      .firstMatch(source.replaceAll(',', '.'));
+  if (match == null) return null;
+  return double.tryParse(match.group(0)!);
+}
+
+double? parseMaterialWidth(MaterialModel? material) {
+  return _parseLeadingNumber(material?.format);
+}
 
 class OrderStageQueueDraft {
   const OrderStageQueueDraft({
@@ -136,7 +149,6 @@ List<Map<String, dynamic>> buildOrderStageQueue({
   required String productTypeId,
   required bool hasCutting,
   required bool hasCardboard,
-  required bool hasBobbinCutting,
   required bool hasFlexPrinting,
   Object? handleType,
   double? orderWidthB,
@@ -149,12 +161,10 @@ List<Map<String, dynamic>> buildOrderStageQueue({
   final selectedFromSource = selectedSwitchableStageId ??
       _selectedSwitchableStageId(existingStages) ??
       _selectedSwitchableStageId(templateStages);
-  final useLegacyBobbinFlag =
-      orderWidthB == null && materialWidth == null && hasBobbinCutting;
   final draft = OrderStageQueueDraft(
     productTypeId: productTypeId,
-    orderWidthB: useLegacyBobbinFlag ? 0 : orderWidthB,
-    materialWidth: useLegacyBobbinFlag ? 1 : materialWidth,
+    orderWidthB: orderWidthB,
+    materialWidth: materialWidth,
     hasPaint: hasFlexPrinting,
     hasTrimming: hasCutting,
     hasCardboard: hasCardboard,
@@ -190,8 +200,8 @@ class _OrderStageQueueBuilder {
   bool get _needsBobbinCutting {
     final orderWidth = draft.orderWidthB;
     final material = draft.materialWidth;
-    if (orderWidth != null && material != null) return orderWidth < material;
-    return false;
+    if (orderWidth == null || material == null) return false;
+    return orderWidth > 0 && material > 0 && orderWidth < material;
   }
 
   void _appendProductStages() {

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -52,6 +52,24 @@ void main() {
     expect(result.last.sortOrder, result.length);
   });
 
+  test('does not add bobbin cutting without positive widths', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: 'Листы',
+        orderWidthB: 0,
+        materialWidth: 600,
+        hasPaint: false,
+        hasTrimming: false,
+        hasCardboard: false,
+      ),
+    );
+
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kBobbinStageId)),
+    );
+  });
+
   test('keeps separate two-sheet technological stages with unique stage keys', () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(


### PR DESCRIPTION
### Motivation
- Replace brittle boolean flag for bobbin cutting with explicit numeric widths so the builder can decide based on concrete order/material sizes.
- Centralize parsing of material width extracted from `MaterialModel.format` to avoid duplicated logic.

### Description
- Added `parseMaterialWidth(MaterialModel?)` and `_parseLeadingNumber` in `lib/modules/orders/stage_queue_builder.dart` and imported `material_model.dart` there.
- Modified `buildOrderStageQueue(...)` to stop accepting the legacy `hasBobbinCutting` boolean and to pass numeric `orderWidthB` and `materialWidth` into the centralized draft instead.
- Updated `_needsBobbinCutting` to add bobbin cutting only when both widths are non-null, positive and `orderWidthB < materialWidth`.
- In `lib/modules/orders/edit_order_screen.dart` introduced `_mainMaterialForStageQueue()` (use `_selectedMaterial` or first from `_collectSelectedPapers()`), used `_product.widthB ?? _product.width` for order width, and passed numeric `materialWidth` via `parseMaterialWidth(mainMaterial)` into the builder.
- Removed bobbin insertion from `_applyBaseStageRulesForQueuePreview()` (previously controlled by `_trimming`) and updated local format-width helpers to reuse `parseMaterialWidth`.
- Added a unit test `test/stage_queue_builder_test.dart` case to assert bobbin stage is not added when order width is not positive.

### Testing
- Ran `git diff --check` which passed with no whitespace errors.
- Added a unit test that verifies bobbin cutting is not added when `orderWidthB == 0` (test file updated under `test/stage_queue_builder_test.dart`).
- Attempted to run `dart format` and `flutter test` but they were not executed because `dart`/`flutter` are not available in the current environment (commands failed due to missing executables).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb00335078832f9e70336a2380251a)