### PR TITLE
Исправление UUID и разделение этапов, связанных с картоном

### DIFF
--- a/lib/modules/orders/order_stage_filter.dart
+++ b/lib/modules/orders/order_stage_filter.dart
@@ -5,7 +5,17 @@ const String twistedHandleStageId = 'c51ebb2e-dac8-4068-9e4c-ce0d8b975626';
 const String manualHandleStageId = 'c25acbfa-390a-4e87-84aa-536055e013f4';
 const String dieCutHandleStageId = '4925309c-a2c6-4f5f-9f5e-7dd5ff38827d';
 const String cuttingStageId = 'c828062f-a6a6-4fe5-b01b-c51e36fe5fba';
-const String cardboardStageId = 'ce15da53-34bb-4a48-acef-610dddfad42e';
+const String kCardboardCuttingStageId =
+    'd7d91f75-2f85-446f-8c1d-a20606bdb3b1';
+const String kCardboardInsertStageId =
+    'ce15da53-34bb-4a48-acef-610ddfd4a42e';
+const String kBottomWithCardboardAssemblyStageId =
+    'd15da69b-9842-4967-96ed-28a4834b409e';
+const Set<String> kOptionalCardboardStageIds = {
+  kCardboardCuttingStageId,
+  kCardboardInsertStageId,
+  kBottomWithCardboardAssemblyStageId,
+};
 
 List<Map<String, dynamic>> filterOrderStagesByOptions({
   required List<Map<String, dynamic>> stages,
@@ -27,7 +37,7 @@ List<Map<String, dynamic>> filterOrderStagesByOptions({
     if (stageId == dieCutHandleStageId) {
       return selectedHandleType == OrderHandleType.dieCut;
     }
-    if (stageId == cardboardStageId) {
+    if (kOptionalCardboardStageIds.contains(stageId)) {
       return hasCardboard;
     }
     if (stageId == cuttingStageId) {

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -36,7 +36,12 @@ const String kAutoSmallStageId = 'cbcbe469-b924-4064-ae05-885ccd1b842a';
 const String kTubeStageId = 'e62fc013-4785-4375-b3ee-a3ca51f77199';
 const String kSheetCutStageId = '19a67630-8374-4f9f-ae5b-f2f66828720b';
 const String kCuttingStageId = cuttingStageId;
-const String kCardboardStageId = cardboardStageId;
+const String kCardboardCuttingStageId =
+    'd7d91f75-2f85-446f-8c1d-a20606bdb3b1';
+const String kCardboardInsertStageId =
+    'ce15da53-34bb-4a48-acef-610ddfd4a42e';
+const String kBottomWithCardboardAssemblyStageId =
+    'd15da69b-9842-4967-96ed-28a4834b409e';
 const String kFlatHandleStageId = flatHandleStageId;
 const String kTwistedHandleStageId = twistedHandleStageId;
 const String kManualHandleStageId = manualHandleStageId;
@@ -288,7 +293,13 @@ class _OrderStageQueueBuilder {
   }
 
   void _appendCardboardStages() {
-    if (draft.hasCardboard) _add(_stage(kCardboardStageId, 'Картон'));
+    if (!draft.hasCardboard) return;
+    _add(_stage(kCardboardCuttingStageId, 'Резка картона'));
+    _add(_stage(kCardboardInsertStageId, 'Вставка картона'));
+    _add(_stage(
+      kBottomWithCardboardAssemblyStageId,
+      'Сборка дно+картон',
+    ));
   }
 
   void _appendHandleStage() {

--- a/test/order_stage_filter_test.dart
+++ b/test/order_stage_filter_test.dart
@@ -9,7 +9,9 @@ void main() {
     _stage(twistedHandleStageId),
     _stage(manualHandleStageId),
     _stage(dieCutHandleStageId),
-    _stage(cardboardStageId),
+    _stage(kCardboardCuttingStageId),
+    _stage(kCardboardInsertStageId),
+    _stage(kBottomWithCardboardAssemblyStageId),
     _stage(cuttingStageId),
     _stage('other-stage'),
   ];
@@ -51,7 +53,9 @@ void main() {
     expect(filtered.map((s) => s['stageId']), [
       flatHandleStageId,
       manualHandleStageId,
-      cardboardStageId,
+      kCardboardCuttingStageId,
+      kCardboardInsertStageId,
+      kBottomWithCardboardAssemblyStageId,
       cuttingStageId,
       'other-stage',
     ]);

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -1,5 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sheet_clone/modules/orders/order_stage_filter.dart';
+import 'package:sheet_clone/modules/orders/order_stage_filter.dart'
+    hide kBottomWithCardboardAssemblyStageId,
+        kCardboardCuttingStageId,
+        kCardboardInsertStageId;
 import 'package:sheet_clone/modules/orders/stage_queue_builder.dart';
 
 void main() {
@@ -100,7 +103,9 @@ void main() {
         kScotchStageId,
         kFromTwoSheetsStageId,
         kTubeAssemblyStageId,
-        kCardboardStageId,
+        kCardboardCuttingStageId,
+        kCardboardInsertStageId,
+        kBottomWithCardboardAssemblyStageId,
         kBottomGlueStageId,
         kFlatHandleGroupStageId,
         kPackagingStageId,
@@ -108,7 +113,14 @@ void main() {
     );
     expect(
       result.map((stage) => stage.stageName),
-      containsAll(['С 2х листов', 'Сборка трубы', 'Склейка дна']),
+      containsAll([
+        'С 2х листов',
+        'Сборка трубы',
+        'Резка картона',
+        'Вставка картона',
+        'Сборка дно+картон',
+        'Склейка дна',
+      ]),
     );
     expect(flatHandleStage.workplaceIds, [
       kFlatHandleStageId,


### PR DESCRIPTION
### Motivation
- Исправить опечатку UUID для этапа «Вставка картона» и перестать использовать один универсальный `cardboardStageId`, выделив отдельные технологические этапы для различных операций с картоном.
- Обеспечить корректную фильтрацию optional этапов картонных операций по флагу `hasCardboard` в очереди этапов заказа.
- Обновить построитель очереди этапов, чтобы он добавлял отдельные этапы «Резка картона», «Вставка картона» и «Сборка дно+картон», и привести тесты в соответствие с новой моделью.

### Description
- Добавлены константы `kCardboardCuttingStageId`, `kCardboardInsertStageId`, `kBottomWithCardboardAssemblyStageId` и набор `kOptionalCardboardStageIds` в `lib/modules/orders/order_stage_filter.dart` и `lib/modules/orders/stage_queue_builder.dart`.
- В `filterOrderStagesByOptions` заменена проверка одного `cardboardStageId` на `kOptionalCardboardStageIds.contains(stageId)` чтобы все cardboard-related optional этапы контролировались флагом `hasCardboard`.
- В `_appendCardboardStages` (`stage_queue_builder.dart`) очередь теперь добавляет три отдельные стадии с именами `Резка картона`, `Вставка картона` и `Сборка дно+картон` вместо единой «Картон». 
- Обновлены тесты `test/order_stage_filter_test.dart` и `test/stage_queue_builder_test.dart` чтобы ожидать новые id и названия этапов и скорректированы импорты/ожидания в них.

### Testing
- Попытка запустить модульные тесты через `flutter test test/order_stage_filter_test.dart test/stage_queue_builder_test.dart` завершилась неудачей из-за отсутствия `flutter` в окружении (`/bin/bash: line 1: flutter: command not found`), поэтому unit-тесты не были выполнены в CI этого окружения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb17bdb3cc832f95d9ade6f74d9aed)