### PR TITLE
Limit cardboard-unsupported products and bind Cardboard checkbox to support check

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -90,6 +90,9 @@ bool _supportsCardboard(String productTypeId) {
       .contains(productTypeId.trim().toLowerCase());
 }
 
+bool supportsCardboardForTesting(String productTypeId) =>
+    _supportsCardboard(productTypeId);
+
 class _StageRuleOutcome {
   final List<Map<String, dynamic>> stages;
   final bool shouldCompleteBobbin;
@@ -5581,6 +5584,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               children: [
                 _buildCompactCheckboxTile(
                   value: _cardboardChecked,
+                  enabled: supportsCardboard,
                   onChanged: supportsCardboard
                       ? (val) => setState(() {
                             _cardboardChecked = val ?? false;
@@ -5738,13 +5742,17 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     required bool value,
     required ValueChanged<bool?>? onChanged,
     required String label,
+    bool enabled = true,
     double? width,
   }) {
     final theme = Theme.of(context);
+    final effectiveOnChanged = enabled ? onChanged : null;
 
     final tile = InkWell(
       borderRadius: BorderRadius.circular(10),
-      onTap: onChanged == null ? null : () => onChanged(!value),
+      onTap: effectiveOnChanged == null
+          ? null
+          : () => effectiveOnChanged(!value),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 1),
         child: Row(
@@ -5755,7 +5763,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               alignment: Alignment.centerLeft,
               child: Checkbox(
                 value: value,
-                onChanged: onChanged,
+                onChanged: effectiveOnChanged,
                 visualDensity: VisualDensity.compact,
                 materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),

--- a/test/edit_order_screen_cardboard_test.dart
+++ b/test/edit_order_screen_cardboard_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/edit_order_screen.dart';
+import 'package:sheet_clone/modules/orders/stage_queue_builder.dart';
+
+void main() {
+  group('supportsCardboardForTesting', () {
+    test('returns false for sheet and V-type products', () {
+      expect(supportsCardboardForTesting(kSheetProductTypeId), isFalse);
+
+      for (final productTypeId in kVTypeProducts) {
+        expect(
+          supportsCardboardForTesting(productTypeId),
+          isFalse,
+          reason: 'V-type product $productTypeId should not support cardboard',
+        );
+      }
+    });
+
+    test('returns true for P-type and two-sheet package products', () {
+      expect(supportsCardboardForTesting(kPTypePackageProduct), isTrue);
+      expect(supportsCardboardForTesting(kTwoSheetPackageProductTypeId), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- Ensure that cardboard support rules apply only to sheet products and all V-type products and that the two-sheet-package UUID `b07cd977-939c-4d4f-b68c-8d163341460e` is not treated as unsupported.
- Make the `Картон` checkbox UI reflect the same support check so that it is disabled when cardboard is not supported and add unit coverage for the behavior.

### Description
- Added a test helper `supportsCardboardForTesting` that delegates to the existing `_supportsCardboard` function to expose the rule to tests in `lib/modules/orders/edit_order_screen.dart`.
- Wired the `Картон` checkbox to use the computed `supportsCardboard` for both `enabled` and `onChanged` so the control is disabled when unsupported (change around lines 5579–5597).
- Extended `_buildCompactCheckboxTile` to accept a `bool enabled` parameter and to disable both the `InkWell` tap handler and the `Checkbox.onChanged` when `enabled` is `false` (changes in `_buildCompactCheckboxTile`).
- Added unit tests `test/edit_order_screen_cardboard_test.dart` that assert sheets and all `kVTypeProducts` return `false`, and that `kPTypePackageProduct` and `kTwoSheetPackageProductTypeId` return `true`.

### Testing
- Ran a source assertion script (`python3`) which confirmed the `_cardboardUnsupportedProductTypeIds` contents, absence of the UUID `b07cd977-939c-4d4f-b68c-8d163341460e` from that set, and that the `enabled: supportsCardboard` binding is present, and the script passed.
- Added `test/edit_order_screen_cardboard_test.dart` but `flutter test` was not executed in this environment because the Flutter SDK is not installed (`flutter: command not found`).
- `dart format` was not run due to `dart: command not found` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1df4db24832fa67d6714b0d9563e)