### PR TITLE
Исправить сборку очереди производства при отсутствии выбранного шаблона

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -102,6 +102,44 @@ class _StageRuleOutcome {
       {required this.stages, this.shouldCompleteBobbin = false, this.bobbinId});
 }
 
+List<Map<String, dynamic>> _buildStageMapsForProductionPlanSave({
+  required List<Map<String, dynamic>> stagePreviewStages,
+  required String? stageTemplateId,
+  required List<Map<String, dynamic>> selectedTemplateStages,
+  required List<Map<String, dynamic>> Function({
+    required List<Map<String, dynamic>> templateStages,
+  }) buildStageQueueFromCurrentDraft,
+}) {
+  if (stagePreviewStages.isNotEmpty) {
+    return stagePreviewStages
+        .map((stage) => Map<String, dynamic>.from(stage))
+        .toList(growable: true);
+  }
+
+  final hasSelectedTemplate = (stageTemplateId ?? '').trim().isNotEmpty;
+  return buildStageQueueFromCurrentDraft(
+    templateStages: hasSelectedTemplate
+        ? selectedTemplateStages
+        : const <Map<String, dynamic>>[],
+  );
+}
+
+@visibleForTesting
+List<Map<String, dynamic>> buildStageMapsForProductionPlanSaveForTesting({
+  required List<Map<String, dynamic>> stagePreviewStages,
+  required String? stageTemplateId,
+  required List<Map<String, dynamic>> selectedTemplateStages,
+  required List<Map<String, dynamic>> Function({
+    required List<Map<String, dynamic>> templateStages,
+  }) buildStageQueueFromCurrentDraft,
+}) =>
+    _buildStageMapsForProductionPlanSave(
+      stagePreviewStages: stagePreviewStages,
+      stageTemplateId: stageTemplateId,
+      selectedTemplateStages: selectedTemplateStages,
+      buildStageQueueFromCurrentDraft: buildStageQueueFromCurrentDraft,
+    );
+
 class _EditOrderScreenState extends State<EditOrderScreen> {
   static const String _paintInfoParamLabel = 'Информация для красок:';
 
@@ -3032,18 +3070,18 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       // stageTemplateId сохраняется в заказе выше, но автогенерация строится по полям формы.
       final templateStages = _selectedTemplateStageMaps();
 
-      List<Map<String, dynamic>> stageMaps;
       // Источник истины при сохранении — текущий preview.
       // Он уже может содержать ручную перестановку флексо/бобинорезки.
-      if (_stagePreviewStages.isNotEmpty) {
-        stageMaps = _stagePreviewStages
-            .map((stage) => Map<String, dynamic>.from(stage))
-            .toList(growable: true);
-      } else {
-        stageMaps = _buildStageQueueFromCurrentDraft(
-          templateStages: templateStages,
-        );
-      }
+      // Если preview пустой и шаблон не выбран, строим очередь строго из
+      // текущего черновика без этапов шаблона.
+      List<Map<String, dynamic>> stageMaps =
+          _buildStageMapsForProductionPlanSave(
+        stagePreviewStages: _stagePreviewStages,
+        stageTemplateId: _stageTemplateId,
+        selectedTemplateStages: templateStages,
+        buildStageQueueFromCurrentDraft: ({required templateStages}) =>
+            _buildStageQueueFromCurrentDraft(templateStages: templateStages),
+      );
 
       final outcome = await _applyStageRules(stageMaps);
       stageMaps = outcome.stages;

--- a/test/edit_order_screen_cardboard_test.dart
+++ b/test/edit_order_screen_cardboard_test.dart
@@ -3,6 +3,52 @@ import 'package:sheet_clone/modules/orders/edit_order_screen.dart';
 import 'package:sheet_clone/modules/orders/stage_queue_builder.dart';
 
 void main() {
+  group('production plan save stage maps', () {
+    test(
+      'creates product-type queue without selected template and ends with packaging',
+      () {
+        List<Map<String, dynamic>>? receivedTemplateStages;
+
+        final stageMaps = buildStageMapsForProductionPlanSaveForTesting(
+          stagePreviewStages: const <Map<String, dynamic>>[],
+          stageTemplateId: '',
+          selectedTemplateStages: const <Map<String, dynamic>>[
+            {
+              'stageKey': kPMainSwitchStageKey,
+              'stageId': kTubeStageId,
+              'selectedWorkplaceId': kTubeStageId,
+              'stageName': 'Труба',
+            },
+          ],
+          buildStageQueueFromCurrentDraft: ({required templateStages}) {
+            receivedTemplateStages = templateStages;
+            return buildOrderStageQueue(
+              productTypeId: kPTypePackageProduct,
+              hasCutting: true,
+              hasCardboard: true,
+              hasFlexPrinting: false,
+              templateStages: templateStages,
+            );
+          },
+        );
+
+        expect(receivedTemplateStages, isEmpty);
+        expect(
+          stageMaps.map((stage) => stage['stageKey']),
+          [
+            kPMainSwitchStageKey,
+            kCuttingStageId,
+            kCardboardCuttingStageId,
+            kCardboardInsertStageId,
+            kPackagingStageId,
+          ],
+        );
+        expect(stageMaps.first['stageName'], 'Автомат большой');
+        expect(stageMaps.last['stageName'], 'Упаковка');
+      },
+    );
+  });
+
   group('supportsCardboardForTesting', () {
     test('returns false for sheet and V-type products', () {
       expect(supportsCardboardForTesting(kSheetProductTypeId), isFalse);


### PR DESCRIPTION
### Motivation
- Исправить поведение сохранения производственной очереди, чтобы при пустом preview и отсутствии выбранного шаблона строилась очередь из текущего черновика без подстановки шаблонных этапов.

### Description
- Добавлен helper ` _buildStageMapsForProductionPlanSave` и тестовый фасад `buildStageMapsForProductionPlanSaveForTesting` для однозначного выбора источника этапов при сохранении (preview vs. построение из черновика с опциональными `templateStages`).
- В блоке сохранения заказа (при `canRebuildProductionPlan`) вызов формирования `stageMaps` заменён на использование нового helperа, который при пустом `_stagePreviewStages` и пустом `_stageTemplateId` вызывает построение очереди с `templateStages: []`.
- Итоговые `stageMaps` по-прежнему проходят через `_applyStageRules(stageMaps)` перед записью, а результат сохраняется в `production_plans.stages` и при `update`, и при `insert`.
- Добавлен unit-тест в `test/edit_order_screen_cardboard_test.dart`, который проверяет создание очереди для P-type продукта при отсутствии выбранного шаблона и гарантирует, что маршрут содержит этапы по типу продукта и завершается этапом `Упаковка`.

### Testing
- Выполнена проверка стейта изменений и форматных конфликтов с `git diff --check` — без замечаний.
- Добавленный unit-тест `test/edit_order_screen_cardboard_test.dart` присутствует в PR, но запуск `flutter test test/edit_order_screen_cardboard_test.dart` не выполнен в CI-окружении из‑за отсутствия Flutter SDK (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1f092fac832fa8aec74af8d5f101)