### PR TITLE
Update order handle routing: add dieCut, fix handle IDs, include manual handle

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -985,15 +985,20 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
 
   OrderHandleType _resolveSelectedHandleType() {
-    if (_selectedHandleDescription.trim().isEmpty ||
-        _selectedHandleDescription.trim() == '-') {
+    final normalized = _selectedHandleDescription.trim().toLowerCase();
+    if (normalized.isEmpty || normalized == '-') {
       return OrderHandleType.none;
     }
-    final normalized = _selectedHandleDescription.toLowerCase();
     if (normalized.contains('круч') || normalized.contains('twist')) {
       return OrderHandleType.twisted;
     }
-    return OrderHandleType.flat;
+    if (normalized.contains('плоск') || normalized.contains('flat')) {
+      return OrderHandleType.flat;
+    }
+    if (normalized.contains('выруб') || normalized.contains('die cut')) {
+      return OrderHandleType.dieCut;
+    }
+    return OrderHandleType.none;
   }
 
   Future<_StageRuleOutcome> _applyStageRules(

--- a/lib/modules/orders/order_stage_filter.dart
+++ b/lib/modules/orders/order_stage_filter.dart
@@ -1,7 +1,9 @@
-enum OrderHandleType { none, flat, twisted }
+enum OrderHandleType { none, flat, twisted, dieCut }
 
-const String flatHandleStageId = '6fdff2d9-3f57-45ca-9fad-dd700ac5c320';
-const String twistedHandleStageId = 'c5c1eb2e-dac8-4068-9e4c-ced8fb975626';
+const String flatHandleStageId = '6ffdf2d9-3f57-45ca-9fad-dd700ac5c320';
+const String twistedHandleStageId = 'c51ebb2e-dac8-4068-9e4c-ce0d8b975626';
+const String manualHandleStageId = 'c25acbfa-390a-4e87-84aa-536055e013f4';
+const String dieCutHandleStageId = '4925309c-a2c6-4f5f-9f5e-7dd5ff38827d';
 const String cuttingStageId = 'c828062f-a6a6-4fe5-b01b-c51e36fe5fba';
 const String cardboardStageId = 'ce15da53-34bb-4a48-acef-610dddfad42e';
 
@@ -17,6 +19,13 @@ List<Map<String, dynamic>> filterOrderStagesByOptions({
     }
     if (stageId == twistedHandleStageId) {
       return selectedHandleType == OrderHandleType.twisted;
+    }
+    if (stageId == manualHandleStageId) {
+      return selectedHandleType == OrderHandleType.flat ||
+          selectedHandleType == OrderHandleType.twisted;
+    }
+    if (stageId == dieCutHandleStageId) {
+      return selectedHandleType == OrderHandleType.dieCut;
     }
     if (stageId == cardboardStageId) {
       return hasCardboard;

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -40,6 +40,8 @@ const String kCuttingStageId = cuttingStageId;
 const String kCardboardStageId = cardboardStageId;
 const String kFlatHandleStageId = flatHandleStageId;
 const String kTwistedHandleStageId = twistedHandleStageId;
+const String kManualHandleStageId = manualHandleStageId;
+const String kDieCutHandleStageId = dieCutHandleStageId;
 
 const String kDieCutA1WorkplaceId = '7c168998-76b8-4a4c-9708-af45c2dbd4f0';
 const String kDieCutA2WorkplaceId = '5a47821b-c276-4deb-90de-f196539fc95d';
@@ -47,8 +49,8 @@ const String kBottomGlueWorkplaceId = 'dee83c5c-4624-4ca4-b36c-47673dc5cd72';
 const String kBottomGlueAltWorkplaceId = 'ad504db5-86c3-4284-8266-42bbf967b064';
 const String kBottomGlueSecondAltWorkplaceId = '96075b60-77d8-4fb2-91b0-bfbe6c1ed13c';
 const String kTwistedHandleWorkplaceId = 'c51ebb2e-dac8-4068-9e4c-ce0d8b975626';
-const String kSharedHandleWorkplaceId = 'c25acbfa-390a-4e87-84aa-536055e013f4';
-const String kFlatHandleWorkplaceId = '6ffdf2d9-3f57-45ca-9fad-dd700ac5c320';
+const String kSharedHandleWorkplaceId = kManualHandleStageId;
+const String kFlatHandleWorkplaceId = kFlatHandleStageId;
 
 // The following technological stage keys are intentionally distinct even when
 // a customer installation maps several of them to the same physical workplace.
@@ -281,14 +283,22 @@ class _OrderStageQueueBuilder {
       _add(_stage(
         kFlatHandleGroupStageId,
         'Плоская ручка',
-        workplaceIds: const [kFlatHandleWorkplaceId, kSharedHandleWorkplaceId],
+        workplaceIds: const [
+          kFlatHandleWorkplaceId,
+          kSharedHandleWorkplaceId,
+        ],
       ));
     } else if (type == OrderHandleType.twisted) {
       _add(_stage(
         kTwistedHandleGroupStageId,
         'Кручёная ручка',
-        workplaceIds: const [kTwistedHandleWorkplaceId, kSharedHandleWorkplaceId],
+        workplaceIds: const [
+          kTwistedHandleWorkplaceId,
+          kSharedHandleWorkplaceId,
+        ],
       ));
+    } else if (type == OrderHandleType.dieCut) {
+      _add(_stage(kDieCutHandleStageId, 'Вырубка'));
     }
   }
 

--- a/test/order_stage_filter_test.dart
+++ b/test/order_stage_filter_test.dart
@@ -7,6 +7,8 @@ void main() {
   final baseStages = [
     _stage(flatHandleStageId),
     _stage(twistedHandleStageId),
+    _stage(manualHandleStageId),
+    _stage(dieCutHandleStageId),
     _stage(cardboardStageId),
     _stage(cuttingStageId),
     _stage('other-stage'),
@@ -31,7 +33,11 @@ void main() {
       hasCutting: false,
     );
 
-    expect(filtered.map((s) => s['stageId']), [twistedHandleStageId, 'other-stage']);
+    expect(filtered.map((s) => s['stageId']), [
+      twistedHandleStageId,
+      manualHandleStageId,
+      'other-stage',
+    ]);
   });
 
   test('keeps only flat handle stage and enabled flags', () {
@@ -44,8 +50,23 @@ void main() {
 
     expect(filtered.map((s) => s['stageId']), [
       flatHandleStageId,
+      manualHandleStageId,
       cardboardStageId,
       cuttingStageId,
+      'other-stage',
+    ]);
+  });
+
+  test('keeps die cut handle stage without manual handle stage', () {
+    final filtered = filterOrderStagesByOptions(
+      stages: baseStages,
+      selectedHandleType: OrderHandleType.dieCut,
+      hasCardboard: false,
+      hasCutting: false,
+    );
+
+    expect(filtered.map((s) => s['stageId']), [
+      dieCutHandleStageId,
       'other-stage',
     ]);
   });

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -83,14 +83,64 @@ void main() {
       ),
     );
 
+    final flatHandleStage = result.singleWhere(
+      (stage) => stage.stageKey == kFlatHandleGroupStageId,
+    );
+
     expect(result.map((stage) => stage.stageKey), containsAll([
-      'die_cut_a1',
-      'die_cut_a2',
+      kDieCutA1A2StageId,
       kCardboardStageId,
-      kFlatHandleStageId,
+      kFlatHandleGroupStageId,
       kPackagingStageId,
     ]));
+    expect(flatHandleStage.workplaceIds, [
+      kFlatHandleStageId,
+      kManualHandleStageId,
+    ]);
     expect(result.last.stageKey, kPackagingStageId);
+  });
+
+  test('builds twisted handle as one multi-workplace stage', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kPTypePackageProduct,
+        orderWidthB: 600,
+        materialWidth: 600,
+        hasPaint: false,
+        hasTrimming: false,
+        hasCardboard: false,
+        handleType: OrderHandleType.twisted,
+      ),
+    );
+
+    final handleStage = result.singleWhere(
+      (stage) => stage.stageKey == kTwistedHandleGroupStageId,
+    );
+    expect(handleStage.stageName, 'Кручёная ручка');
+    expect(handleStage.workplaceIds, [
+      kTwistedHandleStageId,
+      kManualHandleStageId,
+    ]);
+  });
+
+  test('builds die cut handle as one stage', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kPTypePackageProduct,
+        orderWidthB: 600,
+        materialWidth: 600,
+        hasPaint: false,
+        hasTrimming: false,
+        hasCardboard: false,
+        handleType: OrderHandleType.dieCut,
+      ),
+    );
+
+    final handleStage = result.singleWhere(
+      (stage) => stage.stageKey == kDieCutHandleStageId,
+    );
+    expect(handleStage.stageName, 'Вырубка');
+    expect(handleStage.workplaceIds, [kDieCutHandleStageId]);
   });
 
   test('builds switchable p-package stage with selected tube workplace', () {


### PR DESCRIPTION
### Motivation
- Support a new handle type `dieCut` and fix workplace IDs so handle routing matches the production spec.
- Ensure the builder and preview logic recognize textual handle descriptions (`круч`, `плоск`, `выруб`, empty/`-`) and produce appropriate stages.

### Description
- Extended `OrderHandleType` with `dieCut` and added constants `manualHandleStageId` and `dieCutHandleStageId`, and corrected `flat`/`twisted` IDs in `lib/modules/orders/order_stage_filter.dart`.
- Updated `filterOrderStagesByOptions` to keep the manual handle stage for both `flat` and `twisted` and to keep the die-cut stage only for `OrderHandleType.dieCut`.
- Wired new IDs into `lib/modules/orders/stage_queue_builder.dart`, made flat and twisted handle stages multi-workplace stages that include the manual handle workplace, and added a die-cut stage (`Вырубка`) when `handleType == OrderHandleType.dieCut`.
- Improved `OrderHandleType _resolveSelectedHandleType()` in `lib/modules/orders/edit_order_screen.dart` to map descriptions containing `круч`→`twisted`, `плоск`→`flat`, `выруб`→`dieCut`, and empty/`-`→`none`.
- Added/adjusted unit tests in `test/order_stage_filter_test.dart` and `test/stage_queue_builder_test.dart` to cover the new `manual` and `dieCut` cases and the builder behavior for flat/twisted/dieCut.

### Testing
- Updated unit tests in `test/order_stage_filter_test.dart` and `test/stage_queue_builder_test.dart` to validate filtering and builder outputs for `flat`, `twisted`, and `dieCut` handle types.
- Ran `git diff --check` which reported no problems.
- Attempted to run `dart format` and `flutter test` but they could not be executed in this environment because the Flutter/Dart SDK is not installed (commands failed with `command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb07bfabf0832f96a02558ef06b694)