### PR TITLE
Auto-build order stage queues; centralize cardboard rules and map workplace UUIDs

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -80,15 +80,8 @@ const Set<String> _legacyBobbinAliases = {
   'w_bobiner',
   'w_bobbin',
 };
-const Set<String> _cardboardUnsupportedProductTypeIds = {
-  kSheetProductTypeId,
-  ...kVTypeProducts,
-};
-
-bool _supportsCardboard(String productTypeId) {
-  return !_cardboardUnsupportedProductTypeIds
-      .contains(productTypeId.trim().toLowerCase());
-}
+bool _supportsCardboard(String productTypeId) =>
+    supportsCardboardForProductType(productTypeId);
 
 bool supportsCardboardForTesting(String productTypeId) =>
     _supportsCardboard(productTypeId);
@@ -2848,9 +2841,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       return true;
     }
 
-    final bool hasStageQueueSelected = _isStageQueueBuilt;
-    final bool canLaunchProductionNow =
-        hasStageQueueSelected && hasEnoughPaperForLaunch();
+    // Очередь теперь автособирается при каждом сохранении заказа: пользователю
+    // не нужно отдельно нажимать кнопку построения очереди.
+    const bool hasStageQueueSelected = true;
+    final bool canLaunchProductionNow = hasEnoughPaperForLaunch();
     final bool wasAlreadyLaunched = widget.order?.assignmentCreated ?? false;
     if (wasAlreadyLaunched) {
       await _loadRuntimeEditLocks();

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -60,9 +60,9 @@ const String kFlatHandleWorkplaceId = kFlatHandleStageId;
 // The following technological stage keys are intentionally distinct even when
 // a customer installation maps several of them to the same physical workplace.
 const String kDieCutA1A2StageId = 'die_cut_a1_a2';
-const String kScotchStageId = 'scotch';
-const String kFromTwoSheetsStageId = 'from_two_sheets';
-const String kTubeAssemblyStageId = 'tube_assembly';
+const String kScotchStageId = 'a9e21c59-e145-4074-8d24-f2db089c8747';
+const String kFromTwoSheetsStageId = '008a5bbd-86f8-48c1-a98b-0034f80492a6';
+const String kTubeAssemblyStageId = '4e4750b0-5849-42be-94b8-a721a68b85da';
 const String kBottomGlueStageId = 'bottom_glue_group';
 const String kTwistedHandleGroupStageId = 'twisted_handle_group';
 const String kFlatHandleGroupStageId = 'flat_handle_group';
@@ -469,6 +469,19 @@ const Map<String, Set<String>> _switchableIdsByGroup = {
   kSwitchablePGroupKey: {kAutoBigStageId, kAutoSmallStageId, kTubeStageId},
 };
 
+bool isSheetProductType(String productTypeId) => _isSheetProduct(productTypeId);
+
+bool isVTypeProductType(String productTypeId) => _isVTypeProduct(productTypeId);
+
+bool isTwoSheetPackageProductType(String productTypeId) =>
+    _isTwoSheetPackageProduct(productTypeId);
+
+bool isPTypePackageProductType(String productTypeId) =>
+    _isPTypePackageProduct(productTypeId);
+
+bool supportsCardboardForProductType(String productTypeId) =>
+    !_isSheetProduct(productTypeId) && !_isVTypeProduct(productTypeId);
+
 bool _isSheetProduct(String productTypeId) {
   final normalized = _normalizeProductType(productTypeId);
   return kSheetProducts.contains(productTypeId) || normalized == 'листы';
@@ -480,7 +493,11 @@ bool _isVTypeProduct(String productTypeId) {
       normalized == 'v пакет' ||
       normalized == 'v-пакет' ||
       normalized == 'в образные' ||
-      normalized == 'в-образные';
+      normalized == 'в-образные' ||
+      normalized == 'в-образный окно' ||
+      normalized == 'в-образный пакет' ||
+      normalized == 'в-образный фри' ||
+      normalized == 'в-образный уголок';
 }
 
 bool _isTwoSheetPackageProduct(String productTypeId) {

--- a/test/edit_order_screen_cardboard_test.dart
+++ b/test/edit_order_screen_cardboard_test.dart
@@ -52,6 +52,7 @@ void main() {
   group('supportsCardboardForTesting', () {
     test('returns false for sheet and V-type products', () {
       expect(supportsCardboardForTesting(kSheetProductTypeId), isFalse);
+      expect(supportsCardboardForTesting('Листы'), isFalse);
 
       for (final productTypeId in kVTypeProducts) {
         expect(
@@ -60,11 +61,28 @@ void main() {
           reason: 'V-type product $productTypeId should not support cardboard',
         );
       }
+
+      for (final productTypeName in const [
+        'В-образный окно',
+        'В-образный пакет',
+        'В-образный фри',
+        'В-образный уголок',
+      ]) {
+        expect(
+          supportsCardboardForTesting(productTypeName),
+          isFalse,
+          reason: 'V-type product name $productTypeName should not support '
+              'cardboard',
+        );
+      }
     });
 
     test('returns true for P-type and two-sheet package products', () {
       expect(supportsCardboardForTesting(kPTypePackageProduct), isTrue);
-      expect(supportsCardboardForTesting(kTwoSheetPackageProductTypeId), isTrue);
+      expect(
+        supportsCardboardForTesting(kTwoSheetPackageProductTypeId),
+        isTrue,
+      );
     });
   });
 }

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -87,6 +87,30 @@ void main() {
     expect(result.last.stageName, 'Упаковка');
   });
 
+  test('recognizes named V-type products as switchable V routes', () {
+    for (final productTypeName in const [
+      'В-образный окно',
+      'В-образный пакет',
+      'В-образный фри',
+      'В-образный уголок',
+    ]) {
+      final result = buildOrderStages(
+        OrderStageQueueDraft(
+          productTypeId: productTypeName,
+          orderWidthB: 600,
+          materialWidth: 600,
+          hasPaint: false,
+          hasTrimming: false,
+          hasCardboard: false,
+        ),
+      );
+
+      expect(result.first.stageKey, kVMainSwitchStageKey);
+      expect(result.first.selectedWorkplaceId, kFriStageId);
+      expect(result.last.stageKey, kPackagingStageId);
+    }
+  });
+
   test('does not add bobbin cutting without positive widths', () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(


### PR DESCRIPTION
### Motivation
- Automatically build/save production stage queues when an order is saved so users no longer must press a separate "build queue" button. 
- Centralize product-type routing decisions (cardboard support and name recognition) so UI and queue builder use the same rules. 
- Use real workplace UUIDs for a few two-sheet-package stages and support named V-type product variants in routing.

### Description
- Set the order save flow to treat the queue as built by default by making `hasStageQueueSelected` always true during save in `lib/modules/orders/edit_order_screen.dart`. 
- Added `supportsCardboardForProductType`, `isSheetProductType`, `isVTypeProductType`, `isTwoSheetPackageProductType`, and `isPTypePackageProductType` helpers in `lib/modules/orders/stage_queue_builder.dart` and wired `edit_order_screen` to call `supportsCardboardForProductType` for enabling/disabling the cardboard checkbox. 
- Mapped three technological stage keys to actual workplace UUIDs by replacing placeholder keys with `kScotchStageId = 'a9e21c59-...88747'`, `kFromTwoSheetsStageId = '008a5bbd-...'`, and `kTubeAssemblyStageId = '4e4750b0-...'` in `lib/modules/orders/stage_queue_builder.dart`. 
- Extended V-type product name recognition to accept visible names such as `В-образный окно`, `В-образный пакет`, `В-образный фри`, and `В-образный уголок` so switchable V-stage logic works with user-facing names. 
- Added/updated tests to cover the new behaviors: `test/stage_queue_builder_test.dart` now contains `recognizes named V-type products as switchable V routes`, and `test/edit_order_screen_cardboard_test.dart` adds checks for named V-type product cardboard support. 

### Testing
- Ran `git diff --check` to validate diff hygiene and it passed. 
- Attempted to run `dart format` on affected files but `dart` was not available in the environment so formatting was not executed. 
- Attempted to run unit tests with `flutter test test/stage_queue_builder_test.dart test/edit_order_screen_cardboard_test.dart` but `flutter` is not installed in the environment, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc26107ee8832fa5c169f51ae2f7ba)