### PR TITLE
P-package routing: add p_main_switch and cardboard branching (big/small auto, tube)

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -262,16 +262,47 @@ class _OrderStageQueueBuilder {
       return;
     }
     if (_isPTypePackageProduct(productTypeId)) {
-      _add(_switchableStage(
-        stageKey: kPMainSwitchStageKey,
-        stageName: _pSwitchableName,
-        workplaceIds: const [kAutoBigStageId, kAutoSmallStageId, kTubeStageId],
-        groupKey: kSwitchablePGroupKey,
-        fallbackSelectedId: kAutoBigStageId,
-      ));
-      _appendCardboardStages();
-      _appendHandleStage();
+      _appendPTypePackageStages();
     }
+  }
+
+  void _appendPTypePackageStages() {
+    final selectedWorkplaceId = _selectedForSwitchable(
+      stageKey: kPMainSwitchStageKey,
+      groupKey: kSwitchablePGroupKey,
+      fallback: kAutoBigStageId,
+    );
+
+    _add(_switchableStage(
+      stageKey: kPMainSwitchStageKey,
+      stageName: _selectedName(selectedWorkplaceId),
+      workplaceIds: const [kAutoBigStageId, kAutoSmallStageId, kTubeStageId],
+      groupKey: kSwitchablePGroupKey,
+      fallbackSelectedId: kAutoBigStageId,
+    ));
+    if (draft.hasTrimming) _add(_stage(kCuttingStageId, 'Резка'));
+    if (draft.hasCardboard) {
+      _add(_stage(kCardboardCuttingStageId, 'Резка картона'));
+      if (selectedWorkplaceId == kAutoBigStageId ||
+          selectedWorkplaceId == kAutoSmallStageId) {
+        _add(_stage(kCardboardInsertStageId, 'Вставка картона'));
+      } else if (selectedWorkplaceId == kTubeStageId) {
+        _add(_stage(
+          kBottomWithCardboardAssemblyStageId,
+          'Сборка дно+картон',
+        ));
+        _add(_stage(
+          kBottomGlueStageId,
+          'Склейка дна',
+          workplaceIds: const [
+            kBottomGlueWorkplaceId,
+            kBottomGlueAltWorkplaceId,
+            kBottomGlueSecondAltWorkplaceId,
+          ],
+        ));
+      }
+    }
+    _appendHandleStage();
   }
 
   void _appendTwoSheetPackageStages() {
@@ -304,16 +335,6 @@ class _OrderStageQueueBuilder {
     _appendHandleStage();
   }
 
-  void _appendCardboardStages() {
-    if (!draft.hasCardboard) return;
-    _add(_stage(kCardboardCuttingStageId, 'Резка картона'));
-    _add(_stage(kCardboardInsertStageId, 'Вставка картона'));
-    _add(_stage(
-      kBottomWithCardboardAssemblyStageId,
-      'Сборка дно+картон',
-    ));
-  }
-
   void _appendHandleStage() {
     final type = draft.handleType;
     if (type == OrderHandleType.flat) {
@@ -343,12 +364,6 @@ class _OrderStageQueueBuilder {
         stageKey: kVMainSwitchStageKey,
         groupKey: kSwitchableVGroupKey,
         fallback: kFriStageId,
-      ));
-
-  String get _pSwitchableName => _selectedName(_selectedForSwitchable(
-        stageKey: kPMainSwitchStageKey,
-        groupKey: kSwitchablePGroupKey,
-        fallback: kAutoBigStageId,
       ));
 
   BuiltOrderStage _stage(

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -294,6 +294,149 @@ void main() {
     expect(handleStage.workplaceIds, [kDieCutHandleStageId]);
   });
 
+  test('builds p-package route for selected big automatic workplace', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kPTypePackageProduct,
+        orderWidthB: 600,
+        materialWidth: 600,
+        hasPaint: false,
+        hasTrimming: true,
+        hasCardboard: true,
+        handleType: OrderHandleType.flat,
+        selectedSwitchableStageId: kAutoBigStageId,
+      ),
+    );
+
+    final switchStage = result.first;
+    final handleStage = result.singleWhere(
+      (stage) => stage.stageKey == kFlatHandleGroupStageId,
+    );
+
+    expect(
+      result.map((stage) => stage.stageKey),
+      [
+        kPMainSwitchStageKey,
+        kCuttingStageId,
+        kCardboardCuttingStageId,
+        kCardboardInsertStageId,
+        kFlatHandleGroupStageId,
+        kPackagingStageId,
+      ],
+    );
+    expect(switchStage.stageName, 'Автомат большой');
+    expect(switchStage.selectedWorkplaceId, kAutoBigStageId);
+    expect(switchStage.workplaceIds, [
+      kAutoBigStageId,
+      kAutoSmallStageId,
+      kTubeStageId,
+    ]);
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kBottomWithCardboardAssemblyStageId)),
+    );
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kBottomGlueStageId)),
+    );
+    expect(handleStage.workplaceIds, [
+      kFlatHandleStageId,
+      kManualHandleStageId,
+    ]);
+  });
+
+  test('builds p-package route for selected small automatic workplace', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kPTypePackageProduct,
+        orderWidthB: 600,
+        materialWidth: 600,
+        hasPaint: false,
+        hasTrimming: true,
+        hasCardboard: true,
+        handleType: OrderHandleType.twisted,
+        selectedSwitchableStageIdsByStageKey: {
+          kPMainSwitchStageKey: kAutoSmallStageId,
+        },
+      ),
+    );
+
+    final switchStage = result.first;
+    final handleStage = result.singleWhere(
+      (stage) => stage.stageKey == kTwistedHandleGroupStageId,
+    );
+
+    expect(
+      result.map((stage) => stage.stageKey),
+      [
+        kPMainSwitchStageKey,
+        kCuttingStageId,
+        kCardboardCuttingStageId,
+        kCardboardInsertStageId,
+        kTwistedHandleGroupStageId,
+        kPackagingStageId,
+      ],
+    );
+    expect(switchStage.stageName, 'Автомат маленький');
+    expect(switchStage.selectedWorkplaceId, kAutoSmallStageId);
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kBottomWithCardboardAssemblyStageId)),
+    );
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kBottomGlueStageId)),
+    );
+    expect(handleStage.workplaceIds, [
+      kTwistedHandleStageId,
+      kManualHandleStageId,
+    ]);
+  });
+
+  test('builds p-package route for selected tube workplace', () {
+    final result = buildOrderStages(
+      const OrderStageQueueDraft(
+        productTypeId: kPTypePackageProduct,
+        orderWidthB: 600,
+        materialWidth: 600,
+        hasPaint: false,
+        hasTrimming: true,
+        hasCardboard: true,
+        handleType: OrderHandleType.dieCut,
+        selectedSwitchableStageId: kTubeStageId,
+      ),
+    );
+
+    final switchStage = result.first;
+    final bottomGlueStage = result.singleWhere(
+      (stage) => stage.stageKey == kBottomGlueStageId,
+    );
+
+    expect(
+      result.map((stage) => stage.stageKey),
+      [
+        kPMainSwitchStageKey,
+        kCuttingStageId,
+        kCardboardCuttingStageId,
+        kBottomWithCardboardAssemblyStageId,
+        kBottomGlueStageId,
+        kDieCutHandleStageId,
+        kPackagingStageId,
+      ],
+    );
+    expect(switchStage.stageName, 'Труба');
+    expect(switchStage.selectedWorkplaceId, kTubeStageId);
+    expect(
+      result.map((stage) => stage.stageKey),
+      isNot(contains(kCardboardInsertStageId)),
+    );
+    expect(bottomGlueStage.workplaceIds, [
+      kBottomGlueWorkplaceId,
+      kBottomGlueAltWorkplaceId,
+      kBottomGlueSecondAltWorkplaceId,
+    ]);
+  });
+
   test('builds switchable p-package stage with selected tube workplace', () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(


### PR DESCRIPTION
### Motivation
- Implement specific routing for P-type packages so the package main switch (`p_main_switch`) can select between three workplaces and subsequent stages change according to the selection.
- Ensure trimming is added immediately after the P-switch when requested and that cardboard-related stages branch correctly for automatic vs tube workflows.
- Keep handle assembly and final packaging behavior consistent with existing logic.

### Description
- Extracted P-package logic into a new method `void _appendPTypePackageStages()` and call it from `_appendProductStages()` when `_isPTypePackageProduct(productTypeId)`.
- Add the switchable stage `p_main_switch` with workplace IDs `kAutoBigStageId`, `kAutoSmallStageId`, and `kTubeStageId`, and determine the selected workplace using `_selectedForSwitchable(...)` (so the stage name reflects the chosen workplace).
- After the switchable stage add `Резка` when `draft.hasTrimming == true`, then add `Резка картона` only when `draft.hasCardboard == true`, and branch: add `Вставка картона` for big/small automatic selections, or add `Сборка дно+картон` and multi-workplace `Склейка дна` for the tube selection; then call the existing `_appendHandleStage()`.
- Removed the now-unnecessary `_appendCardboardStages()` helper and the `_pSwitchableName` getter (the selected name is computed inline); added/updated tests to cover the three `p_main_switch` selections and their expected subsequent stages and workplace selections.

### Testing
- Ran `git diff --check` which produced no reported patch problems.
- Added unit tests for three scenarios: big automatic, small automatic, and tube selected for `p_main_switch` (these tests validate stage order, selected workplace id, and presence/absence of cardboard-specific stages). 
- Attempted to run `flutter test` / `dart test` but both `flutter` and `dart` are unavailable in the execution environment, so the new tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1cbd3470832fbeab0aa1e426a97a)