### PR TITLE
Two-sheet package: implement ordered stages, conditional cuts, die-cut/glue workplaces and tests

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -51,7 +51,8 @@ const String kDieCutA1WorkplaceId = '7c168998-76b8-4a4c-9708-af45c2dbd4f0';
 const String kDieCutA2WorkplaceId = '5a47821b-c276-4deb-90de-f196539fc95d';
 const String kBottomGlueWorkplaceId = 'dee83c5c-4624-4ca4-b36c-47673dc5cd72';
 const String kBottomGlueAltWorkplaceId = 'ad504db5-86c3-4284-8266-42bbf967b064';
-const String kBottomGlueSecondAltWorkplaceId = '96075b60-77d8-4fb2-91b0-bfbe6c1ed13c';
+const String kBottomGlueSecondAltWorkplaceId =
+    '96075b60-77d8-4fb2-91b0-bfbe6c1ed13c';
 const String kTwistedHandleWorkplaceId = 'c51ebb2e-dac8-4068-9e4c-ce0d8b975626';
 const String kSharedHandleWorkplaceId = kManualHandleStageId;
 const String kFlatHandleWorkplaceId = kFlatHandleStageId;
@@ -256,27 +257,7 @@ class _OrderStageQueueBuilder {
       return;
     }
     if (_isTwoSheetPackageProduct(productTypeId)) {
-      _add(_stage(kSheetCutStageId, 'Листорезка'));
-      _add(_stage(kCuttingStageId, 'Резка'));
-      _add(_stage(
-        kDieCutA1A2StageId,
-        'Высечка A1/A2',
-        workplaceIds: const [kDieCutA1WorkplaceId, kDieCutA2WorkplaceId],
-      ));
-      _add(_stage(kScotchStageId, 'Скотч'));
-      _add(_stage(kFromTwoSheetsStageId, 'С 2х листов'));
-      _add(_stage(kTubeAssemblyStageId, 'Сборка трубы'));
-      _appendCardboardStages();
-      _add(_stage(
-        kBottomGlueStageId,
-        'Склейка дна',
-        workplaceIds: const [
-          kBottomGlueWorkplaceId,
-          kBottomGlueAltWorkplaceId,
-          kBottomGlueSecondAltWorkplaceId,
-        ],
-      ));
-      _appendHandleStage();
+      _appendTwoSheetPackageStages();
       return;
     }
     if (_isPTypePackageProduct(productTypeId)) {
@@ -290,6 +271,36 @@ class _OrderStageQueueBuilder {
       _appendCardboardStages();
       _appendHandleStage();
     }
+  }
+
+  void _appendTwoSheetPackageStages() {
+    _add(_stage(kSheetCutStageId, 'Листорезка'));
+    if (draft.hasTrimming) _add(_stage(kCuttingStageId, 'Резка'));
+    _add(_stage(
+      kDieCutA1A2StageId,
+      'Высечка A1/A2',
+      workplaceIds: const [kDieCutA1WorkplaceId, kDieCutA2WorkplaceId],
+    ));
+    _add(_stage(kScotchStageId, 'Скотч'));
+    _add(_stage(kFromTwoSheetsStageId, 'С 2х листов'));
+    _add(_stage(kTubeAssemblyStageId, 'Сборка трубы'));
+    if (draft.hasCardboard) {
+      _add(_stage(kCardboardCuttingStageId, 'Резка картона'));
+    }
+    _add(_stage(
+      kBottomWithCardboardAssemblyStageId,
+      'Сборка дно+картон',
+    ));
+    _add(_stage(
+      kBottomGlueStageId,
+      'Склейка дна',
+      workplaceIds: const [
+        kBottomGlueWorkplaceId,
+        kBottomGlueAltWorkplaceId,
+        kBottomGlueSecondAltWorkplaceId,
+      ],
+    ));
+    _appendHandleStage();
   }
 
   void _appendCardboardStages() {

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -77,7 +77,72 @@ void main() {
     );
   });
 
-  test('builds two-sheet package route for product UUID', () {
+  test(
+    'builds two-sheet package route with trimming, cardboard and flat handle',
+    () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kTwoSheetPackageProductTypeId,
+        orderWidthB: 300,
+        materialWidth: 600,
+        hasPaint: true,
+        hasTrimming: true,
+        hasCardboard: true,
+        handleType: OrderHandleType.flat,
+      ),
+    );
+
+    final dieCutStage = result.singleWhere(
+      (stage) => stage.stageKey == kDieCutA1A2StageId,
+    );
+    final bottomGlueStage = result.singleWhere(
+      (stage) => stage.stageKey == kBottomGlueStageId,
+    );
+    final flatHandleStage = result.singleWhere(
+      (stage) => stage.stageKey == kFlatHandleGroupStageId,
+    );
+
+    expect(
+      result.map((stage) => stage.stageKey),
+      [
+        kBobbinStageId,
+        kFlexPrintingStageId,
+        kSheetCutStageId,
+        kCuttingStageId,
+        kDieCutA1A2StageId,
+        kScotchStageId,
+        kFromTwoSheetsStageId,
+        kTubeAssemblyStageId,
+        kCardboardCuttingStageId,
+        kBottomWithCardboardAssemblyStageId,
+        kBottomGlueStageId,
+        kFlatHandleGroupStageId,
+        kPackagingStageId,
+      ],
+    );
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kCardboardInsertStageId)),
+    );
+    expect(dieCutStage.workplaceIds, [
+      kDieCutA1WorkplaceId,
+      kDieCutA2WorkplaceId,
+    ]);
+    expect(bottomGlueStage.workplaceIds, [
+      kBottomGlueWorkplaceId,
+      kBottomGlueAltWorkplaceId,
+      kBottomGlueSecondAltWorkplaceId,
+    ]);
+    expect(flatHandleStage.workplaceIds, [
+      kFlatHandleStageId,
+      kManualHandleStageId,
+    ]);
+    expect(result.last.stageKey, kPackagingStageId);
+  });
+
+  test(
+    'builds two-sheet package route without trimming or cardboard and with twisted handle',
+    () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(
         productTypeId: kTwoSheetPackageProductTypeId,
@@ -85,13 +150,58 @@ void main() {
         materialWidth: 600,
         hasPaint: false,
         hasTrimming: false,
-        hasCardboard: true,
-        handleType: OrderHandleType.flat,
+        hasCardboard: false,
+        handleType: OrderHandleType.twisted,
       ),
     );
 
-    final flatHandleStage = result.singleWhere(
-      (stage) => stage.stageKey == kFlatHandleGroupStageId,
+    final twistedHandleStage = result.singleWhere(
+      (stage) => stage.stageKey == kTwistedHandleGroupStageId,
+    );
+
+    expect(
+      result.map((stage) => stage.stageKey),
+      [
+        kSheetCutStageId,
+        kDieCutA1A2StageId,
+        kScotchStageId,
+        kFromTwoSheetsStageId,
+        kTubeAssemblyStageId,
+        kBottomWithCardboardAssemblyStageId,
+        kBottomGlueStageId,
+        kTwistedHandleGroupStageId,
+        kPackagingStageId,
+      ],
+    );
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kCuttingStageId)),
+    );
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kCardboardCuttingStageId)),
+    );
+    expect(twistedHandleStage.workplaceIds, [
+      kTwistedHandleStageId,
+      kManualHandleStageId,
+    ]);
+  });
+
+  test('builds two-sheet package route with die cut handle', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kTwoSheetPackageProductTypeId,
+        orderWidthB: 600,
+        materialWidth: 600,
+        hasPaint: false,
+        hasTrimming: true,
+        hasCardboard: false,
+        handleType: OrderHandleType.dieCut,
+      ),
+    );
+
+    final handleStage = result.singleWhere(
+      (stage) => stage.stageKey == kDieCutHandleStageId,
     );
 
     expect(
@@ -103,30 +213,14 @@ void main() {
         kScotchStageId,
         kFromTwoSheetsStageId,
         kTubeAssemblyStageId,
-        kCardboardCuttingStageId,
-        kCardboardInsertStageId,
         kBottomWithCardboardAssemblyStageId,
         kBottomGlueStageId,
-        kFlatHandleGroupStageId,
+        kDieCutHandleStageId,
         kPackagingStageId,
       ],
     );
-    expect(
-      result.map((stage) => stage.stageName),
-      containsAll([
-        'С 2х листов',
-        'Сборка трубы',
-        'Резка картона',
-        'Вставка картона',
-        'Сборка дно+картон',
-        'Склейка дна',
-      ]),
-    );
-    expect(flatHandleStage.workplaceIds, [
-      kFlatHandleStageId,
-      kManualHandleStageId,
-    ]);
-    expect(result.last.stageKey, kPackagingStageId);
+    expect(handleStage.stageName, 'Вырубка');
+    expect(handleStage.workplaceIds, [kDieCutHandleStageId]);
   });
 
   test('builds twisted handle as one multi-workplace stage', () {


### PR DESCRIPTION
### Motivation
- Implement the production routing for two-sheet packages so stages follow the requested order and conditional rules.
- Ensure multi-workplace die-cut and bottom-glue stages are added and keep existing handle/packaging logic unchanged.

### Description
- Refactored the two-sheet package branch into a dedicated `_appendTwoSheetPackageStages()` and call it from `_appendProductStages()` for `two-sheet` products.
- Add `Листорезка` (`kSheetCutStageId`), and add `Резка` (`kCuttingStageId`) only when `draft.hasTrimming` is true.
- Add one multi-workplace `Высечка A1/A2` (`kDieCutA1A2StageId`) with workplaces `kDieCutA1WorkplaceId` (`7c168998-76b8-4a4c-9708-af45c2dbd4f0`) and `kDieCutA2WorkplaceId` (`5a47821b-c276-4deb-90de-f196539fc95d`), then add `Скотч`, `С 2х листов` and `Сборка трубы` in order.
- If `draft.hasCardboard` is true, add `Резка картона` (`kCardboardCuttingStageId`); always add `Сборка дно+картон` (`kBottomWithCardboardAssemblyStageId`) and then multi-workplace `Склейка дна` (`kBottomGlueStageId`) with workplaces `kBottomGlueWorkplaceId` (`dee83c5c-4624-4ca4-b36c-47673dc5cd72`), `kBottomGlueAltWorkplaceId` (`ad504db5-86c3-4284-8266-42bbf967b064`) and `kBottomGlueSecondAltWorkplaceId` (`96075b60-77d8-4fb2-91b0-bfbe6c1ed13c`).
- Reused the existing `_appendHandleStage()` logic for flat/twisted/die-cut handles and preserved `Упаковка` (`kPackagingStageId`) as the final stage; made a minor formatting tweak to a long constant line.

### Testing
- Ran automated source assertions that verify the new `if (draft.hasTrimming) _add(_stage(kCuttingStageId, 'Резка'));` and presence of `_appendTwoSheetPackageStages()`; these checks passed.
- Ran `git diff --check` and basic file-level validations with no reported issues.
- Attempted to run `flutter test` for the unit tests, but `flutter` is not available in the environment so Dart/Flutter unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1a48a490832fbefa7b65c4e706be)