### PR TITLE
Add trimming (Резка) stage for V-type products

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -254,6 +254,7 @@ class _OrderStageQueueBuilder {
         groupKey: kSwitchableVGroupKey,
         fallbackSelectedId: kFriStageId,
       ));
+      if (draft.hasTrimming) _add(_stage(kCuttingStageId, 'Резка'));
       return;
     }
     if (_isTwoSheetPackageProduct(productTypeId)) {

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -59,6 +59,34 @@ void main() {
     expect(result.last.sortOrder, result.length);
   });
 
+  test('builds v-type package route with trimming before final packaging', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kVTypeProductId,
+        orderWidthB: 300,
+        materialWidth: 600,
+        hasPaint: true,
+        hasTrimming: true,
+        hasCardboard: false,
+      ),
+    );
+
+    expect(
+      result.map((stage) => stage.stageKey),
+      [
+        kBobbinStageId,
+        kFlexPrintingStageId,
+        kVMainSwitchStageKey,
+        kCuttingStageId,
+        kPackagingStageId,
+      ],
+    );
+    expect(result[2].stageName, 'Фри');
+    expect(result[2].isSwitchable, isTrue);
+    expect(result[3].stageName, 'Резка');
+    expect(result.last.stageName, 'Упаковка');
+  });
+
   test('does not add bobbin cutting without positive widths', () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(


### PR DESCRIPTION
### Motivation
- Ensure V-type ("В-образные") products include the cutting stage (`Резка`) when `hasTrimming` is true while keeping `Упаковка` as the final stage.

### Description
- Add `if (draft.hasTrimming) _add(_stage(kCuttingStageId, 'Резка'));` after the V-type `Фри/Окно` switchable stage in `lib/modules/orders/stage_queue_builder.dart` and add a unit test in `test/stage_queue_builder_test.dart` that expects the order `[kBobbinStageId, kFlexPrintingStageId, kVMainSwitchStageKey, kCuttingStageId, kPackagingStageId]` for a V-type product with `hasTrimming: true`.

### Testing
- Ran `git diff --check` which produced no issues; attempted `dart format` but the Dart SDK was not available (`dart: command not found`); attempted `flutter test test/stage_queue_builder_test.dart` but the Flutter SDK was not available (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1bbfee18832f8582beaf89180f0a)