### PR TITLE
Allow cardboard cutting stage to bypass sequence guard

### DIFF
--- a/lib/modules/tasks/stage_sequence_utils.dart
+++ b/lib/modules/tasks/stage_sequence_utils.dart
@@ -29,3 +29,95 @@ List<String> normalizeStageSequence(Iterable<String> rawSequence) {
   return unique;
 }
 
+const String kCardboardCuttingStageId =
+    'd7d91f75-2f85-446f-8c1d-a20606bdb3b1';
+
+typedef StageGroupingResolver = String Function(String orderId, String stageId);
+
+class PendingStageState {
+  final String stageId;
+  final bool completed;
+  final bool problem;
+
+  const PendingStageState({
+    required this.stageId,
+    required this.completed,
+    this.problem = false,
+  });
+
+  bool get pending => !completed;
+}
+
+bool canRunOutOfStageSequenceByStageId(String stageId) =>
+    stageId.trim() == kCardboardCuttingStageId;
+
+bool isFirstPendingStageInOrder({
+  required String orderId,
+  required String currentStageId,
+  required Iterable<PendingStageState> stageStates,
+  required Iterable<String> orderedStages,
+  StageGroupingResolver? groupResolver,
+  int Function(String a, String b)? fallbackStageComparator,
+}) {
+  if (canRunOutOfStageSequenceByStageId(currentStageId)) return true;
+
+  String groupKey(String stageId) =>
+      groupResolver?.call(orderId, stageId) ?? stageId;
+
+  final stages = <String, Map<String, bool>>{};
+  for (final state in stageStates) {
+    final key = groupKey(state.stageId);
+    final current = stages[key] ??
+        {'pending': false, 'completed': false, 'problem': false};
+    stages[key] = {
+      'pending': current['pending'] == true || state.pending,
+      'completed': current['completed'] == true || state.completed,
+      'problem': current['problem'] == true || state.problem,
+    };
+  }
+
+  final orderedList = orderedStages.toList(growable: false);
+  if (orderedList.isNotEmpty) {
+    final orderedKeys = <String>[];
+    for (final id in orderedList) {
+      final key = groupKey(id);
+      if (!orderedKeys.contains(key)) orderedKeys.add(key);
+    }
+    final indexMap = <String, int>{};
+    for (var i = 0; i < orderedKeys.length; i++) {
+      indexMap.putIfAbsent(orderedKeys[i], () => i);
+    }
+
+    final currentKey = groupKey(currentStageId);
+    final currentIndex = indexMap[currentKey];
+    if (currentIndex == null || currentIndex <= 0) return true;
+
+    for (var i = currentIndex - 1; i >= 0; i--) {
+      final prevKey = orderedKeys[i];
+      final prevState = stages[prevKey];
+      if (prevState == null) continue;
+
+      final hasPending = prevState['pending'] == true;
+      final hasProblem = prevState['problem'] == true;
+      if (!hasPending && prevState['completed'] == true) {
+        continue;
+      }
+      return prevState['completed'] == true || hasProblem;
+    }
+    return true;
+  }
+
+  final pendingStageIds = stages.entries
+      .where((e) => e.value['pending'] == true && e.value['completed'] != true)
+      .map((e) => e.key)
+      .toList();
+  if (pendingStageIds.isEmpty) return true;
+
+  if (fallbackStageComparator != null) {
+    pendingStageIds.sort(fallbackStageComparator);
+  } else {
+    pendingStageIds.sort();
+  }
+
+  return groupKey(currentStageId) == pendingStageIds.first;
+}

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -23,9 +23,12 @@ import '../warehouse/warehouse_provider.dart';
 import 'task_model.dart';
 import 'task_completion_rules.dart';
 import 'task_provider.dart';
+import 'stage_sequence_utils.dart' as stage_sequence;
 import '../common/pdf_view_screen.dart';
 import '../../services/storage_service.dart';
 // Additional helpers for time formatting and aggregated timers
+const String kCardboardCuttingStageId =
+    stage_sequence.kCardboardCuttingStageId;
 
 class TasksScreen extends StatefulWidget {
   final String employeeId;
@@ -591,79 +594,17 @@ void _ensureBobbinBeforeFlexoByLabel(
 }
 
 /// Разрешить старт только для самого первого незавершённого этапа заказа
-typedef StageGroupingResolver = String Function(String orderId, String stageId);
+bool _canRunOutOfStageSequence(TaskModel task) =>
+    task.stageId.trim() == kCardboardCuttingStageId;
 
 bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     TaskModel task,
-    {StageGroupingResolver? groupResolver}) {
-  String _groupKey(String stageId) =>
-      groupResolver?.call(task.orderId, stageId) ?? stageId;
+    {stage_sequence.StageGroupingResolver? groupResolver}) {
+  if (_canRunOutOfStageSequence(task)) return true;
 
-  // Все задачи этого заказа
   final all = tasks.tasks.where((t) => t.orderId == task.orderId).toList();
   if (all.isEmpty) return true;
 
-  // Сгруппировать по этапу; фиксируем и незавершённые, и уже завершённые
-  // альтернативы, чтобы не блокировать последующие этапы, когда одна из
-  // альтернатив завершена.
-  final stages = <String, Map<String, bool>>{}; // stageId -> {pending, completed, problem}
-  for (final t in all) {
-    final completed = _isEffectivelyCompleted(t);
-    final pending = !completed;
-    final problem = t.status == TaskStatus.problem ||
-        t.comments.any((c) => c.type == 'problem');
-    final key = _groupKey(t.stageId);
-    final current = stages[key] ??
-        {'pending': false, 'completed': false, 'problem': false};
-    stages[key] = {
-      'pending': current['pending'] == true || pending,
-      'completed': current['completed'] == true || completed,
-      'problem': current['problem'] == true || problem,
-    };
-  }
-
-  final orderedStages = tasks.stageSequenceForOrder(task.orderId) ?? const [];
-  if (orderedStages.isNotEmpty) {
-    final orderedKeys = <String>[];
-    for (final id in orderedStages) {
-      final k = _groupKey(id);
-      if (!orderedKeys.contains(k)) orderedKeys.add(k);
-    }
-    final indexMap = <String, int>{};
-    for (var i = 0; i < orderedKeys.length; i++) {
-      indexMap.putIfAbsent(orderedKeys[i], () => i);
-    }
-
-    final currentKey = _groupKey(task.stageId);
-    final currentIndex = indexMap[currentKey];
-    if (currentIndex == null || currentIndex <= 0) return true;
-
-    for (var i = currentIndex - 1; i >= 0; i--) {
-      final prevKey = orderedKeys[i];
-      final prevState = stages[prevKey];
-      if (prevState == null) continue;
-
-      // Ищем ближайший реально существующий предыдущий этап.
-      final hasPending = prevState['pending'] == true;
-      final hasProblem = prevState['problem'] == true;
-      if (!hasPending && prevState['completed'] == true) {
-        continue;
-      }
-      // Следующий этап нельзя запускать, пока предыдущий не завершён,
-      // кроме случаев, когда предыдущий переведён в "Проблему".
-      return prevState['completed'] == true || hasProblem;
-    }
-    return true;
-  }
-
-  // В fallback-режиме сохраняем старое правило: только первый незавершённый.
-  final pendingStageIds = stages.entries
-      .where((e) => e.value['pending'] == true && e.value['completed'] != true)
-      .map((e) => e.key)
-      .toList();
-  if (pendingStageIds.isEmpty) return true;
-
-  // Отсортировать по названию рабочего места (fallback к id)
   int byName(String a, String b) {
     String name(String id) {
       try {
@@ -677,13 +618,21 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     return name(a).compareTo(name(b));
   }
 
-  pendingStageIds.sort(byName);
-
-  // Первый незавершённый этап
-  final firstPendingStageId = pendingStageIds.first;
-
-  // Разрешаем старт, если наш task относится к самому первому незавершённому этапу
-  return _groupKey(task.stageId) == firstPendingStageId;
+  return stage_sequence.isFirstPendingStageInOrder(
+    orderId: task.orderId,
+    currentStageId: task.stageId,
+    stageStates: all.map(
+      (t) => stage_sequence.PendingStageState(
+        stageId: t.stageId,
+        completed: _isEffectivelyCompleted(t),
+        problem: t.status == TaskStatus.problem ||
+            t.comments.any((c) => c.type == 'problem'),
+      ),
+    ),
+    orderedStages: tasks.stageSequenceForOrder(task.orderId) ?? const [],
+    groupResolver: groupResolver,
+    fallbackStageComparator: byName,
+  );
 }
 
 bool _hasWorkplaceQueueActivity(TaskModel task) {
@@ -4293,9 +4242,10 @@ class _TasksScreenState extends State<TasksScreen>
           context.read<ProductionQueueProvider>(),
           stage,
         ) &&
-        _isFirstPendingStage(context.read<TaskProvider>(),
-            context.read<PersonnelProvider>(), task,
-            groupResolver: _stageGroupKey) &&
+        (_canRunOutOfStageSequence(task) ||
+            _isFirstPendingStage(context.read<TaskProvider>(),
+                context.read<PersonnelProvider>(), task,
+                groupResolver: _stageGroupKey)) &&
         stageModeAllowsJoin &&
         !shiftPaused &&
         !groupLocked &&
@@ -4543,9 +4493,10 @@ class _TasksScreenState extends State<TasksScreen>
                         final taskProvider = context.read<TaskProvider>();
                         final personnelProvider = personnel;
                         // Sequential stage guard
-                        if (!_isFirstPendingStage(
-                            taskProvider, personnelProvider, task,
-                            groupResolver: _stageGroupKey)) {
+                        if (!_canRunOutOfStageSequence(task) &&
+                            !_isFirstPendingStage(
+                                taskProvider, personnelProvider, task,
+                                groupResolver: _stageGroupKey)) {
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                                 content: Text(

--- a/test/stage_sequence_utils_test.dart
+++ b/test/stage_sequence_utils_test.dart
@@ -11,4 +11,74 @@ void main() {
     final normalized = normalizeStageSequence(['  a ', 'b', 'a', '', 'c', 'b']);
     expect(normalized, ['a', 'b', 'c']);
   });
+
+  test('cardboard cutting stage can start when previous stages are pending', () {
+    final canStart = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: kCardboardCuttingStageId,
+      stageStates: const [
+        PendingStageState(stageId: 'previous-stage', completed: false),
+        PendingStageState(
+          stageId: kCardboardCuttingStageId,
+          completed: false,
+        ),
+      ],
+      orderedStages: const ['previous-stage', kCardboardCuttingStageId],
+    );
+
+    expect(canStart, isTrue);
+  });
+
+  test('ordinary stages remain blocked until previous stages are completed', () {
+    final canStart = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: 'ordinary-stage',
+      stageStates: const [
+        PendingStageState(stageId: 'previous-stage', completed: false),
+        PendingStageState(stageId: 'ordinary-stage', completed: false),
+      ],
+      orderedStages: const ['previous-stage', 'ordinary-stage'],
+    );
+
+    expect(canStart, isFalse);
+  });
+
+  test('cardboard cutting stage is available when first in order sequence', () {
+    final canStart = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: kCardboardCuttingStageId,
+      stageStates: const [
+        PendingStageState(
+          stageId: kCardboardCuttingStageId,
+          completed: false,
+        ),
+        PendingStageState(stageId: 'next-stage', completed: false),
+      ],
+      orderedStages: const [kCardboardCuttingStageId, 'next-stage'],
+    );
+
+    expect(canStart, isTrue);
+  });
+
+  test('cardboard cutting stage is available when last in order sequence', () {
+    final canStart = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: kCardboardCuttingStageId,
+      stageStates: const [
+        PendingStageState(stageId: 'previous-stage', completed: false),
+        PendingStageState(stageId: 'middle-stage', completed: false),
+        PendingStageState(
+          stageId: kCardboardCuttingStageId,
+          completed: false,
+        ),
+      ],
+      orderedStages: const [
+        'previous-stage',
+        'middle-stage',
+        kCardboardCuttingStageId,
+      ],
+    );
+
+    expect(canStart, isTrue);
+  });
 }


### PR DESCRIPTION
### Motivation
- Some orders require the cardboard cutting stage (`d7d91f75-2f85-446f-8c1d-a20606bdb3b1`) to be startable even when earlier stages are still pending, so the sequence guard must allow that exception while keeping normal ordering for other stages.

### Description
- Added a shared constant `kCardboardCuttingStageId` and a small, testable stage-sequence utility (`PendingStageState`, `isFirstPendingStageInOrder`, `canRunOutOfStageSequenceByStageId`) in `lib/modules/tasks/stage_sequence_utils.dart` to encapsulate the bypass logic and existing ordering rules.
- Introduced `_canRunOutOfStageSequence(TaskModel)` in `lib/modules/tasks/tasks_screen.dart`, imported the stage-sequence utils, and updated `_isFirstPendingStage(...)` to short-circuit when the bypass applies while delegating the rest of the logic to the new helper.
- Updated the control-panel eligibility checks so `canStart` uses `(_canRunOutOfStageSequence(task) || _isFirstPendingStage(...))`, and changed the `onStart()` sequential guard to allow starting when `_canRunOutOfStageSequence(task)` is true.
- Added unit tests in `test/stage_sequence_utils_test.dart` that verify: the cardboard-cutting stage can start when previous stages are pending; ordinary stages remain blocked until previous stages complete; and the cardboard-cutting stage is available when it is first or last in the sequence.

### Testing
- Added tests in `test/stage_sequence_utils_test.dart` covering the bypass and ordinary ordering (tests were created but not executed here due to environment limitations).
- Ran `git diff --check`, which reported no issues.
- Attempts to run `dart format` and `flutter test` were not executed because the environment lacks `dart`/`flutter` commands, so the new tests have not been run in this CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb10efa3b8832f8ef1c00d50426193)