### PR TITLE
Introduce OrderQueueSyncService to safely diff and apply stage queue changes

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -17,6 +17,7 @@ import 'dart:typed_data';
 import 'orders_provider.dart';
 import 'order_stage_filter.dart';
 import 'stage_queue_builder.dart';
+import 'order_queue_sync_service.dart';
 import 'orders_repository.dart';
 import 'order_model.dart';
 import 'product_model.dart';
@@ -2950,6 +2951,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             _stageOrderManuallyChanged);
     final bool queueChangeBlockedByStartedStages =
         stageQueueChangedForLaunchedOrder && _launchedWithStartedStages;
+    if (queueChangeBlockedByStartedStages) {
+      throw const OrderQueueSyncBlockedException();
+    }
     final bool canResetForRelaunchAfterQueueEdit =
         stageQueueChangedForLaunchedOrder && _launchedNoStartedStages;
     // Перестраивать normalized/JSON-план можно только для нового заказа,
@@ -3419,28 +3423,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
       // ---- Sync normalized tables prod_plans/prod_plan_stages (if they exist) ----
       try {
-        // Ensure prod_plans row exists
-        final planRow = await _sb
-            .from('prod_plans')
-            .select('id')
-            .eq('order_id', createdOrUpdatedOrder.id)
-            .maybeSingle();
-        String planId;
-        if (planRow == null) {
-          final inserted = await _sb
-              .from('prod_plans')
-              .insert({
-                'order_id': createdOrUpdatedOrder.id,
-                'status': 'planned',
-              })
-              .select('id')
-              .single();
-          planId = inserted['id'] as String;
-        } else {
-          planId = planRow['id'] as String;
-        }
-        // Rebuild plan stages
-        await _sb.from('prod_plan_stages').delete().eq('plan_id', planId);
+        // Синхронизируем очередь диффом, не трогая завершённые/запущенные этапы
+        // и связанные с ними задачи.
+        final nextQueue = <OrderQueueSyncEntry>[];
         int step = 1;
         String? previousGroupKey;
         for (final sm in stageMaps) {
@@ -3458,23 +3443,22 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             final resolvedStageId = workplaceLookup[rawStageId.toLowerCase()] ??
                 legacyStageLookup[rawStageId.toLowerCase()] ??
                 rawStageId;
-            await _sb.from('prod_plan_stages').insert({
-              'plan_id': planId,
-              'stage_id': resolvedStageId,
-              'stage_group_key': groupKey,
-              'step': step,
-              'status': 'waiting',
-            });
+            nextQueue.add(OrderQueueSyncEntry(
+              stageId: resolvedStageId,
+              stageGroupKey: groupKey.isEmpty ? resolvedStageId : groupKey,
+              step: step,
+            ));
           }
           step += 1;
         }
-        // Mark bobbin as done here as well
-        if (__shouldCompleteBobbin && __bobbinId != null) {
-          await _sb.from('prod_plan_stages').update({
-            'status': 'done',
-            'finished_at': DateTime.now().toIso8601String(),
-          }).match({'plan_id': planId, 'stage_id': __bobbinId});
-        }
+        await OrderQueueSyncService(_sb).sync(
+          orderId: createdOrUpdatedOrder.id,
+          nextQueue: nextQueue,
+          completeBobbin: __shouldCompleteBobbin,
+          bobbinStageId: __bobbinId,
+        );
+      } on OrderQueueSyncBlockedException {
+        rethrow;
       } catch (_) {
         // ignore if tables don't exist
       }

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -1,0 +1,484 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+const String kStartedStageQueueChangeMessage =
+    'Нельзя изменить этап, который уже находится в работе. Завершите или отмените текущий этап перед изменением очереди.';
+
+enum OrderQueueSyncOperationType {
+  keep,
+  insert,
+  updatePending,
+  cancelOrDeletePending,
+  block,
+}
+
+class OrderQueueSyncOperation {
+  const OrderQueueSyncOperation({
+    required this.type,
+    this.current,
+    this.next,
+    this.reason,
+  });
+
+  final OrderQueueSyncEntry? current;
+  final OrderQueueSyncEntry? next;
+  final OrderQueueSyncOperationType type;
+  final String? reason;
+}
+
+class OrderQueueSyncBlockedException implements Exception {
+  const OrderQueueSyncBlockedException([
+    this.message = kStartedStageQueueChangeMessage,
+  ]);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class OrderQueueSyncEntry {
+  const OrderQueueSyncEntry({
+    this.id,
+    required this.stageId,
+    required this.stageGroupKey,
+    required this.step,
+    this.status = 'waiting',
+    this.row = const <String, dynamic>{},
+  });
+
+  final String? id;
+  final String stageId;
+  final String stageGroupKey;
+  final int step;
+  final String status;
+  final Map<String, dynamic> row;
+
+  String get identityKey => '$stageGroupKey::$stageId';
+
+  bool sameQueueSlot(OrderQueueSyncEntry other) =>
+      stageId == other.stageId &&
+      stageGroupKey == other.stageGroupKey &&
+      step == other.step;
+
+  OrderQueueSyncEntry copyWith({
+    String? id,
+    String? stageId,
+    String? stageGroupKey,
+    int? step,
+    String? status,
+    Map<String, dynamic>? row,
+  }) {
+    return OrderQueueSyncEntry(
+      id: id ?? this.id,
+      stageId: stageId ?? this.stageId,
+      stageGroupKey: stageGroupKey ?? this.stageGroupKey,
+      step: step ?? this.step,
+      status: status ?? this.status,
+      row: row ?? this.row,
+    );
+  }
+}
+
+class OrderQueueSyncService {
+  OrderQueueSyncService(this._sb);
+
+  final SupabaseClient _sb;
+
+  static const Set<String> protectedStatuses = <String>{
+    'completed',
+    'complete',
+    'done',
+    'in_progress',
+    'inprogress',
+    'started',
+    'paused',
+    'problem',
+  };
+
+  static const Set<String> pendingStatuses = <String>{
+    '',
+    'pending',
+    'waiting',
+    'planned',
+    'todo',
+    'new',
+  };
+
+  static bool isProtectedStatus(dynamic status) {
+    final normalized = _normalizeStatus(status);
+    return protectedStatuses.contains(normalized);
+  }
+
+  static bool isPendingStatus(dynamic status) {
+    final normalized = _normalizeStatus(status);
+    return pendingStatuses.contains(normalized);
+  }
+
+  static String _normalizeStatus(dynamic status) =>
+      (status?.toString() ?? '').trim().toLowerCase().replaceAll('-', '_');
+
+  static List<OrderQueueSyncOperation> diff({
+    required List<OrderQueueSyncEntry> currentStages,
+    required List<OrderQueueSyncEntry> currentTasks,
+    required List<OrderQueueSyncEntry> nextQueue,
+  }) {
+    final operations = <OrderQueueSyncOperation>[];
+    final nextByKey = <String, OrderQueueSyncEntry>{
+      for (final entry in nextQueue) entry.identityKey: entry,
+    };
+    final currentByKey = <String, OrderQueueSyncEntry>{
+      for (final entry in currentStages) entry.identityKey: entry,
+    };
+
+    for (final current in currentStages) {
+      final next = nextByKey[current.identityKey];
+      if (next == null) {
+        if (isProtectedStatus(current.status)) {
+          operations.add(OrderQueueSyncOperation(
+            type: OrderQueueSyncOperationType.block,
+            current: current,
+            reason: kStartedStageQueueChangeMessage,
+          ));
+        } else {
+          operations.add(OrderQueueSyncOperation(
+            type: OrderQueueSyncOperationType.cancelOrDeletePending,
+            current: current,
+          ));
+        }
+        continue;
+      }
+
+      if (current.sameQueueSlot(next) || isProtectedStatus(current.status)) {
+        operations.add(OrderQueueSyncOperation(
+          type: OrderQueueSyncOperationType.keep,
+          current: current,
+          next: next,
+        ));
+      } else {
+        operations.add(OrderQueueSyncOperation(
+          type: OrderQueueSyncOperationType.updatePending,
+          current: current,
+          next: next,
+        ));
+      }
+    }
+
+    for (final task in currentTasks) {
+      if (nextByKey.containsKey(task.identityKey)) continue;
+      if (isProtectedStatus(task.status)) {
+        operations.add(OrderQueueSyncOperation(
+          type: OrderQueueSyncOperationType.block,
+          current: task,
+          reason: kStartedStageQueueChangeMessage,
+        ));
+      } else {
+        operations.add(OrderQueueSyncOperation(
+          type: OrderQueueSyncOperationType.cancelOrDeletePending,
+          current: task,
+        ));
+      }
+    }
+
+    for (final next in nextQueue) {
+      if (currentByKey.containsKey(next.identityKey)) continue;
+      operations.add(OrderQueueSyncOperation(
+        type: OrderQueueSyncOperationType.insert,
+        next: next,
+      ));
+    }
+
+    return operations;
+  }
+
+  Future<List<OrderQueueSyncOperation>> sync({
+    required String orderId,
+    required List<OrderQueueSyncEntry> nextQueue,
+    bool completeBobbin = false,
+    String? bobbinStageId,
+  }) async {
+    final planId = await _ensurePlan(orderId);
+    final currentStages = await _loadPlanStages(planId);
+    final currentTasks = await _loadTasks(orderId);
+    final operations = diff(
+      currentStages: currentStages,
+      currentTasks: currentTasks,
+      nextQueue: nextQueue,
+    );
+
+    final blocked = operations.where(
+      (op) => op.type == OrderQueueSyncOperationType.block,
+    );
+    if (blocked.isNotEmpty) {
+      throw OrderQueueSyncBlockedException(
+        blocked.first.reason ?? kStartedStageQueueChangeMessage,
+      );
+    }
+
+    for (final op in operations) {
+      switch (op.type) {
+        case OrderQueueSyncOperationType.cancelOrDeletePending:
+          final current = op.current;
+          if (current != null) {
+            await _deletePendingPlanStage(current);
+            await _deletePendingTasks(orderId, current);
+          }
+          break;
+        case OrderQueueSyncOperationType.updatePending:
+          final current = op.current;
+          final next = op.next;
+          if (current != null && next != null) {
+            await _updatePendingPlanStage(current, next);
+            await _syncPendingTaskGroup(orderId, current, next);
+          }
+          break;
+        case OrderQueueSyncOperationType.insert:
+          final next = op.next;
+          if (next != null) {
+            await _insertPlanStage(planId, next);
+          }
+          break;
+        case OrderQueueSyncOperationType.keep:
+        case OrderQueueSyncOperationType.block:
+          break;
+      }
+    }
+
+    await _createMissingTasks(orderId, nextQueue);
+
+    if (completeBobbin && bobbinStageId != null && bobbinStageId.trim().isNotEmpty) {
+      await _markBobbinDone(planId, orderId, bobbinStageId.trim());
+    }
+
+    return operations;
+  }
+
+  Future<String> _ensurePlan(String orderId) async {
+    final planRow = await _sb
+        .from('prod_plans')
+        .select('id')
+        .eq('order_id', orderId)
+        .maybeSingle();
+    if (planRow != null && planRow['id'] != null) {
+      return planRow['id'].toString();
+    }
+    final inserted = await _sb
+        .from('prod_plans')
+        .insert({'order_id': orderId, 'status': 'planned'})
+        .select('id')
+        .single();
+    return inserted['id'].toString();
+  }
+
+  Future<List<OrderQueueSyncEntry>> _loadPlanStages(String planId) async {
+    final rows = await _sb
+        .from('prod_plan_stages')
+        .select('*')
+        .eq('plan_id', planId)
+        .order('step', ascending: true);
+    if (rows is! List) return const <OrderQueueSyncEntry>[];
+    return rows
+        .whereType<Map>()
+        .map((row) => _entryFromPlanRow(Map<String, dynamic>.from(row)))
+        .whereType<OrderQueueSyncEntry>()
+        .toList(growable: false);
+  }
+
+  Future<List<OrderQueueSyncEntry>> _loadTasks(String orderId) async {
+    final rows = await _sb
+        .from('tasks')
+        .select('*')
+        .eq('order_id', orderId);
+    if (rows is! List) return const <OrderQueueSyncEntry>[];
+    return rows
+        .whereType<Map>()
+        .map((row) => _entryFromTaskRow(Map<String, dynamic>.from(row)))
+        .whereType<OrderQueueSyncEntry>()
+        .toList(growable: false);
+  }
+
+  OrderQueueSyncEntry? _entryFromPlanRow(Map<String, dynamic> row) {
+    final stageId = (row['stage_id'] ?? row['stageId'])?.toString().trim();
+    if (stageId == null || stageId.isEmpty) return null;
+    final groupKey = (row['stage_group_key'] ?? row['stageGroupKey'])
+            ?.toString()
+            .trim() ??
+        stageId;
+    return OrderQueueSyncEntry(
+      id: row['id']?.toString(),
+      stageId: stageId,
+      stageGroupKey: groupKey.isEmpty ? stageId : groupKey,
+      step: _readInt(row['step'] ?? row['step_no'] ?? row['seq']),
+      status: (row['status'] ?? 'waiting').toString(),
+      row: row,
+    );
+  }
+
+  OrderQueueSyncEntry? _entryFromTaskRow(Map<String, dynamic> row) {
+    final stageId = (row['stage_id'] ?? row['stageId'])?.toString().trim();
+    if (stageId == null || stageId.isEmpty) return null;
+    final groupKey = (row['stage_group_key'] ?? row['stageGroupKey'])
+            ?.toString()
+            .trim() ??
+        stageId;
+    return OrderQueueSyncEntry(
+      id: row['id']?.toString(),
+      stageId: stageId,
+      stageGroupKey: groupKey.isEmpty ? stageId : groupKey,
+      step: _readInt(row['step'] ?? row['step_no'] ?? row['seq']),
+      status: (row['status'] ?? 'waiting').toString(),
+      row: row,
+    );
+  }
+
+  static int _readInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value?.toString() ?? '') ?? 0;
+  }
+
+  Future<void> _deletePendingPlanStage(OrderQueueSyncEntry current) async {
+    if (current.id != null && current.id!.isNotEmpty) {
+      await _sb.from('prod_plan_stages').delete().eq('id', current.id!);
+      return;
+    }
+    await _sb
+        .from('prod_plan_stages')
+        .delete()
+        .eq('stage_id', current.stageId)
+        .eq('stage_group_key', current.stageGroupKey)
+        .eq('step', current.step);
+  }
+
+  Future<void> _updatePendingPlanStage(
+    OrderQueueSyncEntry current,
+    OrderQueueSyncEntry next,
+  ) async {
+    final updates = {
+      'stage_id': next.stageId,
+      'stage_group_key': next.stageGroupKey,
+      'step': next.step,
+      'status': 'waiting',
+    };
+    await _updatePlanStageWithOptionalStepNo(current, updates, next.step);
+  }
+
+  Future<void> _insertPlanStage(
+    String planId,
+    OrderQueueSyncEntry next,
+  ) async {
+    final row = {
+      'plan_id': planId,
+      'stage_id': next.stageId,
+      'stage_group_key': next.stageGroupKey,
+      'step': next.step,
+      'status': 'waiting',
+    };
+    try {
+      await _sb
+          .from('prod_plan_stages')
+          .insert({...row, 'step_no': next.step});
+    } catch (_) {
+      await _sb.from('prod_plan_stages').insert(row);
+    }
+  }
+
+  Future<void> _updatePlanStageWithOptionalStepNo(
+    OrderQueueSyncEntry current,
+    Map<String, dynamic> updates,
+    int stepNo,
+  ) async {
+    Future<void> run(Map<String, dynamic> payload) async {
+      if (current.id != null && current.id!.isNotEmpty) {
+        await _sb
+            .from('prod_plan_stages')
+            .update(payload)
+            .eq('id', current.id!);
+        return;
+      }
+      await _sb
+          .from('prod_plan_stages')
+          .update(payload)
+          .eq('stage_id', current.stageId)
+          .eq('stage_group_key', current.stageGroupKey)
+          .eq('step', current.step);
+    }
+
+    try {
+      await run({...updates, 'step_no': stepNo});
+    } catch (_) {
+      await run(updates);
+    }
+  }
+
+  Future<void> _deletePendingTasks(
+    String orderId,
+    OrderQueueSyncEntry current,
+  ) async {
+    await _sb
+        .from('tasks')
+        .delete()
+        .eq('order_id', orderId)
+        .eq('stage_id', current.stageId)
+        .eq('stage_group_key', current.stageGroupKey)
+        .inFilter(
+          'status',
+          pendingStatuses.where((s) => s.isNotEmpty).toList(),
+        );
+  }
+
+  Future<void> _syncPendingTaskGroup(
+    String orderId,
+    OrderQueueSyncEntry current,
+    OrderQueueSyncEntry next,
+  ) async {
+    await _sb
+        .from('tasks')
+        .update({
+          'stage_id': next.stageId,
+          'stage_group_key': next.stageGroupKey,
+          'status': 'waiting',
+        })
+        .eq('order_id', orderId)
+        .eq('stage_id', current.stageId)
+        .eq('stage_group_key', current.stageGroupKey)
+        .inFilter(
+          'status',
+          pendingStatuses.where((s) => s.isNotEmpty).toList(),
+        );
+  }
+
+  Future<void> _createMissingTasks(
+    String orderId,
+    List<OrderQueueSyncEntry> nextQueue,
+  ) async {
+    final existing = await _loadTasks(orderId);
+    final existingKeys = existing.map((entry) => entry.identityKey).toSet();
+    for (final next in nextQueue) {
+      if (!existingKeys.add(next.identityKey)) continue;
+      await _sb.from('tasks').insert({
+        'order_id': orderId,
+        'stage_id': next.stageId,
+        'stage_group_key': next.stageGroupKey,
+        'status': 'waiting',
+        'assignees': [],
+        'comments': [],
+      });
+    }
+  }
+
+  Future<void> _markBobbinDone(
+    String planId,
+    String orderId,
+    String bobbinStageId,
+  ) async {
+    final now = DateTime.now().toIso8601String();
+    await _sb.from('prod_plan_stages').update({
+      'status': 'done',
+      'finished_at': now,
+    }).match({'plan_id': planId, 'stage_id': bobbinStageId});
+    await _sb.from('tasks').update({
+      'status': 'done',
+      'completed_at': now,
+    }).match({'order_id': orderId, 'stage_id': bobbinStageId});
+  }
+}

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'material_model.dart';
 import 'order_model.dart';
+import 'order_queue_sync_service.dart';
 import 'product_model.dart';
 import '../../utils/auth_helper.dart';
 
@@ -853,9 +854,10 @@ class OrdersProvider with ChangeNotifier {
         return 'Не удалось запустить заказ: не найдена очередь этапов.';
       }
 
-      await _supabase.from('tasks').delete().eq('order_id', launchOrder.id);
-
+      final nextQueue = <OrderQueueSyncEntry>[];
+      final doneStageKeys = <String>{};
       final Set<String> createdTaskKeys = <String>{};
+      var fallbackStep = 1;
       for (final row in stageRows) {
         final stageIds = _readStageIds(row);
         if (stageIds.isEmpty) continue;
@@ -870,29 +872,42 @@ class OrdersProvider with ChangeNotifier {
             (persistedGroupKey != null && persistedGroupKey.isNotEmpty)
                 ? persistedGroupKey
                 : groupIds.join('|');
+        final step = int.tryParse(
+              (row['step'] ?? row['step_no'] ?? row['seq'] ?? fallbackStep)
+                  .toString(),
+            ) ??
+            fallbackStep;
         final String stageStatus = (row['status'] ?? '').toString().toLowerCase();
-        final String taskStatus =
-            (stageStatus == 'done' || stageStatus == 'completed')
-                ? 'done'
-                : 'waiting';
+        final bool isDoneStage = stageStatus == 'done' || stageStatus == 'completed';
         for (final stageId in stageIds) {
           final dedupeKey = '$stageGroupKey::$stageId';
           if (!createdTaskKeys.add(dedupeKey)) continue;
-          // Для этапов с несколькими рабочими местами создаём по одной задаче
-          // на каждое рабочее место, но связываем их единым stage_group_key.
-          await _supabase.from('tasks').insert({
-            'order_id': launchOrder.id,
-            'stage_id': stageId,
-            'stage_group_key': stageGroupKey,
-            'status': taskStatus,
-            'assignees': [],
-            'comments': [],
-            if (taskStatus == 'done')
-              'completed_at': DateTime.now().toIso8601String(),
-          });
+          nextQueue.add(OrderQueueSyncEntry(
+            stageId: stageId,
+            stageGroupKey: stageGroupKey.isEmpty ? stageId : stageGroupKey,
+            step: step,
+            status: isDoneStage ? 'done' : 'waiting',
+          ));
+          if (isDoneStage) doneStageKeys.add(dedupeKey);
         }
+        fallbackStep += 1;
       }
 
+      await OrderQueueSyncService(_supabase).sync(
+        orderId: launchOrder.id,
+        nextQueue: nextQueue,
+      );
+      for (final key in doneStageKeys) {
+        final parts = key.split('::');
+        if (parts.length != 2) continue;
+        await _supabase.from('tasks').update({
+          'status': 'done',
+          'completed_at': DateTime.now().toIso8601String(),
+        })
+            .eq('order_id', launchOrder.id)
+            .eq('stage_group_key', parts[0])
+            .eq('stage_id', parts[1]);
+      }
 
       // Бизнес-правило резерва: до перевода в in_production
       // пытаемся атомарно зафиксировать резерв бумаги.
@@ -903,8 +918,13 @@ class OrdersProvider with ChangeNotifier {
         ),
       );
       if (reserveError != null) {
-        // Если резерв не зафиксирован, не оставляем созданные задачи.
-        await _supabase.from('tasks').delete().eq('order_id', launchOrder.id);
+        // Если резерв не зафиксирован, убираем только будущие задачи, не трогая
+        // уже начатые/завершённые записи повторного запуска.
+        await _supabase
+            .from('tasks')
+            .delete()
+            .eq('order_id', launchOrder.id)
+            .inFilter('status', ['waiting', 'pending', 'planned']);
         return reserveError;
       }
 
@@ -1178,7 +1198,11 @@ class OrdersProvider with ChangeNotifier {
     try {
       // Бизнес-правило: после правок запущенного, но не начатого заказа
       // убираем его из производственных списков и возвращаем в ручной запуск.
-      await _supabase.from('tasks').delete().eq('order_id', orderId);
+      await _supabase
+          .from('tasks')
+          .delete()
+          .eq('order_id', orderId)
+          .inFilter('status', ['waiting', 'pending', 'planned']);
       await _supabase.from('orders').update({
         'assignment_created': false,
         'status': OrderStatus.ready_to_start.name,


### PR DESCRIPTION
### Motivation
- Avoid destructive full rebuilds of `prod_plan_stages` and unconditional deletion of `tasks` that could remove or replace already started or completed stages and their metadata. 
- Preserve protected stages/tasks (completed/in_progress/started/paused/problem) and prevent queue edits that would modify them. 
- Ensure initial launch creates only missing tasks from the saved queue and repeated rebuilds update only future (pending) tasks. 

### Description
- Added `lib/modules/orders/order_queue_sync_service.dart` which implements `OrderQueueSyncService`, `OrderQueueSyncEntry`, `OrderQueueSyncOperation` and `OrderQueueSyncBlockedException`, status classification helpers and a `diff` that emits operations `keep`, `insert`, `updatePending`, `cancelOrDeletePending`, and `block`. 
- Replaced the previous normalized-plan full delete/insert in `lib/modules/orders/edit_order_screen.dart` with a call to `OrderQueueSyncService.sync(...)` and added immediate throwing of `OrderQueueSyncBlockedException` when a launched order’s started stages would be changed. 
- Updated `lib/modules/orders/orders_provider.dart` launch/relaunch logic to build a `nextQueue` and call the sync service, to create missing future tasks instead of deleting all tasks, to mark already-done stages as done, and to limit rollbacks/reset deletions to only future/pending statuses (e.g. `['waiting','pending','planned']`). 
- Improved plan-stage updates to handle optional `step_no` where supported and to avoid touching protected stage/task rows, while still inserting or updating pending rows when appropriate. 

### Testing
- Ran `git diff --check HEAD~1 HEAD` and verified there are no index/check errors. 
- Attempted to run `dart format` and `dart analyze` on the modified files but the commands could not be executed because the `dart` executable is not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc43eb2e6c832f95fed10b2baa1014)