### PR TITLE
Persist order queue build state

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -553,6 +553,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   bool _stagePreviewScheduled = false;
   bool _stagePreviewInitialized = false;
   bool _isStageQueueBuilt = false;
+  String _queueBuildStatus = QueueBuildStatus.notBuilt;
+  String? _selectedVStage;
+  String? _selectedPStage;
+  Map<String, dynamic>? _queueSignature;
   bool _updatingStageTemplateText = false;
   bool _lastPreviewPaintsFilled = false;
   MaterialModel? _selectedMaterial;
@@ -709,6 +713,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     _makeready = template?.makeready ?? 0;
     _val = template?.val ?? 0;
     _stageTemplateId = template?.stageTemplateId;
+    _queueBuildStatus =
+        widget.order?.queueBuildStatus ?? QueueBuildStatus.notBuilt;
+    _selectedVStage = widget.order?.selectedVStage;
+    _selectedPStage = widget.order?.selectedPStage;
+    _queueSignature = widget.order?.queueSignature == null
+        ? null
+        : Map<String, dynamic>.from(widget.order!.queueSignature!);
     final List<MaterialModel> initialPapers = template != null
         ? (template.paperMaterials.isNotEmpty
             ? List<MaterialModel>.from(template.paperMaterials)
@@ -1437,6 +1448,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       // Важно: после ручного swap больше не должны возвращать auto-порядок.
       _stageOrderManuallyChanged = true;
       _isStageQueueBuilt = false;
+      _markQueueOutdatedIfBuilt();
     });
   }
 
@@ -1457,6 +1469,57 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       hasCardboard: _cardboardChecked,
       handleType: _resolveSelectedHandleType(),
     );
+  }
+
+
+  Map<String, dynamic> _currentQueueSignature() {
+    final mainMaterial = _mainMaterialForStageQueue();
+    final paperIds = _collectSelectedPapers()
+        .map((paper) => {
+              'id': (paper.id ?? '').trim(),
+              'name': paper.name.trim(),
+              'format': (paper.format ?? '').trim(),
+              'grammage': (paper.grammage ?? '').trim(),
+              'quantity': paper.quantity,
+            })
+        .toList(growable: false);
+    return <String, dynamic>{
+      'product_type_id': _product.type.trim(),
+      'product_quantity': _product.quantity,
+      'product_width': _product.width,
+      'product_height': _product.height,
+      'product_depth': _product.depth,
+      'product_width_b': _product.widthB,
+      'material_width': parseMaterialWidth(mainMaterial),
+      'paper_materials': paperIds,
+      'has_paint': _hasAnyPaints(),
+      'has_trimming': _trimming,
+      'has_cardboard': _cardboardChecked,
+      'handle': _selectedHandleDescription.trim(),
+      'stage_template_id': _stageTemplateId,
+    };
+  }
+
+  bool _sameQueueSignature(
+    Map<String, dynamic>? left,
+    Map<String, dynamic>? right,
+  ) {
+    if (left == null || right == null) return left == right;
+    return jsonEncode(left) == jsonEncode(right);
+  }
+
+  void _syncSwitchableStageSelectionFields(
+    List<Map<String, dynamic>> stages,
+  ) {
+    final selections = collectSwitchableStageSelectionsByStageKey(stages);
+    _selectedVStage = selections[kVMainSwitchStageKey];
+    _selectedPStage = selections[kPMainSwitchStageKey];
+  }
+
+  void _markQueueOutdatedIfBuilt() {
+    if (_queueBuildStatus == QueueBuildStatus.built) {
+      _queueBuildStatus = QueueBuildStatus.outdated;
+    }
   }
 
   List<Map<String, dynamic>> _buildStageQueueFromCurrentDraft({
@@ -1494,6 +1557,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     );
     setState(() {
       _stagePreviewStages = queue;
+      _syncSwitchableStageSelectionFields(queue);
+      _queueSignature = _currentQueueSignature();
+      _queueBuildStatus = QueueBuildStatus.built;
       _isStageQueueBuilt = true;
     });
   }
@@ -1730,6 +1796,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   void _scheduleStagePreviewUpdate({bool immediate = false}) {
     if (!mounted) return;
+    if (_queueBuildStatus == QueueBuildStatus.built &&
+        !_sameQueueSignature(_queueSignature, _currentQueueSignature())) {
+      _queueBuildStatus = QueueBuildStatus.outdated;
+    }
     if (immediate) {
       _stagePreviewScheduled = false;
       _rebuildStagePreview();
@@ -2823,6 +2893,19 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     final warehouse = Provider.of<WarehouseProvider>(context, listen: false);
     // Бумага хранится динамическим списком без жёсткого лимита.
     final List<MaterialModel> selectedPapers = _collectSelectedPapers();
+    final currentQueueSignature = _currentQueueSignature();
+    var nextQueueBuildStatus = _queueBuildStatus;
+    if (isCreating && nextQueueBuildStatus != QueueBuildStatus.built) {
+      nextQueueBuildStatus = QueueBuildStatus.notBuilt;
+    } else if (!isCreating &&
+        widget.order?.queueBuildStatus == QueueBuildStatus.built &&
+        !_sameQueueSignature(
+            widget.order?.queueSignature, currentQueueSignature)) {
+      nextQueueBuildStatus = QueueBuildStatus.outdated;
+    }
+    if (nextQueueBuildStatus == QueueBuildStatus.built) {
+      _syncSwitchableStageSelectionFields(_stagePreviewStages);
+    }
     bool hasEnoughPaperForLaunch() {
       if (selectedPapers.isEmpty) return true;
       for (final paper in selectedPapers) {
@@ -2905,6 +2988,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         paymentDone: false,
         comments: _commentsController.text.trim(),
         status: nextOrderStatus,
+        queueBuildStatus: nextQueueBuildStatus,
+        selectedVStage: _selectedVStage,
+        selectedPStage: _selectedPStage,
+        queueSignature: nextQueueBuildStatus == QueueBuildStatus.notBuilt
+            ? null
+            : currentQueueSignature,
       );
       if (_created == null) {
         if (mounted) {
@@ -2983,6 +3072,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         materialShortageMessage: shortageMessage,
         assignmentId: widget.order!.assignmentId,
         assignmentCreated: widget.order!.assignmentCreated,
+        queueBuildStatus: nextQueueBuildStatus,
+        selectedVStage: _selectedVStage,
+        selectedPStage: _selectedPStage,
+        queueSignature: nextQueueBuildStatus == QueueBuildStatus.notBuilt
+            ? null
+            : currentQueueSignature,
       );
       await provider.updateOrder(updated);
       createdOrUpdatedOrder = updated;
@@ -3045,6 +3140,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           status: createdOrUpdatedOrder.status,
           assignmentId: humanId,
           assignmentCreated: createdOrUpdatedOrder.assignmentCreated,
+          queueBuildStatus: createdOrUpdatedOrder.queueBuildStatus,
+          selectedVStage: createdOrUpdatedOrder.selectedVStage,
+          selectedPStage: createdOrUpdatedOrder.selectedPStage,
+          queueSignature: createdOrUpdatedOrder.queueSignature,
         );
         await provider.updateOrder(withReadable);
         createdOrUpdatedOrder = withReadable;
@@ -6480,6 +6579,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           if (toggledStage == null) return;
           setState(() {
             _stagePreviewStages[i] = toggledStage;
+            _syncSwitchableStageSelectionFields(_stagePreviewStages);
+            _queueSignature = _currentQueueSignature();
+            _queueBuildStatus = QueueBuildStatus.built;
             _isStageQueueBuilt = true;
           });
         },

--- a/lib/modules/orders/order_model.dart
+++ b/lib/modules/orders/order_model.dart
@@ -19,6 +19,24 @@ enum OrderStatus {
   completed,
 }
 
+class QueueBuildStatus {
+  static const String notBuilt = 'not_built';
+  static const String built = 'built';
+  static const String outdated = 'outdated';
+
+  static String normalize(String? raw) {
+    final value = (raw ?? '').trim();
+    switch (value) {
+      case notBuilt:
+      case built:
+      case outdated:
+        return value;
+      default:
+        return notBuilt;
+    }
+  }
+}
+
 /// ===== SAFE CAST HELPERS =====
 bool? _asBool(dynamic v) {
   if (v == null) return null;
@@ -125,6 +143,10 @@ class OrderModel {
   String materialShortageMessage;
   String? assignmentId;
   bool assignmentCreated;
+  String queueBuildStatus;
+  String? selectedVStage;
+  String? selectedPStage;
+  Map<String, dynamic>? queueSignature;
 
   OrderModel({
     required this.id,
@@ -160,6 +182,10 @@ class OrderModel {
     this.shippedAt,
     this.shippedBy,
     this.shippedQty,
+    String? queueBuildStatus,
+    this.selectedVStage,
+    this.selectedPStage,
+    Map<String, dynamic>? queueSignature,
   })  : additionalParams = additionalParams ?? const <String>[],
         handle = handle ?? '-',
         cardboard = cardboard ?? 'нет',
@@ -176,7 +202,11 @@ class OrderModel {
         status = status ?? OrderStatus.draft.name,
         hasMaterialShortage = hasMaterialShortage ?? false,
         materialShortageMessage = materialShortageMessage ?? '',
-        assignmentCreated = assignmentCreated ?? false;
+        assignmentCreated = assignmentCreated ?? false,
+        queueBuildStatus = QueueBuildStatus.normalize(queueBuildStatus),
+        queueSignature = queueSignature == null
+            ? null
+            : Map<String, dynamic>.from(queueSignature);
 
   static String normalizeStatus(String? raw) {
     final value = (raw ?? '').trim();
@@ -223,8 +253,9 @@ class OrderModel {
         if (includeNulls || material != null)
           'material': material?.toMap(),
         if (includeNulls || paperMaterials.isNotEmpty)
-          'material_list':
-              paperMaterials.isEmpty ? null : paperMaterials.map((m) => m.toMap()).toList(),
+          'material_list': paperMaterials.isEmpty
+              ? null
+              : paperMaterials.map((m) => m.toMap()).toList(),
         'makeready': makeready,
         'val': val,
         'has_form': hasForm,
@@ -248,6 +279,13 @@ class OrderModel {
           'shipped_at': shippedAt?.toIso8601String(),
         if (includeNulls || shippedBy != null) 'shipped_by': shippedBy,
         if (includeNulls || shippedQty != null) 'shipped_qty': shippedQty,
+        'queue_build_status': QueueBuildStatus.normalize(queueBuildStatus),
+        if (includeNulls || selectedVStage != null)
+          'selected_v_stage': selectedVStage,
+        if (includeNulls || selectedPStage != null)
+          'selected_p_stage': selectedPStage,
+        if (includeNulls || queueSignature != null)
+          'queue_signature': queueSignature,
       };
 
   /// Парсим и camelCase, и snake_case.
@@ -269,7 +307,8 @@ class OrderModel {
       if (raw is List) {
         return raw
             .whereType<Map>()
-            .map((item) => MaterialModel.fromMap(Map<String, dynamic>.from(item as Map)))
+            .map((item) =>
+                MaterialModel.fromMap(Map<String, dynamic>.from(item as Map)))
             .toList();
       }
       return const <MaterialModel>[];
@@ -334,7 +373,9 @@ class OrderModel {
       material: materialMap.isEmpty ? null : MaterialModel.fromMap(materialMap),
       paperMaterials: materialList.isNotEmpty
           ? materialList
-          : (materialMap.isEmpty ? const <MaterialModel>[] : [MaterialModel.fromMap(materialMap)]),
+          : (materialMap.isEmpty
+              ? const <MaterialModel>[]
+              : [MaterialModel.fromMap(materialMap)]),
       makeready:
           ((_pickAny(map, const ['makeready']) as num?)?.toDouble()) ?? 0,
       val: ((_pickAny(map, const ['val']) as num?)?.toDouble()) ?? 0,
@@ -372,6 +413,20 @@ class OrderModel {
       shippedBy: (_pickAny(map, const ['shipped_by', 'shippedBy']) as String?),
       shippedQty:
           _parseDouble(_pickAny(map, const ['shipped_qty', 'shippedQty'])),
+      queueBuildStatus: QueueBuildStatus.normalize(
+          _pickAny(map, const ['queue_build_status', 'queueBuildStatus'])
+              ?.toString()),
+      selectedVStage:
+          (_pickAny(map, const ['selected_v_stage', 'selectedVStage'])
+              as String?),
+      selectedPStage:
+          (_pickAny(map, const ['selected_p_stage', 'selectedPStage'])
+              as String?),
+      queueSignature: (() {
+        final raw = _pickAny(map, const ['queue_signature', 'queueSignature']);
+        final decoded = _asMap(raw);
+        return decoded.isEmpty ? null : decoded;
+      })(),
     );
   }
 
@@ -405,6 +460,10 @@ class OrderModel {
     String? shippedBy,
     double? shippedQty,
     bool? hasForm,
+    String? queueBuildStatus,
+    String? selectedVStage,
+    String? selectedPStage,
+    Map<String, dynamic>? queueSignature,
   }) {
     return OrderModel(
       id: id,
@@ -418,7 +477,8 @@ class OrderModel {
       handle: handle ?? this.handle,
       cardboard: cardboard ?? this.cardboard,
       material: material ?? this.material,
-      paperMaterials: paperMaterials ?? List<MaterialModel>.from(this.paperMaterials),
+      paperMaterials:
+          paperMaterials ?? List<MaterialModel>.from(this.paperMaterials),
       makeready: makeready ?? this.makeready,
       val: val ?? this.val,
       pdfUrl: pdfUrl ?? this.pdfUrl,
@@ -441,6 +501,13 @@ class OrderModel {
       shippedAt: shippedAt ?? this.shippedAt,
       shippedBy: shippedBy ?? this.shippedBy,
       shippedQty: shippedQty ?? this.shippedQty,
+      queueBuildStatus: queueBuildStatus ?? this.queueBuildStatus,
+      selectedVStage: selectedVStage ?? this.selectedVStage,
+      selectedPStage: selectedPStage ?? this.selectedPStage,
+      queueSignature: queueSignature ??
+          (this.queueSignature == null
+              ? null
+              : Map<String, dynamic>.from(this.queueSignature!)),
     );
   }
 }

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -447,6 +447,10 @@ class OrdersProvider with ChangeNotifier {
     bool paymentDone = false,
     String comments = '',
     String status = 'draft',
+    String queueBuildStatus = QueueBuildStatus.notBuilt,
+    String? selectedVStage,
+    String? selectedPStage,
+    Map<String, dynamic>? queueSignature,
     String? assignmentId,
     bool assignmentCreated = false,
   }) async {
@@ -475,6 +479,10 @@ class OrdersProvider with ChangeNotifier {
       paymentDone: paymentDone,
       comments: comments,
       status: status,
+      queueBuildStatus: queueBuildStatus,
+      selectedVStage: selectedVStage,
+      selectedPStage: selectedPStage,
+      queueSignature: queueSignature,
       assignmentId: assignmentId,
       assignmentCreated: assignmentCreated,
     );

--- a/lib/modules/orders/orders_repository.dart
+++ b/lib/modules/orders/orders_repository.dart
@@ -34,6 +34,10 @@ class OrderFormData {
   final String? queueId;
   final String? stageTemplateId;
   final String? status;
+  final String queueBuildStatus;
+  final String? selectedVStage;
+  final String? selectedPStage;
+  final Map<String, dynamic>? queueSignature;
 
   const OrderFormData({
     required this.manager,
@@ -65,6 +69,10 @@ class OrderFormData {
     this.queueId,
     this.stageTemplateId,
     this.status,
+    this.queueBuildStatus = 'not_built',
+    this.selectedVStage,
+    this.selectedPStage,
+    this.queueSignature,
   });
 
   Map<String, dynamic> toInsertMap() {
@@ -98,6 +106,10 @@ class OrderFormData {
       'queue_id': queueId,
       'stage_template_id': stageTemplateId,
       'status': status ?? 'draft',
+      'queue_build_status': queueBuildStatus,
+      'selected_v_stage': selectedVStage,
+      'selected_p_stage': selectedPStage,
+      'queue_signature': queueSignature,
     };
     return _cleanForInsert(m);
   }

--- a/superbase.sql
+++ b/superbase.sql
@@ -369,6 +369,12 @@ create table if not exists public.orders (
   updated_at timestamptz
 );
 alter table public.orders enable row level security;
+-- Безопасные колонки для состояния сборки производственной очереди.
+alter table public.orders
+  add column if not exists queue_build_status text not null default 'not_built',
+  add column if not exists selected_v_stage text,
+  add column if not exists selected_p_stage text,
+  add column if not exists queue_signature jsonb;
 -- Дополнительные колонки для совместимости с приложением
 do $$
 begin

--- a/test/order_model_queue_status_test.dart
+++ b/test/order_model_queue_status_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/order_model.dart';
+import 'package:sheet_clone/modules/orders/product_model.dart';
+
+void main() {
+  ProductModel product() => ProductModel(
+        id: 'product-1',
+        type: 'П-пакет',
+        quantity: 100,
+        width: 10,
+        height: 20,
+        depth: 30,
+        parameters: '',
+      );
+
+  test('serializes queue build fields with snake_case keys', () {
+    final order = OrderModel(
+      id: 'order-1',
+      manager: 'Manager',
+      customer: 'Customer',
+      orderDate: DateTime.utc(2026, 1, 1),
+      dueDate: DateTime.utc(2026, 1, 2),
+      product: product(),
+      queueBuildStatus: QueueBuildStatus.built,
+      selectedVStage: 'v-stage',
+      selectedPStage: 'p-stage',
+      queueSignature: {'product_type_id': 'П-пакет'},
+    );
+
+    final map = order.toMap();
+
+    expect(map['queue_build_status'], QueueBuildStatus.built);
+    expect(map['selected_v_stage'], 'v-stage');
+    expect(map['selected_p_stage'], 'p-stage');
+    expect(map['queue_signature'], {'product_type_id': 'П-пакет'});
+  });
+
+  test('deserializes queue build fields from snake_case keys', () {
+    final order = OrderModel.fromMap({
+      'id': 'order-1',
+      'manager': 'Manager',
+      'customer': 'Customer',
+      'order_date': '2026-01-01T00:00:00.000Z',
+      'product': product().toMap(),
+      'queue_build_status': QueueBuildStatus.outdated,
+      'selected_v_stage': 'v-stage',
+      'selected_p_stage': 'p-stage',
+      'queue_signature': {'has_paint': true},
+    });
+
+    expect(order.queueBuildStatus, QueueBuildStatus.outdated);
+    expect(order.selectedVStage, 'v-stage');
+    expect(order.selectedPStage, 'p-stage');
+    expect(order.queueSignature, {'has_paint': true});
+  });
+
+  test('copyWith keeps and overrides queue build fields', () {
+    final order = OrderModel(
+      id: 'order-1',
+      manager: 'Manager',
+      customer: 'Customer',
+      orderDate: DateTime.utc(2026, 1, 1),
+      dueDate: null,
+      product: product(),
+      queueBuildStatus: QueueBuildStatus.notBuilt,
+    );
+
+    final updated = order.copyWith(
+      queueBuildStatus: QueueBuildStatus.built,
+      selectedVStage: 'v-stage',
+      selectedPStage: 'p-stage',
+      queueSignature: {'has_trimming': false},
+    );
+
+    expect(updated.queueBuildStatus, QueueBuildStatus.built);
+    expect(updated.selectedVStage, 'v-stage');
+    expect(updated.selectedPStage, 'p-stage');
+    expect(updated.queueSignature, {'has_trimming': false});
+  });
+}


### PR DESCRIPTION
### Motivation
- Track and persist production-queue build metadata (build status, chosen switchable stages and a queue signature) on orders so the UI and backend can consistently detect when a previously built queue became outdated and store user selections. 
- Keep read/write of these values centralized in the order model serialization to support both direct DB columns and fallback to JSON/metadata. 

### Description
- Added queue-related fields to the order model: `String queueBuildStatus`, `String? selectedVStage`, `String? selectedPStage`, and `Map<String, dynamic>? queueSignature`, plus `QueueBuildStatus` helper for normalization in `lib/modules/orders/order_model.dart` and updated `toMap()`, `fromMap()` and `copyWith()` to support snake_case keys `queue_build_status`, `selected_v_stage`, `selected_p_stage`, `queue_signature`.
- Wired the edit/create flow in `lib/modules/orders/edit_order_screen.dart` to: default new orders to `QueueBuildStatus.notBuilt`, set `queueBuildStatus = 'built'` and persist selected switchable stages and a computed queue signature when the user builds the queue, and mark a previously `built` queue as `outdated` when important parameters change.
- Propagated new fields through the persistence/repository layer by extending `OrdersProvider.createOrder()` and `OrderFormData.toInsertMap()` / `OrdersRepository` to include the new queue metadata, and ensured optimistic/insert/update paths preserve these values (`lib/modules/orders/orders_provider.dart`, `lib/modules/orders/orders_repository.dart`).
- Added DB-safe columns in `superbase.sql` to store the metadata when available: `queue_build_status`, `selected_v_stage`, `selected_p_stage`, and `queue_signature` (JSONB), while keeping existing JSON/metadata fallback semantics.
- Added unit coverage for model serialization/deserialization and `copyWith()` behavior in `test/order_model_queue_status_test.dart`.

### Testing
- Ran a repository sanity check with `git diff --check` which reported no problems. (OK)
- Added a unit test file `test/order_model_queue_status_test.dart` that validates `toMap()`, `fromMap()` and `copyWith()` for the new fields; test exists in the tree but could not be executed in this environment because `flutter`/`dart` tooling is not available (`flutter: command not found`). (NOT RUN)
- Manual code review and local static verifications of changed call sites to ensure new fields are passed through optimistic create/update paths and read back via `OrderModel.fromMap()`; no runtime test failures observed in this environment. (INSPECTED)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3afdcc48832fb10161e465c1bc06)