### PR TITLE
Rebuild order stage preview after switchable stage toggle

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1531,6 +1531,13 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     final switchableSelectionSource = existingStages.isNotEmpty
         ? existingStages
         : _stagePreviewStages;
+    final selectedSwitchableStageIdsByStageKey = <String, String>{
+      ...collectSwitchableStageSelectionsByStageKey(switchableSelectionSource),
+      if ((_selectedVStage ?? '').trim().isNotEmpty)
+        kVMainSwitchStageKey: _selectedVStage!.trim(),
+      if ((_selectedPStage ?? '').trim().isNotEmpty)
+        kPMainSwitchStageKey: _selectedPStage!.trim(),
+    };
     return buildOrderStageQueue(
       productTypeId: draft.productTypeId,
       hasCutting: draft.hasTrimming,
@@ -1542,7 +1549,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       switchableStageKey: draft.switchableStageKey,
       selectedSwitchableStageId: draft.selectedSwitchableStageId,
       selectedSwitchableStageIdsByStageKey:
-          collectSwitchableStageSelectionsByStageKey(switchableSelectionSource),
+          selectedSwitchableStageIdsByStageKey,
       existingStages: existingStages,
       templateStages: templateStages,
     );
@@ -2899,7 +2906,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     final List<MaterialModel> selectedPapers = _collectSelectedPapers();
     final currentQueueSignature = _currentQueueSignature();
     var nextQueueBuildStatus = _queueBuildStatus;
-    if (isCreating && nextQueueBuildStatus != QueueBuildStatus.built) {
+    if (isCreating &&
+        nextQueueBuildStatus != QueueBuildStatus.built &&
+        nextQueueBuildStatus != QueueBuildStatus.outdated) {
       nextQueueBuildStatus = QueueBuildStatus.notBuilt;
     } else if (!isCreating &&
         widget.order?.queueBuildStatus == QueueBuildStatus.built &&
@@ -6607,12 +6616,33 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         onTap: () {
           final toggledStage = toggleProductStageObject(stage);
           if (toggledStage == null) return;
+          final toggledStageKey = toggledStage['stageKey']?.toString();
+          final selectedWorkplaceId =
+              toggledStage['selectedWorkplaceId']?.toString();
+          if (selectedWorkplaceId == null || selectedWorkplaceId.isEmpty) {
+            return;
+          }
           setState(() {
-            _stagePreviewStages[i] = toggledStage;
-            _syncSwitchableStageSelectionFields(_stagePreviewStages);
+            if (toggledStageKey == kVMainSwitchStageKey) {
+              _selectedVStage = selectedWorkplaceId;
+            } else if (toggledStageKey == kPMainSwitchStageKey) {
+              _selectedPStage = selectedWorkplaceId;
+            } else {
+              return;
+            }
+
+            final currentStages = _stagePreviewStages
+                .map((stage) => Map<String, dynamic>.from(stage))
+                .toList(growable: false);
+            final queue = _buildStageQueueFromCurrentDraft(
+              existingStages: currentStages,
+              templateStages: _selectedTemplateStageMaps(),
+            );
+            _stagePreviewStages = queue;
+            _syncSwitchableStageSelectionFields(queue);
             _queueSignature = _currentQueueSignature();
-            _queueBuildStatus = QueueBuildStatus.built;
-            _isStageQueueBuilt = true;
+            _queueBuildStatus = QueueBuildStatus.outdated;
+            _isStageQueueBuilt = false;
           });
         },
         child: Container(


### PR DESCRIPTION
### Motivation
- При переключении переключаемого этапа (В-/П-опции) нужно обновлять выбранный вариант в состоянии формы и немедленно пересобирать очередь, чтобы зависимые этапы (например, для «Труба») появлялись в превью до сохранения заказа.
- Текущее поведение точечно заменяло отдельный элемент превью и помечало очередь как собранную, что скрывало необходимость дорасчёта и не отражало факт устаревшей очереди.

### Description
- В `lib/modules/orders/edit_order_screen.dart` в `_buildStageQueueFromCurrentDraft()` добавлено объединение текущих `_selectedVStage`/`_selectedPStage` в `selectedSwitchableStageIdsByStageKey` и передача этого словаря в общий builder `buildOrderStageQueue`.
- В обработчике переключения в `_buildStagePreviewSection()` заменено прямое присваивание точечного toggled-stage на обновление `_selectedVStage`/`_selectedPStage`, последующую перестройку очереди через `_buildStageQueueFromCurrentDraft(...)` и замену `_stagePreviewStages` на результат builder-а, чтобы UI сразу показал пересчитанную очередь.
- После переключения очередь теперь помечается как `outdated` и флаг `_isStageQueueBuilt` сбрасывается, вместо прежнего присваивания `built`.
- При создании нового заказа предотвращено понижение статуса `outdated` в `not_built`, чтобы ручное переключение сохраняло состояние «устарело» до явной сборки очереди.

### Testing
- Выполнены базовые проверочные проверки изменений в изменённых файлах (diff/check) и статический просмотр модификаций; эти проверки прошли успешно.
- Попытка запустить юнит‑тесты `flutter test test/stage_queue_builder_test.dart test/edit_order_screen_cardboard_test.dart` не выполнена в этой среде, так как Flutter SDK отсутствует (`flutter: command not found`).
- Логика изменения использует уже покрытые тестами функции билдера очереди (`buildOrderStageQueue`) и существующие тесты в репозитории ожидают корректное поведение для сценариев с `kTubeStageId`/`Сборка дно+картон` и `Склейка дна` (см. `test/stage_queue_builder_test.dart` и `test/edit_order_screen_cardboard_test.dart`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc42dd2660832f8b133cd8e72823f4)