### PR TITLE
Добавить селекторы переключаемых этапов в просмотр очереди

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -47,6 +47,13 @@ class EditOrderScreen extends StatefulWidget {
   State<EditOrderScreen> createState() => _EditOrderScreenState();
 }
 
+class _SwitchableStageOption {
+  const _SwitchableStageOption(this.stageId, this.label);
+
+  final String stageId;
+  final String label;
+}
+
 class _PaintEntry {
   TmcModel? tmc;
   String? name;
@@ -1523,6 +1530,165 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       _queueBuildStatus = QueueBuildStatus.outdated;
     }
   }
+
+  bool _isSwitchablePreviewStage(Map<String, dynamic> stage) {
+    final value = stage['isSwitchable'];
+    if (value == true) return true;
+    if (value is String && value.toLowerCase().trim() == 'true') return true;
+    return _switchableStageKeyFromPreviewStage(stage) != null;
+  }
+
+  String? _switchableStageKeyFromPreviewStage(Map<String, dynamic> stage) {
+    final stageKey = (stage['stageKey'] ?? stage['stage_key'])?.toString();
+    final groupKey = stage['switchableGroupKey']?.toString();
+    if (stageKey == kVMainSwitchStageKey ||
+        stageKey == kSwitchableVGroupKey ||
+        stageKey == kFriStageId ||
+        stageKey == kWindowStageId ||
+        groupKey == kSwitchableVGroupKey) {
+      return kVMainSwitchStageKey;
+    }
+    if (stageKey == kPMainSwitchStageKey ||
+        stageKey == kSwitchablePGroupKey ||
+        stageKey == kAutoBigStageId ||
+        stageKey == kAutoSmallStageId ||
+        stageKey == kTubeStageId ||
+        groupKey == kSwitchablePGroupKey) {
+      return kPMainSwitchStageKey;
+    }
+
+    final selectedId = _selectedSwitchableIdFromPreviewStage(stage);
+    if (selectedId == kFriStageId || selectedId == kWindowStageId) {
+      return kVMainSwitchStageKey;
+    }
+    if (selectedId == kAutoBigStageId ||
+        selectedId == kAutoSmallStageId ||
+        selectedId == kTubeStageId) {
+      return kPMainSwitchStageKey;
+    }
+    return null;
+  }
+
+  String? _selectedSwitchableIdFromPreviewStage(Map<String, dynamic> stage) {
+    final id = (stage['selectedWorkplaceId'] ??
+            stage['stageId'] ??
+            stage['stage_id'] ??
+            stage['stageid'] ??
+            stage['workplaceId'] ??
+            stage['workplace_id'] ??
+            stage['id'])
+        ?.toString()
+        .trim();
+    if (id == null || id.isEmpty) return null;
+    return id;
+  }
+
+  List<_SwitchableStageOption> _switchableOptionsForStageKey(
+    String stageKey,
+  ) {
+    if (stageKey == kVMainSwitchStageKey) {
+      return const [
+        _SwitchableStageOption(kFriStageId, 'Фри'),
+        _SwitchableStageOption(kWindowStageId, 'Окно'),
+      ];
+    }
+    if (stageKey == kPMainSwitchStageKey) {
+      return const [
+        _SwitchableStageOption(kAutoBigStageId, 'Автомат большой'),
+        _SwitchableStageOption(kAutoSmallStageId, 'Автомат маленький'),
+        _SwitchableStageOption(kTubeStageId, 'Труба'),
+      ];
+    }
+    return const <_SwitchableStageOption>[];
+  }
+
+  String? _selectedSwitchableStageIdForPreview(
+    String stageKey,
+    Map<String, dynamic> stage,
+  ) {
+    final stateSelected = stageKey == kVMainSwitchStageKey
+        ? _selectedVStage
+        : stageKey == kPMainSwitchStageKey
+            ? _selectedPStage
+            : null;
+    final selected =
+        (stateSelected ?? _selectedSwitchableIdFromPreviewStage(stage))
+            ?.trim();
+    final options = _switchableOptionsForStageKey(stageKey)
+        .map((option) => option.stageId)
+        .toSet();
+    if (selected != null && options.contains(selected)) return selected;
+    return options.isEmpty ? null : options.first;
+  }
+
+  void _selectSwitchablePreviewStage(String stageKey, String selectedStageId) {
+    final current = stageKey == kVMainSwitchStageKey
+        ? _selectedVStage
+        : stageKey == kPMainSwitchStageKey
+            ? _selectedPStage
+            : null;
+    if (current == selectedStageId) return;
+
+    setState(() {
+      if (stageKey == kVMainSwitchStageKey) {
+        _selectedVStage = selectedStageId;
+      } else if (stageKey == kPMainSwitchStageKey) {
+        _selectedPStage = selectedStageId;
+      } else {
+        return;
+      }
+
+      final currentStages = _stagePreviewStages
+          .map((stage) => Map<String, dynamic>.from(stage))
+          .toList(growable: false);
+      final queue = _buildStageQueueFromCurrentDraft(
+        existingStages: currentStages,
+        templateStages: _selectedTemplateStageMaps(),
+      );
+      _stagePreviewStages = queue;
+      _syncSwitchableStageSelectionFields(queue);
+      _queueBuildStatus = QueueBuildStatus.outdated;
+      _isStageQueueBuilt = false;
+    });
+  }
+
+  Widget? _buildSwitchableStageSelector(Map<String, dynamic> stage) {
+    if (!_isSwitchablePreviewStage(stage)) return null;
+    final stageKey = _switchableStageKeyFromPreviewStage(stage);
+    if (stageKey == null) return null;
+    final options = _switchableOptionsForStageKey(stageKey);
+    if (options.isEmpty) return null;
+    final selected = _selectedSwitchableStageIdForPreview(stageKey, stage);
+    if (selected == null) return null;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: SegmentedButton<String>(
+        segments: [
+          for (final option in options)
+            ButtonSegment<String>(
+              value: option.stageId,
+              label: Text(option.label),
+            ),
+        ],
+        selected: {selected},
+        onSelectionChanged: (selection) {
+          if (selection.isEmpty) return;
+          _selectSwitchablePreviewStage(stageKey, selection.first);
+        },
+      ),
+    );
+  }
+
+  String? _persistedSelectedVStage(String queueBuildStatus) =>
+      queueBuildStatus == QueueBuildStatus.built
+          ? _selectedVStage
+          : widget.order?.selectedVStage;
+
+  String? _persistedSelectedPStage(String queueBuildStatus) =>
+      queueBuildStatus == QueueBuildStatus.built
+          ? _selectedPStage
+          : widget.order?.selectedPStage;
 
   List<Map<String, dynamic>> _buildStageQueueFromCurrentDraft({
     List<Map<String, dynamic>> existingStages = const <Map<String, dynamic>>[],
@@ -3006,8 +3172,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         comments: _commentsController.text.trim(),
         status: nextOrderStatus,
         queueBuildStatus: nextQueueBuildStatus,
-        selectedVStage: _selectedVStage,
-        selectedPStage: _selectedPStage,
+        selectedVStage: _persistedSelectedVStage(nextQueueBuildStatus),
+        selectedPStage: _persistedSelectedPStage(nextQueueBuildStatus),
         queueSignature: nextQueueBuildStatus == QueueBuildStatus.notBuilt
             ? null
             : currentQueueSignature,
@@ -3090,8 +3256,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         assignmentId: widget.order!.assignmentId,
         assignmentCreated: widget.order!.assignmentCreated,
         queueBuildStatus: nextQueueBuildStatus,
-        selectedVStage: _selectedVStage,
-        selectedPStage: _selectedPStage,
+        selectedVStage: _persistedSelectedVStage(nextQueueBuildStatus),
+        selectedPStage: _persistedSelectedPStage(nextQueueBuildStatus),
         queueSignature: nextQueueBuildStatus == QueueBuildStatus.notBuilt
             ? null
             : currentQueueSignature,
@@ -6596,40 +6762,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               '')
           .toString()
           .trim();
-      children.add(GestureDetector(
-        onTap: () {
-          final toggledStage = toggleProductStageObject(stage);
-          if (toggledStage == null) return;
-          final toggledStageKey = toggledStage['stageKey']?.toString();
-          final selectedWorkplaceId =
-              toggledStage['selectedWorkplaceId']?.toString();
-          if (selectedWorkplaceId == null || selectedWorkplaceId.isEmpty) {
-            return;
-          }
-          setState(() {
-            if (toggledStageKey == kVMainSwitchStageKey) {
-              _selectedVStage = selectedWorkplaceId;
-            } else if (toggledStageKey == kPMainSwitchStageKey) {
-              _selectedPStage = selectedWorkplaceId;
-            } else {
-              return;
-            }
-
-            final currentStages = _stagePreviewStages
-                .map((stage) => Map<String, dynamic>.from(stage))
-                .toList(growable: false);
-            final queue = _buildStageQueueFromCurrentDraft(
-              existingStages: currentStages,
-              templateStages: _selectedTemplateStageMaps(),
-            );
-            _stagePreviewStages = queue;
-            _syncSwitchableStageSelectionFields(queue);
-            _queueSignature = _currentQueueSignature();
-            _queueBuildStatus = QueueBuildStatus.outdated;
-            _isStageQueueBuilt = false;
-          });
-        },
-        child: Container(
+      final switchableSelector = _buildSwitchableStageSelector(stage);
+      children.add(
+        Container(
           margin: EdgeInsets.only(top: i == 0 ? 0 : 8),
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
@@ -6654,13 +6789,14 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                           style: theme.textTheme.bodySmall,
                         ),
                       ),
+                    if (switchableSelector != null) switchableSelector,
                   ],
                 ),
               ),
             ],
           ),
         ),
-      ));
+      );
     }
 
     return Column(


### PR DESCRIPTION
### Motivation
- Сделать переключаемые этапы в preview явными и управляемыми через UI по признакам `isSwitchable`, `switchableGroupKey`, `stageKey` или по выбранному `stage/workplace id` для В- и П-образных вариантов. 
- Позволить оперативно менять вариант этапа в preview, немедленно пересобирать очередь и помечать её как устаревшую, при этом сохранять выбор в заказ только после явного сборa очереди (бизнес-правило). 

### Description
- Добавлена модель опций `_SwitchableStageOption` и набор вспомогательных функций для распознавания switchable-этапа в preview: `_isSwitchablePreviewStage`, `_switchableStageKeyFromPreviewStage`, `_selectedSwitchableIdFromPreviewStage`, `_switchableOptionsForStageKey`. 
- Реализован селектор `_buildSwitchableStageSelector` на основе `SegmentedButton` с опциями для В-образных этапов (`Фри`, `Окно`) и для П-образного пакета (`Автомат большой`, `Автомат маленький`, `Труба`) и визуальным выделением активного варианта. 
- При выборе варианта обновляется локальный state (`_selectedVStage` / `_selectedPStage`), немедленно пересобирается preview через существующий `_buildStageQueueFromCurrentDraft()` (используется `stage_queue_builder.dart`), и очередь помечается как `outdated` (`_queueBuildStatus = QueueBuildStatus.outdated`). 
- Визуализация preview изменена: вместо скрытого переключения по tap внутри карточки этапа теперь рендерится явный selector внутри блока этапа. 
- Сохранение выбранных вариантов в создаваемый/обновляемый заказ ограничено: при записи в заказ используются `_persistedSelectedVStage` / `_persistedSelectedPStage`, которые возвращают текущие `_selected*` только если очередь в статусе `built`, иначе сохраняются ранее сохранённые значения (или null для нового заказа). 

### Testing
- Выполнена проверка изменений с `git diff --check`, ошибок не обнаружено. (успех)
- Попытка запустить `flutter test test/stage_queue_builder_test.dart` не удалась в среде выполнения, так как команда `flutter` отсутствует (`/bin/bash: line 1: flutter: command not found`). (не выполнено)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc478a5d7c832fa9d93adc57d3308a)