### PR TITLE
Map two-sheet package to UUID and restrict sheet products set

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -3,10 +3,8 @@ import 'material_model.dart';
 
 // Product type IDs from the production routing specification.
 const String kSheetProductTypeId = 'aab3ed17-1688-43f0-b623-58dac264941f';
-const String kSheetProductTypeAltId = 'b07cd977-939c-4d4f-b68c-8d163341460e';
 const Set<String> kSheetProducts = {
   kSheetProductTypeId,
-  kSheetProductTypeAltId,
 };
 
 const String kVTypeProductId = '448b731a-eafe-40f1-9268-bc5dd6ba57bc';
@@ -20,7 +18,8 @@ const Set<String> kVTypeProducts = {
   kVTypeProductAlt3Id,
 };
 
-const String kTwoSheetPackageProductTypeId = 'package_two_sheets';
+const String kTwoSheetPackageProductTypeId =
+    'b07cd977-939c-4d4f-b68c-8d163341460e';
 const Set<String> kTwoSheetPackageProducts = {kTwoSheetPackageProductTypeId};
 
 const String kPTypePackageProduct = '71c889cb-b24c-4bda-9a69-ae312f9a4bbd';

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -26,6 +26,10 @@ void main() {
     expect(result.first['stageId'], kSheetCutStageId);
   });
 
+  test('sheet products contain only the sheet UUID', () {
+    expect(kSheetProducts, {kSheetProductTypeId});
+  });
+
   test('builds sheet queue from centralized draft rules', () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(
@@ -70,10 +74,10 @@ void main() {
     );
   });
 
-  test('keeps separate two-sheet technological stages with unique stage keys', () {
+  test('builds two-sheet package route for product UUID', () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(
-        productTypeId: 'Пакет из 2х листов',
+        productTypeId: kTwoSheetPackageProductTypeId,
         orderWidthB: 600,
         materialWidth: 600,
         hasPaint: false,
@@ -87,12 +91,25 @@ void main() {
       (stage) => stage.stageKey == kFlatHandleGroupStageId,
     );
 
-    expect(result.map((stage) => stage.stageKey), containsAll([
-      kDieCutA1A2StageId,
-      kCardboardStageId,
-      kFlatHandleGroupStageId,
-      kPackagingStageId,
-    ]));
+    expect(
+      result.map((stage) => stage.stageKey),
+      [
+        kSheetCutStageId,
+        kCuttingStageId,
+        kDieCutA1A2StageId,
+        kScotchStageId,
+        kFromTwoSheetsStageId,
+        kTubeAssemblyStageId,
+        kCardboardStageId,
+        kBottomGlueStageId,
+        kFlatHandleGroupStageId,
+        kPackagingStageId,
+      ],
+    );
+    expect(
+      result.map((stage) => stage.stageName),
+      containsAll(['С 2х листов', 'Сборка трубы', 'Склейка дна']),
+    );
     expect(flatHandleStage.workplaceIds, [
       kFlatHandleStageId,
       kManualHandleStageId,


### PR DESCRIPTION
### Motivation
- Ensure the two-sheet package product is recognized by its UUID instead of a label so the builder selects the correct technological route. 
- Prevent the two-sheet package UUID from being treated as a sheet product to avoid incorrect sheet routing.

### Description
- Removed the alt UUID `b07cd977-939c-4d4f-b68c-8d163341460e` from `kSheetProducts` so `kSheetProducts` now contains only `kSheetProductTypeId` (`aab3ed17-1688-43f0-b623-58dac264941f`).
- Replaced the `kTwoSheetPackageProductTypeId` value with the UUID `b07cd977-939c-4d4f-b68c-8d163341460e` so two-sheet package routing is triggered by that UUID. 
- Updated tests in `test/stage_queue_builder_test.dart` to add a check that `kSheetProducts` equals `{kSheetProductTypeId}` and to call `buildOrderStages` with `kTwoSheetPackageProductTypeId` and assert the full two-sheet package route (including stages `С 2х листов`, `Сборка трубы`, `Склейка дна`).
- Modified `lib/modules/orders/stage_queue_builder.dart` and `test/stage_queue_builder_test.dart` accordingly.

### Testing
- Added/updated unit tests in `test/stage_queue_builder_test.dart` but full test execution was not performed because the environment lacks `flutter`/`dart` (attempted `flutter test` failed with `flutter: command not found`).
- Ran repository searches and static checks (`rg`) to verify the new UUID and set membership, which located the updated constants and test references. 
- Changes were committed (`Fix two-sheet package product routing`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb16208f50832fa22e3c48ac896059)