### PR TITLE
Gate order readiness/launch on built stage queue and mark queue outdated on edits

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1024,6 +1024,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     setState(() {
       _stageTemplateId = template.id;
       _selectedStageTemplateName = template.name;
+      _markQueueOutdatedIfBuilt();
       _stagePreviewStages = <Map<String, dynamic>>[];
       _stagePreviewError = null;
       _stagePreviewLoading = true;
@@ -1643,6 +1644,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           _selectedStageTemplateName!.trim() != text.trim()) {
         _stageTemplateId = null;
         _selectedStageTemplateName = null;
+        _markQueueOutdatedIfBuilt();
         _stagePreviewStages = <Map<String, dynamic>>[];
         _stagePreviewError = null;
         _stagePreviewLoading = false;
@@ -2272,6 +2274,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       if (extraIndex >= 0 && extraIndex < _extraPaperMaterials.length) {
         final currentExtra = _extraPaperMaterials[extraIndex];
         setState(() {
+          _markQueueOutdatedIfBuilt();
           _extraPaperMaterials[extraIndex] = currentExtra.copyWith(
             id: paper.id,
             name: paper.description,
@@ -2283,6 +2286,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             unit: 'м',
           );
         });
+        _scheduleStagePreviewUpdate();
         return;
       }
     }
@@ -2924,10 +2928,10 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       return true;
     }
 
-    // Очередь теперь автособирается при каждом сохранении заказа: пользователю
-    // не нужно отдельно нажимать кнопку построения очереди.
-    const bool hasStageQueueSelected = true;
-    final bool canLaunchProductionNow = hasEnoughPaperForLaunch();
+    final bool hasBuiltStageQueue =
+        nextQueueBuildStatus == QueueBuildStatus.built;
+    final bool canLaunchProductionNow =
+        hasBuiltStageQueue && hasEnoughPaperForLaunch();
     final bool wasAlreadyLaunched = widget.order?.assignmentCreated ?? false;
     if (wasAlreadyLaunched) {
       await _loadRuntimeEditLocks();
@@ -2947,21 +2951,21 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         (wasAlreadyLaunched && canResetForRelaunchAfterQueueEdit);
     final String nextOrderStatus = wasAlreadyLaunched
         ? widget.order!.status
-        : (!hasStageQueueSelected
+        : (!hasBuiltStageQueue
             ? OrderStatus.draft.name
             : (canLaunchProductionNow
-            ? OrderStatus.ready_to_start.name
-            : OrderStatus.waiting_materials.name));
+                ? OrderStatus.ready_to_start.name
+                : OrderStatus.waiting_materials.name));
     final bool nextHasMaterialShortage = wasAlreadyLaunched
         ? widget.order!.hasMaterialShortage
-        : (hasStageQueueSelected ? !canLaunchProductionNow : false);
+        : (hasBuiltStageQueue ? !canLaunchProductionNow : false);
     final String shortageMessage = wasAlreadyLaunched
         ? widget.order!.materialShortageMessage
-        : (!hasStageQueueSelected
+        : (!hasBuiltStageQueue
             ? ''
             : (canLaunchProductionNow
-            ? ''
-            : 'Недостаточно материала на складе. Пополните склад и запустите заказ вручную.'));
+                ? ''
+                : 'Недостаточно материала на складе. Пополните склад и запустите заказ вручную.'));
     late OrderModel createdOrUpdatedOrder;
     bool resetForRelaunchAfterEdit = false;
     if (widget.order == null) {
@@ -3090,7 +3094,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         await provider.resetLaunchedOrderForRelaunch(updated.id);
         createdOrUpdatedOrder = createdOrUpdatedOrder.copyWith(
           assignmentCreated: false,
-          status: OrderStatus.ready_to_start.name,
+          status: nextOrderStatus,
         );
         resetForRelaunchAfterEdit = true;
       }
@@ -3158,7 +3162,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       createdOrUpdatedOrder.pdfUrl = uploadedPath;
       await provider.updateOrder(createdOrUpdatedOrder);
     }
-    if (canRebuildProductionPlan) {
+    if (canRebuildProductionPlan && hasBuiltStageQueue) {
       // Создаём или обновляем производственную очередь независимо от шаблона.
       // stageTemplateId сохраняется в заказе выше, но автогенерация строится по полям формы.
       final templateStages = _selectedTemplateStageMaps();
@@ -3499,7 +3503,17 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           ),
         ),
       );
-    } else if (!createdOrUpdatedOrder.assignmentCreated && !hasStageQueueSelected) {
+    } else if (!createdOrUpdatedOrder.assignmentCreated &&
+        nextQueueBuildStatus == QueueBuildStatus.outdated) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Очередь изменилась, нажмите Собрать очередь',
+          ),
+        ),
+      );
+    } else if (!createdOrUpdatedOrder.assignmentCreated &&
+        !hasBuiltStageQueue) {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
@@ -5232,6 +5246,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                                       _lengthExceeded = false;
                                     }
                                   });
+                                  _scheduleStagePreviewUpdate();
                                 },
                               ),
                             ),
@@ -5527,9 +5542,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               _stockExtraQtyTouched = false;
               _product.leftover = null;
             });
-            if (shouldUpdateStagePreview) {
-              _scheduleStagePreviewUpdate(immediate: true);
-            }
+            _scheduleStagePreviewUpdate(
+              immediate: shouldUpdateStagePreview,
+            );
             _stockExtraSearchDebounce?.cancel();
             _stockExtraSearchController.clear();
             _updateStockExtraQtyController();
@@ -5553,6 +5568,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       onChanged: (val) {
         final qty = int.tryParse(val) ?? 0;
         _product.quantity = qty;
+        _scheduleStagePreviewUpdate();
       },
       validator: (value) {
         if (value == null || value.trim().isEmpty) {
@@ -6353,6 +6369,20 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         ),
       ),
     );
+    if (_queueBuildStatus == QueueBuildStatus.outdated) {
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Text(
+            'Очередь изменилась, нажмите Собрать очередь',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.error,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ),
+      );
+    }
 
     if (includeMakeready) {
       children.add(_buildMakereadyFields());

--- a/lib/modules/orders/order_launch_rules.dart
+++ b/lib/modules/orders/order_launch_rules.dart
@@ -3,13 +3,14 @@ import 'order_model.dart';
 
 /// Returns whether the order can be launched from the orders list UI.
 ///
-/// The UI only gates launching by assignment/status and available material.
-/// Presence of a persisted stage queue is validated by OrdersProvider.launchOrder
-/// so orders without a legacy [OrderModel.stageTemplateId] can still be
-/// launched when their stages are saved in production plan tables.
+/// The UI gates launching by assignment/status, queue build state, and
+/// available material. OrdersProvider.launchOrder repeats the queue check
+/// against persisted data before creating tasks.
 bool canLaunchOrder(OrderModel order, Iterable<TmcModel> allTmc) {
   if (order.assignmentCreated ||
-      order.statusEnum != OrderStatus.ready_to_start) {
+      order.statusEnum != OrderStatus.ready_to_start ||
+      QueueBuildStatus.normalize(order.queueBuildStatus) !=
+          QueueBuildStatus.built) {
     return false;
   }
 

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -146,6 +146,22 @@ class OrdersProvider with ChangeNotifier {
       }).toList(growable: false);
 
       for (final order in pending) {
+        final queueBuilt = QueueBuildStatus.normalize(order.queueBuildStatus) ==
+            QueueBuildStatus.built;
+        if (!queueBuilt) {
+          if (order.statusEnum == OrderStatus.draft &&
+              !order.hasMaterialShortage &&
+              order.materialShortageMessage.isEmpty) {
+            continue;
+          }
+          await _supabase.from('orders').update({
+            'status': OrderStatus.draft.name,
+            'has_material_shortage': false,
+            'material_shortage_message': '',
+          }).eq('id', order.id);
+          continue;
+        }
+
         final hasEnough = await _hasEnoughMaterialForLaunch(order);
         final nextStatus = hasEnough
             ? OrderStatus.ready_to_start
@@ -695,16 +711,41 @@ class OrdersProvider with ChangeNotifier {
     if (order.assignmentCreated) {
       return null;
     }
-    if (order.statusEnum != OrderStatus.ready_to_start) {
+    OrderModel launchOrder = order;
+    try {
+      final persisted = await _supabase
+          .from('orders')
+          .select()
+          .eq('id', order.id)
+          .maybeSingle();
+      if (persisted is Map) {
+        launchOrder = OrderModel.fromMap(
+          Map<String, dynamic>.from(persisted),
+        );
+      }
+    } catch (_) {
+      // If the row cannot be reloaded, keep checking the provided model below.
+    }
+    if (QueueBuildStatus.normalize(launchOrder.queueBuildStatus) !=
+        QueueBuildStatus.built) {
+      return QueueBuildStatus.normalize(launchOrder.queueBuildStatus) ==
+              QueueBuildStatus.outdated
+          ? 'Заказ нельзя запустить: очередь изменилась, нажмите «Собрать очередь» и сохраните заказ.'
+          : 'Заказ нельзя запустить: сначала соберите очередь этапов и сохраните заказ.';
+    }
+    if (launchOrder.assignmentCreated) {
+      return null;
+    }
+    if (launchOrder.statusEnum != OrderStatus.ready_to_start) {
       return 'Заказ нельзя запустить: статус должен быть ready_to_start.';
     }
-    if (!await _hasEnoughMaterialForLaunch(order)) {
-      final message = await _materialShortageMessage(order);
+    if (!await _hasEnoughMaterialForLaunch(launchOrder)) {
+      final message = await _materialShortageMessage(launchOrder);
       await _supabase.from('orders').update({
         'status': OrderStatus.waiting_materials.name,
         'has_material_shortage': true,
         'material_shortage_message': message,
-      }).eq('id', order.id);
+      }).eq('id', launchOrder.id);
       await refresh();
       return message.isEmpty
           ? 'Недостаточно материала для запуска заказа.'
@@ -757,7 +798,7 @@ class OrdersProvider with ChangeNotifier {
         final plan = await _supabase
             .from('prod_plans')
             .select('id')
-            .eq('order_id', order.id)
+            .eq('order_id', launchOrder.id)
             .maybeSingle();
         final String? planId = plan?['id']?.toString();
         if (planId != null && planId.isNotEmpty) {
@@ -779,7 +820,7 @@ class OrdersProvider with ChangeNotifier {
           final legacyPlan = await _supabase
               .from('production_plans')
               .select('stages')
-              .eq('order_id', order.id)
+              .eq('order_id', launchOrder.id)
               .maybeSingle();
           final dynamic stages = legacyPlan?['stages'];
           if (stages is List) {
@@ -812,7 +853,7 @@ class OrdersProvider with ChangeNotifier {
         return 'Не удалось запустить заказ: не найдена очередь этапов.';
       }
 
-      await _supabase.from('tasks').delete().eq('order_id', order.id);
+      await _supabase.from('tasks').delete().eq('order_id', launchOrder.id);
 
       final Set<String> createdTaskKeys = <String>{};
       for (final row in stageRows) {
@@ -825,9 +866,10 @@ class OrdersProvider with ChangeNotifier {
             ?.toString()
             .trim();
         final groupIds = List<String>.from(stageIds)..sort();
-        final stageGroupKey = (persistedGroupKey != null && persistedGroupKey.isNotEmpty)
-            ? persistedGroupKey
-            : groupIds.join('|');
+        final stageGroupKey =
+            (persistedGroupKey != null && persistedGroupKey.isNotEmpty)
+                ? persistedGroupKey
+                : groupIds.join('|');
         final String stageStatus = (row['status'] ?? '').toString().toLowerCase();
         final String taskStatus =
             (stageStatus == 'done' || stageStatus == 'completed')
@@ -839,7 +881,7 @@ class OrdersProvider with ChangeNotifier {
           // Для этапов с несколькими рабочими местами создаём по одной задаче
           // на каждое рабочее место, но связываем их единым stage_group_key.
           await _supabase.from('tasks').insert({
-            'order_id': order.id,
+            'order_id': launchOrder.id,
             'stage_id': stageId,
             'stage_group_key': stageGroupKey,
             'status': taskStatus,
@@ -854,19 +896,21 @@ class OrdersProvider with ChangeNotifier {
 
       // Бизнес-правило резерва: до перевода в in_production
       // пытаемся атомарно зафиксировать резерв бумаги.
-      final reserveError = await _syncPaperReservationsForOrder(order.copyWith(
-        status: OrderStatus.in_production.name,
-        assignmentCreated: true,
-      ));
+      final reserveError = await _syncPaperReservationsForOrder(
+        launchOrder.copyWith(
+          status: OrderStatus.in_production.name,
+          assignmentCreated: true,
+        ),
+      );
       if (reserveError != null) {
         // Если резерв не зафиксирован, не оставляем созданные задачи.
-        await _supabase.from('tasks').delete().eq('order_id', order.id);
+        await _supabase.from('tasks').delete().eq('order_id', launchOrder.id);
         return reserveError;
       }
 
       final String nextAssignmentId =
-          (order.assignmentId ?? '').trim().isNotEmpty
-              ? order.assignmentId!.trim()
+          (launchOrder.assignmentId ?? '').trim().isNotEmpty
+              ? launchOrder.assignmentId!.trim()
               : generateAssignmentId();
 
       await _supabase.from('orders').update({
@@ -875,9 +919,9 @@ class OrdersProvider with ChangeNotifier {
         'material_shortage_message': '',
         'assignment_created': true,
         'assignment_id': nextAssignmentId,
-      }).eq('id', order.id);
+      }).eq('id', launchOrder.id);
 
-      final index = _orders.indexWhere((o) => o.id == order.id);
+      final index = _orders.indexWhere((o) => o.id == launchOrder.id);
       if (index != -1) {
         _orders[index] = _orders[index].copyWith(
           status: OrderStatus.in_production.name,
@@ -890,7 +934,10 @@ class OrdersProvider with ChangeNotifier {
       }
 
       await _logOrderEvent(
-          order.id, 'Запуск', 'Заказ запущен в производство. Бумага переведена в резерв');
+        launchOrder.id,
+        'Запуск',
+        'Заказ запущен в производство. Бумага переведена в резерв',
+      );
       return null;
     } catch (e, st) {
       debugPrint('❌ launchOrder error: $e\n$st');
@@ -1414,23 +1461,29 @@ class OrdersProvider with ChangeNotifier {
   }
 
   Future<void> _applyImmediateMaterialAvailabilityState(OrderModel order) async {
-    final hasEnough = await _hasEnoughMaterialForLaunch(order);
-    final shortageMessage = hasEnough ? '' : await _materialShortageMessage(order);
-    final nextStatus = hasEnough
-        ? (order.statusEnum == OrderStatus.waiting_materials
-            ? OrderStatus.ready_to_start
-            : order.statusEnum)
-        : OrderStatus.waiting_materials;
+    final queueBuilt = QueueBuildStatus.normalize(order.queueBuildStatus) ==
+        QueueBuildStatus.built;
+    final hasEnough = queueBuilt && await _hasEnoughMaterialForLaunch(order);
+    final shortageMessage =
+        queueBuilt && !hasEnough ? await _materialShortageMessage(order) : '';
+    final nextStatus = !queueBuilt
+        ? (order.assignmentCreated ? order.statusEnum : OrderStatus.draft)
+        : (hasEnough
+            ? (order.statusEnum == OrderStatus.waiting_materials
+                ? OrderStatus.ready_to_start
+                : order.statusEnum)
+            : OrderStatus.waiting_materials);
+    final hasMaterialShortage = queueBuilt && !hasEnough;
 
     if (order.statusEnum == nextStatus &&
-        order.hasMaterialShortage == !hasEnough &&
+        order.hasMaterialShortage == hasMaterialShortage &&
         order.materialShortageMessage == shortageMessage) {
       return;
     }
 
     final updatePayload = <String, dynamic>{
       'status': nextStatus.name,
-      'has_material_shortage': !hasEnough,
+      'has_material_shortage': hasMaterialShortage,
       'material_shortage_message': shortageMessage,
     };
 
@@ -1440,7 +1493,7 @@ class OrdersProvider with ChangeNotifier {
     if (index != -1) {
       _orders[index] = _orders[index].copyWith(
         status: nextStatus.name,
-        hasMaterialShortage: !hasEnough,
+        hasMaterialShortage: hasMaterialShortage,
         materialShortageMessage: shortageMessage,
       );
       notifyListeners();


### PR DESCRIPTION
### Motivation
- Ensure orders cannot become `ready_to_start` or be launched unless a persisted stage queue was explicitly `built` and saved, preventing implicit/autobuilt queues from allowing premature launches. 
- Keep local UI and persisted state in sync: when important form inputs change a previously-built queue must become `outdated` so users must rebuild and confirm the queue. 
- Provide clear user feedback when the queue is stale and prevent server-side task creation for orders with missing or outdated queues. 

### Description
- In `lib/modules/orders/edit_order_screen.dart` replaced the always-true `hasStageQueueSelected` behavior with `hasBuiltStageQueue` derived from `nextQueueBuildStatus`, made new orders default to `draft` until the queue is `built`, and prevented saving/creating production plans unless `queueBuildStatus == 'built'`.
- Added local invalidation of a built queue (`_markQueueOutdatedIfBuilt`) when key form inputs change (template selection/edits, paper/material selections, dimension/parameter changes) and ensured preview updates are scheduled via `_scheduleStagePreviewUpdate()` so the UI reflects `outdated` state.
- Show an in-form warning `Очередь изменилась, нажмите Собрать очередь` in the production section and show a snackbar with the same text when saving if the queue is `outdated`.
- In `lib/modules/orders/order_launch_rules.dart` extended `canLaunchOrder()` to require `QueueBuildStatus.normalize(order.queueBuildStatus) == QueueBuildStatus.built` in addition to existing checks.
- In `lib/modules/orders/orders_provider.dart` added repository-side protections: `recheckMaterialAvailability()` no longer promotes orders whose `queueBuildStatus` is not `built` (it can set them back to `draft`), and `launchOrder()` reloads the persisted order and returns a clear error message if the persisted `queueBuildStatus` is `not_built` or `outdated` instead of creating tasks; DB operations in `launchOrder()` use the reloaded model where appropriate.

### Testing
- Ran `git diff --check` to verify there are no whitespace/merge problems and it passed.
- Attempted `dart format --set-exit-if-changed` on the modified files but `dart` was not available in the environment so formatting could not be executed. 
- Attempted `flutter analyze` but `flutter` is not available in the environment so static analysis could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc40fe77a0832fa4aea9c0ec64fc4d)