### PR TITLE
Add workplaceIds stage grouping support

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1695,8 +1695,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   List<Map<String, dynamic>> _templateStageMaps(TemplateModel template) {
     return template.stages
         .map((s) => {
-              'stageId': s.stageId,
-              'workplaceId': s.stageId,
+              'stageId': s.allStageIds.isNotEmpty ? s.allStageIds.first : s.stageId,
+              'workplaceId':
+                  s.allStageIds.isNotEmpty ? s.allStageIds.first : s.stageId,
+              'workplaceIds': List<String>.from(s.allStageIds),
               'stageName': s.stageName,
               'workplaceName': s.stageName,
               if (s.alternativeStageIds.isNotEmpty)
@@ -3166,6 +3168,25 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           legacyStageLookup.containsValue(stageId);
     }
 
+    Iterable<dynamic> _collectIdsFrom(dynamic candidate) sync* {
+      if (candidate is List) {
+        for (final value in candidate) {
+          yield value;
+        }
+        return;
+      }
+      if (candidate is String) {
+        for (final token in candidate.split(',')) {
+          yield token;
+        }
+      }
+    }
+
+    Iterable<dynamic> _collectWorkplaceIds(Map<String, dynamic> sm) sync* {
+      yield* _collectIdsFrom(sm['workplaceIds']);
+      yield* _collectIdsFrom(sm['workplace_ids']);
+    }
+
     Iterable<dynamic> _collectAlternativeIds(Map<String, dynamic> sm) sync* {
       final candidates = <dynamic>[
         sm['alternativeStageIds'],
@@ -3176,17 +3197,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         sm['stage_ids'],
       ];
       for (final candidate in candidates) {
-        if (candidate is List) {
-          for (final value in candidate) {
-            yield value;
-          }
-          continue;
-        }
-        if (candidate is String) {
-          for (final token in candidate.split(',')) {
-            yield token;
-          }
-        }
+        yield* _collectIdsFrom(candidate);
       }
     }
 
@@ -3201,7 +3212,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         }
       }
 
-      addCandidate(_resolveStageId(sm));
+      final workplaceCandidates = _collectWorkplaceIds(sm).toList();
+      if (workplaceCandidates.isNotEmpty) {
+        for (final raw in workplaceCandidates) {
+          addCandidate(raw);
+        }
+      } else {
+        addCandidate(_resolveStageId(sm));
+      }
 
       for (final probe in <dynamic>[
         sm['stageName'],
@@ -3274,6 +3292,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           await _sb.from('prod_plan_stages').insert({
             'plan_id': planId,
             'stage_id': resolvedStageId,
+            'stage_group_key': groupKey,
             'step': step,
             'status': 'waiting',
           });

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -713,7 +713,20 @@ class OrdersProvider with ChangeNotifier {
           ids.add(id);
         }
 
-        add(row['stage_id'] ?? row['stageId'] ?? row['workplace_id']);
+        final workplaceIds = row['workplace_ids'] ?? row['workplaceIds'];
+        if (workplaceIds is List) {
+          for (final id in workplaceIds) {
+            add(id);
+          }
+        } else if (workplaceIds is String) {
+          for (final token in workplaceIds.split(',')) {
+            add(token);
+          }
+        }
+
+        if (ids.isEmpty) {
+          add(row['stage_id'] ?? row['stageId'] ?? row['workplace_id']);
+        }
         final alternatives = row['alternative_stage_ids'] ??
             row['alternativeStageIds'] ??
             row['stage_ids'] ??
@@ -742,7 +755,7 @@ class OrdersProvider with ChangeNotifier {
         if (planId != null && planId.isNotEmpty) {
           final rows = await _supabase
               .from('prod_plan_stages')
-              .select('stage_id, alternative_stage_ids, status, step, step_no, seq')
+              .select('stage_id, alternative_stage_ids, status, step, step_no, seq, stage_group_key')
               .eq('plan_id', planId)
               .order('step', ascending: true);
           if (rows is List) {
@@ -764,6 +777,7 @@ class OrdersProvider with ChangeNotifier {
           if (stages is List) {
             for (final raw in stages.whereType<Map>()) {
               final map = Map<String, dynamic>.from(raw as Map);
+              final workplaceIds = map['workplaceIds'] ?? map['workplace_ids'];
               final stageId = (map['stageId'] ??
                       map['stage_id'] ??
                       map['stageid'] ??
@@ -774,6 +788,7 @@ class OrdersProvider with ChangeNotifier {
               if (stageId == null || stageId.trim().isEmpty) continue;
               stageRows.add({
                 'stage_id': stageId.trim(),
+                if (workplaceIds != null) 'workplace_ids': workplaceIds,
                 if (map['alternativeStageIds'] != null)
                   'alternative_stage_ids': map['alternativeStageIds'],
                 if (map['alternative_stage_ids'] != null)
@@ -795,8 +810,16 @@ class OrdersProvider with ChangeNotifier {
       for (final row in stageRows) {
         final stageIds = _readStageIds(row);
         if (stageIds.isEmpty) continue;
+        final persistedGroupKey = (row['stage_group_key'] ??
+                row['stageGroupKey'] ??
+                row['queue_stage_key'] ??
+                row['queueStageKey'])
+            ?.toString()
+            .trim();
         final groupIds = List<String>.from(stageIds)..sort();
-        final stageGroupKey = groupIds.join('|');
+        final stageGroupKey = (persistedGroupKey != null && persistedGroupKey.isNotEmpty)
+            ? persistedGroupKey
+            : groupIds.join('|');
         final String stageStatus = (row['status'] ?? '').toString().toLowerCase();
         final String taskStatus =
             (stageStatus == 'done' || stageStatus == 'completed')

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -41,14 +41,24 @@ const String kCardboardStageId = cardboardStageId;
 const String kFlatHandleStageId = flatHandleStageId;
 const String kTwistedHandleStageId = twistedHandleStageId;
 
+const String kDieCutA1WorkplaceId = '7c168998-76b8-4a4c-9708-af45c2dbd4f0';
+const String kDieCutA2WorkplaceId = '5a47821b-c276-4deb-90de-f196539fc95d';
+const String kBottomGlueWorkplaceId = 'dee83c5c-4624-4ca4-b36c-47673dc5cd72';
+const String kBottomGlueAltWorkplaceId = 'ad504db5-86c3-4284-8266-42bbf967b064';
+const String kBottomGlueSecondAltWorkplaceId = '96075b60-77d8-4fb2-91b0-bfbe6c1ed13c';
+const String kTwistedHandleWorkplaceId = 'c51ebb2e-dac8-4068-9e4c-ce0d8b975626';
+const String kSharedHandleWorkplaceId = 'c25acbfa-390a-4e87-84aa-536055e013f4';
+const String kFlatHandleWorkplaceId = '6ffdf2d9-3f57-45ca-9fad-dd700ac5c320';
+
 // The following technological stage keys are intentionally distinct even when
 // a customer installation maps several of them to the same physical workplace.
-const String kDieCutA1StageId = 'die_cut_a1';
-const String kDieCutA2StageId = 'die_cut_a2';
+const String kDieCutA1A2StageId = 'die_cut_a1_a2';
 const String kScotchStageId = 'scotch';
 const String kFromTwoSheetsStageId = 'from_two_sheets';
 const String kTubeAssemblyStageId = 'tube_assembly';
-const String kBottomGlueStageId = 'bottom_glue';
+const String kBottomGlueStageId = 'bottom_glue_group';
+const String kTwistedHandleGroupStageId = 'twisted_handle_group';
+const String kFlatHandleGroupStageId = 'flat_handle_group';
 
 const String kSwitchableVGroupKey = 'v_bottom_stage';
 const String kSwitchablePGroupKey = 'p_package_stage';
@@ -121,14 +131,17 @@ class BuiltOrderStage {
   }
 
   Map<String, dynamic> toMap() {
-    final selectedId = selectedWorkplaceId ??
-        (workplaceIds.isNotEmpty ? workplaceIds.first : stageKey);
+    final selectedId = workplaceIds.isNotEmpty ? workplaceIds.first : stageKey;
+    final alternativeIds = workplaceIds
+        .where((id) => id.trim().isNotEmpty && id != selectedId)
+        .toList();
     return {
       'stageKey': stageKey,
       'stageId': selectedId,
       'id': selectedId,
       'workplaceId': selectedId,
       'workplaceIds': List<String>.from(workplaceIds),
+      if (alternativeIds.isNotEmpty) 'alternativeStageIds': alternativeIds,
       'stageName': stageName,
       'workplaceName': stageName,
       'sortOrder': sortOrder,
@@ -225,20 +238,23 @@ class _OrderStageQueueBuilder {
       _add(_stage(kSheetCutStageId, 'Листорезка'));
       _add(_stage(kCuttingStageId, 'Резка'));
       _add(_stage(
-        'die_cut_a1',
-        'Высечка A1',
-        workplaceIds: const [kDieCutA1StageId],
-      ));
-      _add(_stage(
-        'die_cut_a2',
-        'Высечка A2',
-        workplaceIds: const [kDieCutA2StageId],
+        kDieCutA1A2StageId,
+        'Высечка A1/A2',
+        workplaceIds: const [kDieCutA1WorkplaceId, kDieCutA2WorkplaceId],
       ));
       _add(_stage(kScotchStageId, 'Скотч'));
       _add(_stage(kFromTwoSheetsStageId, 'С 2х листов'));
       _add(_stage(kTubeAssemblyStageId, 'Сборка трубы'));
       _appendCardboardStages();
-      _add(_stage(kBottomGlueStageId, 'Склейка дна'));
+      _add(_stage(
+        kBottomGlueStageId,
+        'Склейка дна',
+        workplaceIds: const [
+          kBottomGlueWorkplaceId,
+          kBottomGlueAltWorkplaceId,
+          kBottomGlueSecondAltWorkplaceId,
+        ],
+      ));
       _appendHandleStage();
       return;
     }
@@ -262,9 +278,17 @@ class _OrderStageQueueBuilder {
   void _appendHandleStage() {
     final type = draft.handleType;
     if (type == OrderHandleType.flat) {
-      _add(_stage(kFlatHandleStageId, 'Плоская ручка'));
+      _add(_stage(
+        kFlatHandleGroupStageId,
+        'Плоская ручка',
+        workplaceIds: const [kFlatHandleWorkplaceId, kSharedHandleWorkplaceId],
+      ));
     } else if (type == OrderHandleType.twisted) {
-      _add(_stage(kTwistedHandleStageId, 'Кручёная ручка'));
+      _add(_stage(
+        kTwistedHandleGroupStageId,
+        'Кручёная ручка',
+        workplaceIds: const [kTwistedHandleWorkplaceId, kSharedHandleWorkplaceId],
+      ));
     }
   }
 

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -68,9 +68,16 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
 
   List<String> _plannedStageIds(pcompat.PlannedStage planned) {
     final ids = <String>{};
-    final primary = planned.stageId.trim();
-    if (primary.isNotEmpty) ids.add(primary);
     final extra = planned.extra;
+    final workplaceIds = _decodeStringList(
+      extra['workplaceIds'] ?? extra['workplace_ids'],
+    );
+    if (workplaceIds.isNotEmpty) {
+      ids.addAll(workplaceIds.where((id) => id.trim().isNotEmpty));
+    } else {
+      final primary = planned.stageId.trim();
+      if (primary.isNotEmpty) ids.add(primary);
+    }
     final altIds = _decodeStringList(
       extra['alternativeStageIds'] ?? extra['alternative_stage_ids'],
     );
@@ -268,7 +275,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
           final String planId = plan['id'] as String;
           final rows = await sb
               .from('prod_plan_stages')
-              .select('stage_id, stage_name, workplace_name, name, step, step_no, seq')
+              .select('stage_id, stage_name, workplace_name, name, step, step_no, seq, stage_group_key')
               .eq('plan_id', planId);
 
           if (rows is List && rows.isNotEmpty) {
@@ -277,15 +284,31 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                 .map((r) => Map<String, dynamic>.from(r))
                 .toList()
               ..sort((a, b) => _readStageOrder(a).compareTo(_readStageOrder(b)));
+            final groupedRows = <String, List<Map<String, dynamic>>>{};
             for (final m in normalizedRows) {
-              final id =
-                  (m['stage_id'] ?? m['id'] ?? m['workplace_id'] ?? '').toString();
-              final name =
-                  (m['stage_name'] ?? m['workplace_name'] ?? m['name'] ?? 'Этап')
-                      .toString();
-              if (id.isNotEmpty) {
-                stages.add(pcompat.PlannedStage(stageId: id, stageName: name));
-              }
+              final orderKey = _readStageOrder(m).toString().padLeft(6, '0');
+              final groupKey = (m['stage_group_key'] ?? '').toString().trim();
+              final fallbackId = (m['stage_id'] ?? m['id'] ?? m['workplace_id'] ?? '').toString();
+              final key = '$orderKey::${groupKey.isNotEmpty ? groupKey : fallbackId}';
+              groupedRows.putIfAbsent(key, () => <Map<String, dynamic>>[]).add(m);
+            }
+            for (final rows in groupedRows.values) {
+              final ids = rows
+                  .map((m) => (m['stage_id'] ?? m['id'] ?? m['workplace_id'] ?? '').toString())
+                  .where((id) => id.trim().isNotEmpty)
+                  .toList();
+              if (ids.isEmpty) continue;
+              final first = rows.first;
+              final name = (first['stage_name'] ??
+                      first['workplace_name'] ??
+                      first['name'] ??
+                      'Этап')
+                  .toString();
+              stages.add(pcompat.PlannedStage(
+                stageId: ids.first,
+                stageName: name,
+                extra: {'workplaceIds': ids},
+              ));
             }
           }
         }

--- a/lib/modules/production_planning/compat.dart
+++ b/lib/modules/production_planning/compat.dart
@@ -53,21 +53,44 @@ class PlannedStage {
       );
 
   factory PlannedStage.fromMap(Map<String, dynamic> m) {
-    final id =
-        (m['stage_id'] ?? m['stageId'] ?? m['id'] ?? m['code'])?.toString();
+    final workplaceIds =
+        _readStringList(m['workplaceIds'] ?? m['workplace_ids']);
+    final legacyAlternatives = _readStringList(
+      m['alternativeStageIds'] ?? m['alternative_stage_ids'],
+    );
+    final rawId = workplaceIds.isNotEmpty
+        ? workplaceIds.first
+        : (m['stage_id'] ??
+                m['stageId'] ??
+                m['workplaceId'] ??
+                m['workplace_id'] ??
+                m['id'] ??
+                m['code'])
+            ?.toString();
+    final allWorkplaces = _dedupeOrdered(
+      workplaceIds.isNotEmpty
+          ? workplaceIds
+          : [rawId ?? '', ...legacyAlternatives],
+    );
     final name = (m['stage_name'] ?? m['stageName'] ?? m['name'] ?? m['title'])
             ?.toString() ??
         '';
     final o = m['order'] ?? m['position'] ?? m['idx'] ?? 0;
 
     final result = PlannedStage(
-      stageId: id,
+      stageId: allWorkplaces.isNotEmpty ? allWorkplaces.first : rawId,
       stageName: name,
       order: (o is int) ? o : int.tryParse(o.toString()) ?? 0,
     );
     // сохраняем исходные поля как extra + канонические ключи
     final mm = Map<String, dynamic>.from(m);
     mm['stage_id'] = result.stageId.isEmpty ? name : result.stageId;
+    mm['stageId'] = result.stageId.isEmpty ? name : result.stageId;
+    mm['workplaceId'] = result.stageId.isEmpty ? name : result.stageId;
+    if (allWorkplaces.isNotEmpty) {
+      mm['workplaceIds'] = allWorkplaces;
+      mm['alternativeStageIds'] = allWorkplaces.skip(1).toList();
+    }
     mm['stage_name'] = name;
     mm['order'] = result.order;
     result.extra = mm;
@@ -97,6 +120,26 @@ class PlannedStage {
       extra: extra ?? Map<String, dynamic>.from(this.extra),
     );
   }
+}
+
+List<String> _readStringList(dynamic raw) {
+  if (raw is List) return raw.map((e) => e.toString()).toList();
+  if (raw is String && raw.trim().isNotEmpty) {
+    return raw.split(',').map((e) => e.trim()).toList();
+  }
+  return const [];
+}
+
+List<String> _dedupeOrdered(List<String> values) {
+  final seen = <String>{};
+  final result = <String>[];
+  for (final value in values) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) continue;
+    if (!seen.add(trimmed.toLowerCase())) continue;
+    result.add(trimmed);
+  }
+  return result;
 }
 
 // Универсальный парсер в список PlannedStage

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -2054,20 +2054,37 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           }
         }
 
-        final primary = _resolveStageId(
-          sm['stageId'] ??
-              sm['stageid'] ??
-              sm['stage_id'] ??
-              sm['workplaceId'] ??
-              sm['workplace_id'] ??
-              sm['id'] ??
-              sm['stageName'] ??
-              sm['stage_name'] ??
-              sm['workplaceName'] ??
-              sm['workplace_name'],
-        );
-        if (primary != null && primary.isNotEmpty) {
-          ids.add(primary);
+        void addList(dynamic raw) {
+          if (raw is List) {
+            for (final entry in raw) {
+              final id = _resolveStageId(entry);
+              if (id != null && id.isNotEmpty) ids.add(id);
+              addComposite(entry);
+            }
+          } else if (raw is String) {
+            addComposite(raw);
+          }
+        }
+
+        addList(sm['workplaceIds']);
+        addList(sm['workplace_ids']);
+
+        if (ids.isEmpty) {
+          final primary = _resolveStageId(
+            sm['stageId'] ??
+                sm['stageid'] ??
+                sm['stage_id'] ??
+                sm['workplaceId'] ??
+                sm['workplace_id'] ??
+                sm['id'] ??
+                sm['stageName'] ??
+                sm['stage_name'] ??
+                sm['workplaceName'] ??
+                sm['workplace_name'],
+          );
+          if (primary != null && primary.isNotEmpty) {
+            ids.add(primary);
+          }
         }
 
         addComposite(sm['stageName']);
@@ -2077,14 +2094,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         addComposite(sm['title']);
         addComposite(sm['name']);
 
-        final rawAlt = sm['alternativeStageIds'] ?? sm['alternative_stage_ids'];
-        if (rawAlt is List) {
-          for (final entry in rawAlt) {
-            final id = _resolveStageId(entry);
-            if (id != null && id.isNotEmpty) ids.add(id);
-            addComposite(entry);
-          }
-        }
+        addList(sm['alternativeStageIds'] ?? sm['alternative_stage_ids']);
 
         final rawAltNames =
             sm['alternativeStageNames'] ?? sm['alternative_stage_names'];
@@ -2131,6 +2141,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       final createdStageIds = <String>{};
       for (final sm in stageMaps) {
         final stageIds = _extractStageIds(sm);
+        final resolvedStageIds = stageIds
+            .map((stageId) => workplaceLookup[stageId.toLowerCase()] ??
+                legacyStageLookup[stageId.toLowerCase()] ??
+                stageId)
+            .where((stageId) => stageId.trim().isNotEmpty)
+            .toList();
+        final canonical = List<String>.from(resolvedStageIds)..sort();
+        final stageGroupKey = canonical.join('|');
         for (final stageId in stageIds) {
           if (stageId.isEmpty) continue;
           try {
@@ -2151,6 +2169,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             await _sb.from('tasks').insert({
               'order_id': createdOrUpdatedOrder.id,
               'stage_id': resolvedStageId,
+              'stage_group_key': stageGroupKey.isEmpty ? resolvedStageId : stageGroupKey,
               'status': 'waiting',
               'assignees': [],
               'comments': [],
@@ -2189,17 +2208,30 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           // Rebuild plan stages
           await _sb.from('prod_plan_stages').delete().eq('plan_id', planId);
           int step = 1;
+          String? previousGroupKey;
           for (final sm in stageMaps) {
-            final stageId =
-                (sm['stageId'] as String?) ?? (sm['stage_id'] as String?);
-            if (stageId == null || stageId.isEmpty) continue;
-            await _sb.from('prod_plan_stages').insert({
-              'plan_id': planId,
-              'stage_id': stageId,
-              'step': step,
-              'step_no': step,
-              'status': 'waiting',
-            });
+            final stageIds = _extractStageIds(sm);
+            if (stageIds.isEmpty) continue;
+            final resolvedStageIds = stageIds
+                .map((stageId) => workplaceLookup[stageId.toLowerCase()] ??
+                    legacyStageLookup[stageId.toLowerCase()] ??
+                    stageId)
+                .where((stageId) => stageId.trim().isNotEmpty)
+                .toList();
+            final canonical = List<String>.from(resolvedStageIds)..sort();
+            final groupKey = canonical.join('|');
+            if (groupKey.isNotEmpty && groupKey == previousGroupKey) continue;
+            previousGroupKey = groupKey;
+            for (final stageId in resolvedStageIds) {
+              await _sb.from('prod_plan_stages').insert({
+                'plan_id': planId,
+                'stage_id': stageId,
+                'stage_group_key': groupKey,
+                'step': step,
+                'step_no': step,
+                'status': 'waiting',
+              });
+            }
             step++;
           }
           // Mark bobbin as done here as well

--- a/lib/modules/production_planning/planned_stage_model.dart
+++ b/lib/modules/production_planning/planned_stage_model.dart
@@ -1,6 +1,7 @@
 class PlannedStage {
   final String stageId;
   final String stageName;
+  final List<String> workplaceIds;
   final List<String> alternativeStageIds;
   final List<String> alternativeStageNames;
   String? comment;
@@ -8,14 +9,28 @@ class PlannedStage {
   PlannedStage({
     required this.stageId,
     required this.stageName,
-    this.alternativeStageIds = const [],
+    List<String>? workplaceIds,
+    List<String> alternativeStageIds = const [],
     this.alternativeStageNames = const [],
     this.comment,
-  });
+  })  : workplaceIds = workplaceIds == null || workplaceIds.isEmpty
+            ? _dedupeOrdered(
+                [stageId, ...alternativeStageIds],
+                caseInsensitive: true,
+              )
+            : _dedupeOrdered(workplaceIds, caseInsensitive: true),
+        alternativeStageIds = (workplaceIds == null || workplaceIds.isEmpty
+                ? _dedupeOrdered(
+                    [stageId, ...alternativeStageIds],
+                    caseInsensitive: true,
+                  )
+                : _dedupeOrdered(workplaceIds, caseInsensitive: true))
+            .skip(1)
+            .toList();
 
   List<String> get allStageIds =>
       _dedupeOrdered(
-        [stageId, ...alternativeStageIds],
+        workplaceIds.isNotEmpty ? workplaceIds : [stageId, ...alternativeStageIds],
         caseInsensitive: true,
       );
 
@@ -27,46 +42,72 @@ class PlannedStage {
 
   PlannedStage copyWith({
     String? comment,
+    List<String>? workplaceIds,
     List<String>? alternativeStageIds,
     List<String>? alternativeStageNames,
   }) =>
       PlannedStage(
         stageId: stageId,
         stageName: stageName,
+        workplaceIds: workplaceIds ?? this.workplaceIds,
         alternativeStageIds: alternativeStageIds ?? this.alternativeStageIds,
         alternativeStageNames: alternativeStageNames ?? this.alternativeStageNames,
         comment: comment ?? this.comment,
       );
 
   Map<String, dynamic> toMap() => {
-        'stageId': stageId,
+        'stageId': allStageIds.isNotEmpty ? allStageIds.first : stageId,
+        'workplaceId': allStageIds.isNotEmpty ? allStageIds.first : stageId,
+        'workplaceIds': allStageIds,
         'stageName': stageName,
-        if (alternativeStageIds.isNotEmpty) 'alternativeStageIds': alternativeStageIds,
+        if (allStageIds.length > 1) 'alternativeStageIds': allStageIds.skip(1).toList(),
         if (alternativeStageNames.isNotEmpty) 'alternativeStageNames': alternativeStageNames,
         if (comment != null && comment!.isNotEmpty) 'comment': comment,
       };
 
-  factory PlannedStage.fromMap(Map<String, dynamic> map) => PlannedStage(
-        stageId: map['stageId'] as String,
-        stageName: (map['stageName'] as String? ?? '').trim(),
-        alternativeStageIds: _dedupeOrdered(
-          (map['alternativeStageIds'] as List?)
-                ?.whereType<dynamic>()
-                .map((e) => e.toString())
-                .toList() ??
-              const [],
-          caseInsensitive: true,
+  factory PlannedStage.fromMap(Map<String, dynamic> map) {
+    final primary = (map['stageId'] ??
+                map['stage_id'] ??
+                map['workplaceId'] ??
+                map['workplace_id'] ??
+                map['id'])
+            ?.toString() ??
+        '';
+    final explicitWorkplaces =
+        _readStringList(map['workplaceIds'] ?? map['workplace_ids']);
+    final legacyAlternatives = _readStringList(
+      map['alternativeStageIds'] ?? map['alternative_stage_ids'],
+    );
+    final workplaces = explicitWorkplaces.isNotEmpty
+        ? explicitWorkplaces
+        : _dedupeOrdered([primary, ...legacyAlternatives],
+            caseInsensitive: true);
+    final stageName = (map['stageName'] ?? map['stage_name'] ?? '').toString();
+    return PlannedStage(
+      stageId: workplaces.isNotEmpty ? workplaces.first : primary,
+      stageName: stageName.trim(),
+      workplaceIds: workplaces,
+      alternativeStageIds:
+          workplaces.length > 1 ? workplaces.skip(1).toList() : const [],
+      alternativeStageNames: _dedupeOrdered(
+        _readStringList(
+          map['alternativeStageNames'] ?? map['alternative_stage_names'],
         ),
-        alternativeStageNames: _dedupeOrdered(
-          (map['alternativeStageNames'] as List?)
-                ?.whereType<dynamic>()
-                .map((e) => e.toString())
-                .toList() ??
-              const [],
-          caseInsensitive: true,
-        ),
-        comment: map['comment'] as String?,
-      );
+        caseInsensitive: true,
+      ),
+      comment: map['comment'] as String?,
+    );
+  }
+}
+
+List<String> _readStringList(dynamic raw) {
+  if (raw is List) {
+    return raw.map((e) => e.toString()).toList();
+  }
+  if (raw is String && raw.trim().isNotEmpty) {
+    return raw.split(',').map((e) => e.trim()).toList();
+  }
+  return const [];
 }
 
 List<String> _dedupeOrdered(

--- a/lib/modules/production_planning/template_editor_screen.dart
+++ b/lib/modules/production_planning/template_editor_screen.dart
@@ -26,8 +26,9 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
       _nameCtrl.text = tpl.name;
       _stages.addAll(tpl.stages.map(
         (s) => PlannedStage(
-          stageId: s.stageId,
+          stageId: s.allStageIds.isNotEmpty ? s.allStageIds.first : s.stageId,
           stageName: s.stageName,
+          workplaceIds: s.workplaceIds,
           alternativeStageIds: s.alternativeStageIds,
           alternativeStageNames: s.alternativeStageNames,
           comment: s.comment,
@@ -84,6 +85,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
                         PlannedStage(
                           stageId: primary.id,
                           stageName: primary.name,
+                          workplaceIds: selected.map((e) => e.id).toList(),
                           alternativeStageIds: alternatives.map((e) => e.id).toList(),
                           alternativeStageNames: alternatives.map((e) => e.name).toList(),
                         ),

--- a/lib/modules/tasks/task_model.dart
+++ b/lib/modules/tasks/task_model.dart
@@ -273,6 +273,7 @@ class TaskModel {
         'orderId': orderId,
         'stageId': stageId,
         'stageGroupKey': stageGroupKey,
+        'queueStageKey': stageGroupKey,
         if (capturedByWorkplaceId != null)
           'capturedByWorkplaceId': capturedByWorkplaceId,
         if (capturedByUserId != null) 'capturedByUserId': capturedByUserId,
@@ -340,6 +341,8 @@ class TaskModel {
   final stageGroupKey = _normalizeId(pick([
     'stageGroupKey',
     'stage_group_key',
+    'queueStageKey',
+    'queue_stage_key',
   ]));
   final capturedByWorkplaceId = _normalizeId(
     pick(['capturedByWorkplaceId', 'captured_by_workplace_id']),

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -63,7 +63,7 @@ class TaskProvider with ChangeNotifier {
     final resolvedStageId = _resolveWorkplaceId(_normalizeId(rawStageId));
     data['stageId'] = resolvedStageId;
     final rawStageGroupKey =
-        row['stage_group_key'] ?? row['stageGroupKey'] ?? row['group_key'];
+        row['stage_group_key'] ?? row['stageGroupKey'] ?? row['queue_stage_key'] ?? row['queueStageKey'] ?? row['group_key'];
     final normalizedGroupKey = _normalizeId(rawStageGroupKey);
     data['stageGroupKey'] =
         normalizedGroupKey.isEmpty ? resolvedStageId : normalizedGroupKey;
@@ -438,9 +438,22 @@ class TaskProvider with ChangeNotifier {
       result.add(id);
     }
 
-    addCandidate(
-      pick(const ['stage_id', 'stageId', 'workplace_id', 'workplaceId', 'id']),
-    );
+    dynamic workplaceIds = pick(const ['workplaceIds', 'workplace_ids']);
+    if (workplaceIds is List) {
+      for (final value in workplaceIds) {
+        addCandidate(value);
+      }
+    } else if (workplaceIds is String) {
+      for (final token in workplaceIds.split(',')) {
+        addCandidate(token);
+      }
+    }
+
+    if (result.isEmpty) {
+      addCandidate(
+        pick(const ['stage_id', 'stageId', 'workplace_id', 'workplaceId', 'id']),
+      );
+    }
 
     dynamic alt = pick(const [
       'alternativeStageIds',

--- a/supabase/migrations/20260506_add_stage_group_to_prod_plan_stages.sql
+++ b/supabase/migrations/20260506_add_stage_group_to_prod_plan_stages.sql
@@ -1,0 +1,9 @@
+alter table if exists public.prod_plan_stages
+  add column if not exists stage_group_key text;
+
+update public.prod_plan_stages
+set stage_group_key = stage_id
+where coalesce(stage_group_key, '') = '';
+
+create index if not exists prod_plan_stages_plan_stage_group_idx
+  on public.prod_plan_stages(plan_id, stage_group_key);


### PR DESCRIPTION
### Motivation
- Introduce explicit multi-workplace support so a single logical stage can represent several physical workplaces and keep legacy compatibility with `stageId`/`workplaceId`/`alternativeStageIds` fields.
- Ensure production planning and task creation treat multi-workplace stages as a single unit so one workplace capturing a stage blocks competing workplaces in the same group.
- Provide a DB migration to persist a shared group key for `prod_plan_stages` so normalized plans can reuse the grouping on the server side.

### Description
- Added `workplaceIds` to built queue items and `PlannedStage` and made serialization emit legacy-compatible fields (`stageId`, `workplaceId`, `alternativeStageIds`) using the first ID as primary and remaining IDs as alternatives (`lib/modules/orders/stage_queue_builder.dart`, `lib/modules/production_planning/planned_stage_model.dart`).
- Collapsed configured multi-workplace technological stages into single queue objects with the requested workplace sets for: `die_cut_a1_a2`, `bottom_glue_group`, `twisted_handle_group`, and `flat_handle_group` (workplace UUID lists added) (`lib/modules/orders/stage_queue_builder.dart`).
- Updated stage parsing and resolution to prefer `workplaceIds` when present and fall back to legacy lists; templates and editors now include `workplaceIds` when producing stage maps (`lib/modules/orders/edit_order_screen.dart`, `lib/modules/production_planning/template_editor_screen.dart`).
- When creating tasks and rebuilding production-plan rows the code now computes a canonical `stage_group_key` for multi-workplace steps and stores it on created tasks / `prod_plan_stages` rows so the group is treated atomically at runtime (`lib/modules/orders/orders_provider.dart`, `lib/modules/production_planning/form_editor_screen.dart`, `lib/modules/tasks/task_provider.dart`, `lib/modules/tasks/task_model.dart`).
- Propagated `workplaceIds` into production UI readers and compat layers so planned stages created from `prod_plan_stages` are grouped and expose all workplace IDs (`lib/modules/production/production_details_screen.dart`, `lib/modules/production_planning/compat.dart`).
- Added a Supabase migration file that adds and indexes `stage_group_key` on `prod_plan_stages` to persist group keys server-side (`supabase/migrations/20260506_add_stage_group_to_prod_plan_stages.sql`).

### Testing
- Ran `git diff --check` to validate there are no indexable diff issues; it succeeded.
- Attempted `dart analyze` and `flutter analyze` but those binaries were not available in this environment so static analysis could not be executed here (recommend running both in CI/local dev).
- No failing automated tests were produced by the checks performed in this environment; please run full analyzer and app tests in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb02c23918832f862377036c5cde34)