### PR TITLE
Refine switchable order stage toggles and preserve selections

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1422,6 +1422,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     List<Map<String, dynamic>> templateStages = const <Map<String, dynamic>>[],
   }) {
     final draft = _currentStageQueueDraft();
+    final switchableSelectionSource = existingStages.isNotEmpty
+        ? existingStages
+        : _stagePreviewStages;
     return buildOrderStageQueue(
       productTypeId: draft.productTypeId,
       hasCutting: draft.hasTrimming,
@@ -1432,6 +1435,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       materialWidth: draft.materialWidth,
       switchableStageKey: draft.switchableStageKey,
       selectedSwitchableStageId: draft.selectedSwitchableStageId,
+      selectedSwitchableStageIdsByStageKey:
+          collectSwitchableStageSelectionsByStageKey(switchableSelectionSource),
       existingStages: existingStages,
       templateStages: templateStages,
     );
@@ -6411,46 +6416,45 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           .trim();
       children.add(GestureDetector(
         onTap: () {
-          final id = (stage['stageId'] ?? stage['id'] ?? '').toString();
-          final toggled = toggleProductStage(id);
-          if (toggled == null) return;
+          final toggledStage = toggleProductStageObject(stage);
+          if (toggledStage == null) return;
           setState(() {
-            stage['stageId'] = toggled;
-            stage['id'] = toggled;
+            _stagePreviewStages[i] = toggledStage;
             _isStageQueueBuilt = true;
           });
         },
         child: Container(
-        margin: EdgeInsets.only(top: i == 0 ? 0 : 8),
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          border: Border.all(color: theme.dividerColor),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('${i + 1}.', style: theme.textTheme.bodyMedium),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(title, style: theme.textTheme.bodyMedium),
-                  if (description.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(
-                        description,
-                        style: theme.textTheme.bodySmall,
+          margin: EdgeInsets.only(top: i == 0 ? 0 : 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            border: Border.all(color: theme.dividerColor),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('${i + 1}.', style: theme.textTheme.bodyMedium),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title, style: theme.textTheme.bodyMedium),
+                    if (description.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          description,
+                          style: theme.textTheme.bodySmall,
+                        ),
                       ),
-                    ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      )));
+      ));
     }
 
     return Column(

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -62,6 +62,8 @@ const String kBottomGlueStageId = 'bottom_glue_group';
 const String kTwistedHandleGroupStageId = 'twisted_handle_group';
 const String kFlatHandleGroupStageId = 'flat_handle_group';
 
+const String kVMainSwitchStageKey = 'v_main_switch';
+const String kPMainSwitchStageKey = 'p_main_switch';
 const String kSwitchableVGroupKey = 'v_bottom_stage';
 const String kSwitchablePGroupKey = 'p_package_stage';
 
@@ -88,6 +90,7 @@ class OrderStageQueueDraft {
     this.handleType,
     this.switchableStageKey,
     this.selectedSwitchableStageId,
+    this.selectedSwitchableStageIdsByStageKey = const <String, String>{},
   });
 
   final String productTypeId;
@@ -99,6 +102,7 @@ class OrderStageQueueDraft {
   final Object? handleType;
   final String? switchableStageKey;
   final String? selectedSwitchableStageId;
+  final Map<String, String> selectedSwitchableStageIdsByStageKey;
 }
 
 class BuiltOrderStage {
@@ -133,7 +137,10 @@ class BuiltOrderStage {
   }
 
   Map<String, dynamic> toMap() {
-    final selectedId = workplaceIds.isNotEmpty ? workplaceIds.first : stageKey;
+    final selectedId = (selectedWorkplaceId != null &&
+            workplaceIds.contains(selectedWorkplaceId))
+        ? selectedWorkplaceId!
+        : (workplaceIds.isNotEmpty ? workplaceIds.first : stageKey);
     final alternativeIds = workplaceIds
         .where((id) => id.trim().isNotEmpty && id != selectedId)
         .toList();
@@ -170,9 +177,16 @@ List<Map<String, dynamic>> buildOrderStageQueue({
   double? materialWidth,
   String? switchableStageKey,
   String? selectedSwitchableStageId,
+  Map<String, String> selectedSwitchableStageIdsByStageKey =
+      const <String, String>{},
   List<Map<String, dynamic>> existingStages = const [],
   List<Map<String, dynamic>> templateStages = const [],
 }) {
+  final selectedByStageKey = <String, String>{
+    ..._selectedSwitchableStageIdsByStageKey(templateStages),
+    ..._selectedSwitchableStageIdsByStageKey(existingStages),
+    ...selectedSwitchableStageIdsByStageKey,
+  };
   final selectedFromSource = selectedSwitchableStageId ??
       _selectedSwitchableStageId(existingStages) ??
       _selectedSwitchableStageId(templateStages);
@@ -186,6 +200,7 @@ List<Map<String, dynamic>> buildOrderStageQueue({
     handleType: handleType,
     switchableStageKey: switchableStageKey,
     selectedSwitchableStageId: selectedFromSource,
+    selectedSwitchableStageIdsByStageKey: selectedByStageKey,
   );
   return buildOrderStages(draft).map((stage) => stage.toMap()).toList();
 }
@@ -228,7 +243,7 @@ class _OrderStageQueueBuilder {
     }
     if (_isVTypeProduct(productTypeId)) {
       _add(_switchableStage(
-        stageKey: kSwitchableVGroupKey,
+        stageKey: kVMainSwitchStageKey,
         stageName: _vSwitchableName,
         workplaceIds: const [kFriStageId, kWindowStageId],
         groupKey: kSwitchableVGroupKey,
@@ -262,7 +277,7 @@ class _OrderStageQueueBuilder {
     }
     if (_isPTypePackageProduct(productTypeId)) {
       _add(_switchableStage(
-        stageKey: kSwitchablePGroupKey,
+        stageKey: kPMainSwitchStageKey,
         stageName: _pSwitchableName,
         workplaceIds: const [kAutoBigStageId, kAutoSmallStageId, kTubeStageId],
         groupKey: kSwitchablePGroupKey,
@@ -302,11 +317,17 @@ class _OrderStageQueueBuilder {
     }
   }
 
-  String get _vSwitchableName =>
-      _selectedName(_selectedForGroup(kSwitchableVGroupKey, kFriStageId));
+  String get _vSwitchableName => _selectedName(_selectedForSwitchable(
+        stageKey: kVMainSwitchStageKey,
+        groupKey: kSwitchableVGroupKey,
+        fallback: kFriStageId,
+      ));
 
-  String get _pSwitchableName =>
-      _selectedName(_selectedForGroup(kSwitchablePGroupKey, kAutoBigStageId));
+  String get _pSwitchableName => _selectedName(_selectedForSwitchable(
+        stageKey: kPMainSwitchStageKey,
+        groupKey: kSwitchablePGroupKey,
+        fallback: kAutoBigStageId,
+      ));
 
   BuiltOrderStage _stage(
     String stageKey,
@@ -329,7 +350,11 @@ class _OrderStageQueueBuilder {
     required String groupKey,
     required String fallbackSelectedId,
   }) {
-    final selected = _selectedForGroup(groupKey, fallbackSelectedId);
+    final selected = _selectedForSwitchable(
+      stageKey: stageKey,
+      groupKey: groupKey,
+      fallback: fallbackSelectedId,
+    );
     return BuiltOrderStage(
       stageKey: stageKey,
       stageName: stageName,
@@ -340,10 +365,22 @@ class _OrderStageQueueBuilder {
     );
   }
 
-  String _selectedForGroup(String groupKey, String fallback) {
+  String _selectedForSwitchable({
+    required String stageKey,
+    required String groupKey,
+    required String fallback,
+  }) {
+    final selectedByStageKey =
+        draft.selectedSwitchableStageIdsByStageKey[stageKey];
+    if (selectedByStageKey != null &&
+        _switchableIdsByStageKey[stageKey]!.contains(selectedByStageKey)) {
+      return selectedByStageKey;
+    }
+
     final selected = draft.selectedSwitchableStageId;
     if (draft.switchableStageKey != null &&
-        draft.switchableStageKey != groupKey) {
+        draft.switchableStageKey != groupKey &&
+        draft.switchableStageKey != stageKey) {
       return fallback;
     }
     if (selected != null &&
@@ -379,6 +416,16 @@ class _OrderStageQueueBuilder {
     ];
   }
 }
+
+const Map<String, Set<String>> _switchableIdsByStageKey = {
+  kVMainSwitchStageKey: {kFriStageId, kWindowStageId},
+  kPMainSwitchStageKey: {kAutoBigStageId, kAutoSmallStageId, kTubeStageId},
+};
+
+const Map<String, String> _switchableGroupKeyByStageKey = {
+  kVMainSwitchStageKey: kSwitchableVGroupKey,
+  kPMainSwitchStageKey: kSwitchablePGroupKey,
+};
 
 const Map<String, Set<String>> _switchableIdsByGroup = {
   kSwitchableVGroupKey: {kFriStageId, kWindowStageId},
@@ -438,6 +485,69 @@ String _selectedName(String stageId) {
     default:
       return '';
   }
+}
+
+Map<String, String> collectSwitchableStageSelectionsByStageKey(
+  List<Map<String, dynamic>> stages,
+) =>
+    _selectedSwitchableStageIdsByStageKey(stages);
+
+Map<String, String> _selectedSwitchableStageIdsByStageKey(
+  List<Map<String, dynamic>> stages,
+) {
+  final selections = <String, String>{};
+  for (final stage in stages) {
+    final rawStageKey = (stage['stageKey'] ?? stage['stage_key'])?.toString();
+    final rawGroupKey = stage['switchableGroupKey']?.toString();
+    final selectedId = _selectedSwitchableIdFromStage(stage);
+    if (selectedId == null) continue;
+    final stageKey = _normalizeSwitchableStageKey(rawStageKey, rawGroupKey) ??
+        _switchableStageKeyForWorkplaceId(selectedId);
+    if (stageKey == null) continue;
+    if (_switchableIdsByStageKey[stageKey]!.contains(selectedId)) {
+      selections[stageKey] = selectedId;
+    }
+  }
+  return selections;
+}
+
+String? _normalizeSwitchableStageKey(String? stageKey, String? groupKey) {
+  if (stageKey != null && _switchableIdsByStageKey.containsKey(stageKey)) {
+    return stageKey;
+  }
+  if (stageKey == kSwitchableVGroupKey || groupKey == kSwitchableVGroupKey) {
+    return kVMainSwitchStageKey;
+  }
+  if (stageKey == kSwitchablePGroupKey || groupKey == kSwitchablePGroupKey) {
+    return kPMainSwitchStageKey;
+  }
+  return null;
+}
+
+String? _switchableStageKeyForWorkplaceId(String workplaceId) {
+  for (final entry in _switchableIdsByStageKey.entries) {
+    if (entry.value.contains(workplaceId)) return entry.key;
+  }
+  return null;
+}
+
+String? _selectedSwitchableIdFromStage(Map<String, dynamic> stage) {
+  final id = (stage['selectedWorkplaceId'] ??
+          stage['stageId'] ??
+          stage['stage_id'] ??
+          stage['stageid'] ??
+          stage['workplaceId'] ??
+          stage['workplace_id'] ??
+          stage['id'])
+      ?.toString();
+  if (id == null || id.isEmpty) return null;
+  if (id == kVMainSwitchStageKey ||
+      id == kPMainSwitchStageKey ||
+      id == kSwitchableVGroupKey ||
+      id == kSwitchablePGroupKey) {
+    return null;
+  }
+  return id;
 }
 
 String? _selectedSwitchableStageId(List<Map<String, dynamic>> stages) {
@@ -511,4 +621,41 @@ String? toggleProductStage(String stageId) {
     default:
       return null;
   }
+}
+
+Map<String, dynamic>? toggleProductStageObject(Map<String, dynamic> stage) {
+  final currentId = _selectedSwitchableIdFromStage(stage);
+  if (currentId == null) return null;
+  final stageKey = _normalizeSwitchableStageKey(
+        (stage['stageKey'] ?? stage['stage_key'])?.toString(),
+        stage['switchableGroupKey']?.toString(),
+      ) ??
+      _switchableStageKeyForWorkplaceId(currentId);
+  if (stageKey == null) return null;
+  final toggledId = toggleProductStage(currentId);
+  if (toggledId == null ||
+      !_switchableIdsByStageKey[stageKey]!.contains(toggledId)) {
+    return null;
+  }
+
+  final updated = Map<String, dynamic>.from(stage);
+  final stageName = _selectedName(toggledId);
+  updated['stageKey'] = stageKey;
+  updated['stageId'] = toggledId;
+  updated['stage_id'] = toggledId;
+  updated['stageid'] = toggledId;
+  updated['id'] = toggledId;
+  updated['workplaceId'] = toggledId;
+  updated['workplace_id'] = toggledId;
+  updated['stageName'] = stageName;
+  updated['workplaceName'] = stageName;
+  updated['isSwitchable'] = true;
+  updated['switchableGroupKey'] = _switchableGroupKeyByStageKey[stageKey];
+  updated['selectedWorkplaceId'] = toggledId;
+  updated['workplaceIds'] =
+      List<String>.from(_switchableIdsByStageKey[stageKey]!);
+  updated['alternativeStageIds'] = _switchableIdsByStageKey[stageKey]!
+      .where((id) => id != toggledId)
+      .toList(growable: false);
+  return updated;
 }

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -156,9 +156,53 @@ void main() {
       ),
     );
 
-    expect(result.first.stageKey, kSwitchablePGroupKey);
+    expect(result.first.stageKey, kPMainSwitchStageKey);
     expect(result.first.isSwitchable, isTrue);
     expect(result.first.selectedWorkplaceId, kTubeStageId);
     expect(result.last.stageKey, kPackagingStageId);
   });
+
+  test('keeps switchable selections by stage key when rebuilding queue', () {
+    final result = buildOrderStageQueue(
+      productTypeId: kPTypePackageProduct,
+      hasCutting: false,
+      hasCardboard: true,
+      hasFlexPrinting: false,
+      selectedSwitchableStageIdsByStageKey: const {
+        kPMainSwitchStageKey: kTubeStageId,
+      },
+    );
+
+    final switchStage = result.singleWhere(
+      (stage) => stage['stageKey'] == kPMainSwitchStageKey,
+    );
+    expect(switchStage['stageId'], kTubeStageId);
+    expect(switchStage['workplaceId'], kTubeStageId);
+    expect(switchStage['selectedWorkplaceId'], kTubeStageId);
+    expect(switchStage['stageName'], 'Труба');
+    expect(switchStage['isSwitchable'], isTrue);
+    expect(switchStage['switchableGroupKey'], kSwitchablePGroupKey);
+  });
+
+  test('toggles full switchable stage object metadata', () {
+    final toggled = toggleProductStageObject({
+      'stageKey': kVMainSwitchStageKey,
+      'stageId': kFriStageId,
+      'workplaceId': kFriStageId,
+      'selectedWorkplaceId': kFriStageId,
+      'stageName': 'Фри',
+      'isSwitchable': true,
+      'switchableGroupKey': kSwitchableVGroupKey,
+      'workplaceIds': [kFriStageId, kWindowStageId],
+    });
+
+    expect(toggled, isNotNull);
+    expect(toggled!['stageKey'], kVMainSwitchStageKey);
+    expect(toggled['stageId'], kWindowStageId);
+    expect(toggled['workplaceId'], kWindowStageId);
+    expect(toggled['selectedWorkplaceId'], kWindowStageId);
+    expect(toggled['stageName'], 'Окно');
+    expect(toggled['workplaceName'], 'Окно');
+  });
+
 }


### PR DESCRIPTION
### Motivation
- Ensure V-/P- package switchers have stable `stageKey`s so UI selections can be preserved across queue rebuilds. 
- Allow preview UI toggles to return a full, consistent stage object (names + ids) instead of only swapping an ID to keep metadata synchronized. 
- Persist current switchable workplace choices when rebuilding the stage queue so manual edits and neighboring rule changes don't lose user selections.

### Description
- Added new main switch stage keys `kVMainSwitchStageKey` (`v_main_switch`) and `kPMainSwitchStageKey` (`p_main_switch`) and used them when building V/P switchable stages. 
- Extended `OrderStageQueueDraft` with `selectedSwitchableStageIdsByStageKey` and updated `buildOrderStageQueue` to accept and merge keyed selections from templates/existing stages. 
- Made `BuiltOrderStage.toMap()` prefer `selectedWorkplaceId` when emitting `stageId`/`workplaceId`, and updated `_OrderStageQueueBuilder` to select workplaces by stage-keyed preferences. 
- Added helpers to collect and normalize selections: `collectSwitchableStageSelectionsByStageKey`, `_selectedSwitchableStageIdsByStageKey`, `_normalizeSwitchableStageKey`, `_switchableStageKeyForWorkplaceId`, and `_selectedSwitchableIdFromStage`. 
- Implemented `toggleProductStageObject(Map)` which returns a full updated stage map (ids, `stageName`/`workplaceName`, `selectedWorkplaceId`, `workplaceIds`/`alternativeStageIds`, `switchableGroupKey`) for preview toggles. 
- Updated `edit_order_screen.dart` to pass current preview selections into `_buildStageQueueFromCurrentDraft` and to replace the preview-stage `onTap` logic to use `toggleProductStageObject(stage)` and replace the stage with the returned object. 
- Added/updated unit tests in `test/stage_queue_builder_test.dart` covering keyed rebuild persistence and full-object toggling, and adjusted expectations to the new `stageKey` constants.

### Testing
- Added unit tests in `test/stage_queue_builder_test.dart` for keyed switchable rebuilds and `toggleProductStageObject`; tests were added but not executed in this environment. 
- Attempted to run `flutter test`, but the Flutter SDK is not available in the execution environment so the test run was skipped. 
- Performed local code checks (formatting attempted but `dart`/`flutter` not present); repository changes compile-time verification should be run in a dev environment with Flutter/Dart SDKs installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb08e98268832f859799f9f0e15d2e)