### PR TITLE
Centralize order queue handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Order stage queue source of truth
+
+The factual technological queue for an order is resolved through
+`OrderQueueService`. The source priority is:
+
+1. the saved queue on the order;
+2. normalized production plan rows (`prod_plans` / `prod_plan_stages`);
+3. legacy `production_plans.stages` JSON;
+4. the stage template only as a fallback for old orders without a saved queue.
+
+`stageTemplateId` is no longer a source of truth for the actual order queue. It
+is retained as UI/editing metadata and as a legacy fallback key only when no
+saved queue or plan rows exist.

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -17,7 +17,7 @@ import 'dart:typed_data';
 import 'orders_provider.dart';
 import 'order_stage_filter.dart';
 import 'stage_queue_builder.dart';
-import 'order_queue_sync_service.dart';
+import 'order_queue_service.dart';
 import 'orders_repository.dart';
 import 'order_model.dart';
 import 'product_model.dart';
@@ -520,6 +520,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   final _formKey = GlobalKey<FormState>();
   final _uuid = const Uuid();
   final SupabaseClient _sb = Supabase.instance.client;
+  late final OrderQueueService _orderQueueService = OrderQueueService(_sb);
 
   // Персонал: выбранный менеджер из списка сотрудников с ролью «Менеджер»
   String? _selectedManager;
@@ -1705,18 +1706,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       if ((_selectedPStage ?? '').trim().isNotEmpty)
         kPMainSwitchStageKey: _selectedPStage!.trim(),
     };
-    return buildOrderStageQueue(
-      productTypeId: draft.productTypeId,
-      hasCutting: draft.hasTrimming,
-      hasCardboard: draft.hasCardboard,
-      hasFlexPrinting: draft.hasPaint,
-      handleType: draft.handleType,
-      orderWidthB: draft.orderWidthB,
-      materialWidth: draft.materialWidth,
-      switchableStageKey: draft.switchableStageKey,
-      selectedSwitchableStageId: draft.selectedSwitchableStageId,
-      selectedSwitchableStageIdsByStageKey:
-          selectedSwitchableStageIdsByStageKey,
+    return _orderQueueService.buildPreviewQueue(
+      draft.copyWithSwitchableSelections(selectedSwitchableStageIdsByStageKey),
       existingStages: existingStages,
       templateStages: templateStages,
     );
@@ -3342,293 +3333,29 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       await provider.updateOrder(createdOrUpdatedOrder);
     }
     if (canRebuildProductionPlan && hasBuiltStageQueue) {
-      // Создаём или обновляем производственную очередь независимо от шаблона.
-      // stageTemplateId сохраняется в заказе выше, но автогенерация строится по полям формы.
+      // Сохраняем фактическую очередь заказа через общий сервис.
+      // stageTemplateId остаётся метаданным выбора в UI, а не источником истины.
       final templateStages = _selectedTemplateStageMaps();
-
-      // Источник истины при сохранении — текущий preview.
-      // Он уже может содержать ручную перестановку флексо/бобинорезки.
-      // Если preview пустой и шаблон не выбран, строим очередь строго из
-      // текущего черновика без этапов шаблона.
-      List<Map<String, dynamic>> stageMaps =
-          _buildStageMapsForProductionPlanSave(
+      var stageMaps = _buildStageMapsForProductionPlanSave(
         stagePreviewStages: _stagePreviewStages,
         stageTemplateId: _stageTemplateId,
         selectedTemplateStages: templateStages,
         buildStageQueueFromCurrentDraft: ({required templateStages}) =>
             _buildStageQueueFromCurrentDraft(templateStages: templateStages),
       );
-
       final outcome = await _applyStageRules(stageMaps);
       stageMaps = outcome.stages;
-      final bool __shouldCompleteBobbin = outcome.shouldCompleteBobbin;
-      final String? __bobbinId = outcome.bobbinId;
-      // Save or update production plan in dedicated table 'production_plans'
-      final existingPlan = await _sb
-          .from('production_plans')
-          .select('id')
-          .eq('order_id', createdOrUpdatedOrder.id)
-          .maybeSingle();
-      if (existingPlan != null) {
-        await _sb
-            .from('production_plans')
-            .update({'stages': stageMaps}).eq('id', existingPlan['id']);
-      } else {
-        await _sb.from('production_plans').insert(
-            {'order_id': createdOrUpdatedOrder.id, 'stages': stageMaps});
-      }
-
-      bool _looksLikeBobbin(Map<String, dynamic> sm) {
-        final title =
-            ((sm['stageName'] ?? sm['title']) as String?)?.toLowerCase() ?? '';
-        return title.contains('бобинорезка') ||
-            title.contains('бабинорезка') ||
-            title.contains('bobbin');
-      }
-
-      String? _resolveStageId(Map<String, dynamic> sm) {
-        final sid = (sm['stageId'] as String?) ??
-            (sm['stageid'] as String?) ??
-            (sm['stage_id'] as String?) ??
-            (sm['workplaceId'] as String?) ??
-            (sm['workplace_id'] as String?) ??
-            (sm['id'] as String?);
-        if ((_looksLikeBobbin(sm) || sid == null || sid.isEmpty) &&
-            __bobbinId != null &&
-            __bobbinId!.isNotEmpty) {
-          return __bobbinId;
-        }
-        return sid;
-      }
-
-      String _normalizeText(dynamic value) => (value?.toString() ?? '').trim();
-
-      final workplaceLookup = <String, String>{};
-      Future<List<Map<String, dynamic>>> _loadWorkplaceRows() async {
-        Future<List<Map<String, dynamic>>> readRows(String select) async {
-          final rows = await _sb.from('workplaces').select(select);
-          if (rows is! List) return const <Map<String, dynamic>>[];
-          return rows
-              .whereType<Map>()
-              .map((row) => Map<String, dynamic>.from(row))
-              .toList(growable: false);
-        }
-
-        try {
-          return await readRows(
-            'id, code, name, title, short_name, workplace_name, stage_name',
-          );
-        } catch (_) {
-          try {
-            return await readRows('id, name, code, title, short_name');
-          } catch (_) {
-            try {
-              return await readRows('id, name');
-            } catch (_) {
-              return const <Map<String, dynamic>>[];
-            }
-          }
-        }
-      }
-
-      final workplaceRows = await _loadWorkplaceRows();
-      bool _containsBobbinWord(String value) {
-        final text = value.toLowerCase();
-        return text.contains('бобин') ||
-            text.contains('бабин') ||
-            text.contains('bobin') ||
-            text.contains('bobbin');
-      }
-
-      bool _containsFlexoWord(String value) {
-        final text = value.toLowerCase();
-        return text.contains('флекс') || text.contains('flexo');
-      }
-
-      final legacyStageLookup = <String, String>{};
-      legacyStageLookup['w_flexoprint'] = _canonicalFlexoWorkplaceId;
-      legacyStageLookup['w_flexo'] = _canonicalFlexoWorkplaceId;
-      legacyStageLookup['w_bobiner'] = _canonicalBobbinWorkplaceId;
-      legacyStageLookup['w_bobbin'] = _canonicalBobbinWorkplaceId;
-      for (final map in workplaceRows) {
-        final id = _normalizeText(map['id']);
-        if (id.isEmpty) continue;
-        final probes = [
-          map['id'],
-          map['code'],
-          map['name'],
-          map['title'],
-          map['short_name'],
-          map['workplace_name'],
-          map['stage_name'],
-        ];
-        final joined = probes.map(_normalizeText).join(' ').toLowerCase();
-        if (_containsBobbinWord(joined)) {
-          legacyStageLookup['w_bobiner'] = id;
-          legacyStageLookup['w_bobbin'] = id;
-        }
-        if (_containsFlexoWord(joined)) {
-          legacyStageLookup['w_flexoprint'] = id;
-          legacyStageLookup['w_flexo'] = id;
-        }
-        for (final probe in probes) {
-          final key = _normalizeText(probe).toLowerCase();
-          if (key.isEmpty) continue;
-          workplaceLookup.putIfAbsent(key, () => id);
-        }
-      }
-
-      String? _resolveStageValue(dynamic raw) {
-        final normalized = _normalizeText(raw);
-        if (normalized.isEmpty) return null;
-        final key = normalized.toLowerCase();
-        return workplaceLookup[key] ?? legacyStageLookup[key] ?? normalized;
-      }
-
-      bool _looksLikeUuid(String value) {
-        final v = value.trim();
-        return RegExp(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$')
-            .hasMatch(v);
-      }
-
-      final knownWorkplaceIds = workplaceRows
-          .map((row) => _normalizeText(row['id']))
-          .where((id) => id.isNotEmpty)
-          .toSet();
-
-      bool _isResolvableWorkplaceId(String stageId) {
-        if (stageId.isEmpty) return false;
-        if (_looksLikeUuid(stageId)) {
-          // При неполном lookup (например, из-за RLS) пропускаем UUID дальше,
-          // но при наличии списка рабочих мест всё равно предпочитаем реальные id.
-          return knownWorkplaceIds.isEmpty || knownWorkplaceIds.contains(stageId);
-        }
-        return workplaceLookup.containsValue(stageId) ||
-            legacyStageLookup.containsValue(stageId);
-      }
-
-      Iterable<dynamic> _collectIdsFrom(dynamic candidate) sync* {
-        if (candidate is List) {
-          for (final value in candidate) {
-            yield value;
-          }
-          return;
-        }
-        if (candidate is String) {
-          for (final token in candidate.split(',')) {
-            yield token;
-          }
-        }
-      }
-
-      Iterable<dynamic> _collectWorkplaceIds(Map<String, dynamic> sm) sync* {
-        yield* _collectIdsFrom(sm['workplaceIds']);
-        yield* _collectIdsFrom(sm['workplace_ids']);
-      }
-
-      Iterable<dynamic> _collectAlternativeIds(Map<String, dynamic> sm) sync* {
-        final candidates = <dynamic>[
-          sm['alternativeStageIds'],
-          sm['alternative_stage_ids'],
-          sm['allStageIds'],
-          sm['all_stage_ids'],
-          sm['stageIds'],
-          sm['stage_ids'],
-        ];
-        for (final candidate in candidates) {
-          yield* _collectIdsFrom(candidate);
-        }
-      }
-
-      List<String> _resolveStageIds(Map<String, dynamic> sm) {
-        final candidates = <String>[];
-
-        void addCandidate(dynamic raw) {
-          final resolved = _resolveStageValue(raw);
-          if (resolved == null || resolved.isEmpty) return;
-          if (!candidates.contains(resolved)) {
-            candidates.add(resolved);
-          }
-        }
-
-        final workplaceCandidates = _collectWorkplaceIds(sm).toList();
-        if (workplaceCandidates.isNotEmpty) {
-          for (final raw in workplaceCandidates) {
-            addCandidate(raw);
-          }
-        } else {
-          addCandidate(_resolveStageId(sm));
-        }
-
-        for (final probe in <dynamic>[
-          sm['stageName'],
-          sm['stage_name'],
-          sm['workplaceName'],
-          sm['workplace_name'],
-          sm['title'],
-          sm['name'],
-        ]) {
-          addCandidate(probe);
-        }
-
-        for (final raw in _collectAlternativeIds(sm)) {
-          addCandidate(raw);
-        }
-
-        final resolved = <String>[];
-        for (final candidate in candidates) {
-          if (_isResolvableWorkplaceId(candidate) && !resolved.contains(candidate)) {
-            resolved.add(candidate);
-          }
-        }
-
-        if (resolved.isNotEmpty) return resolved;
-        if (candidates.isEmpty) return const <String>[];
-        return <String>[candidates.first];
-      }
-
-      // ---- Sync normalized tables prod_plans/prod_plan_stages (if they exist) ----
-      try {
-        // Синхронизируем очередь диффом, не трогая завершённые/запущенные этапы
-        // и связанные с ними задачи.
-        final nextQueue = <OrderQueueSyncEntry>[];
-        int step = 1;
-        String? previousGroupKey;
-        for (final sm in stageMaps) {
-          final stageIds = _resolveStageIds(sm);
-          if (stageIds.isEmpty) continue;
-
-          final canonical = List<String>.from(stageIds)..sort();
-          final groupKey = canonical.join('|');
-          if (groupKey.isNotEmpty && groupKey == previousGroupKey) {
-            continue;
-          }
-          previousGroupKey = groupKey;
-
-          for (final rawStageId in stageIds) {
-            final resolvedStageId = workplaceLookup[rawStageId.toLowerCase()] ??
-                legacyStageLookup[rawStageId.toLowerCase()] ??
-                rawStageId;
-            nextQueue.add(OrderQueueSyncEntry(
-              stageId: resolvedStageId,
-              stageGroupKey: groupKey.isEmpty ? resolvedStageId : groupKey,
-              step: step,
-            ));
-          }
-          step += 1;
-        }
-        await OrderQueueSyncService(_sb).sync(
-          orderId: createdOrUpdatedOrder.id,
-          nextQueue: nextQueue,
-          completeBobbin: __shouldCompleteBobbin,
-          bobbinStageId: __bobbinId,
-        );
-      } on OrderQueueSyncBlockedException {
-        rethrow;
-      } catch (_) {
-        // ignore if tables don't exist
-      }
-      // ---- /sync normalized tables ----
+      await _orderQueueService.saveBuiltQueue(
+        createdOrUpdatedOrder.id,
+        stageMaps,
+        <String, String?>{
+          'selected_v_stage': _persistedSelectedVStage(nextQueueBuildStatus),
+          'selected_p_stage': _persistedSelectedPStage(nextQueueBuildStatus),
+        },
+        currentQueueSignature,
+        completeBobbin: outcome.shouldCompleteBobbin,
+        bobbinStageId: outcome.bobbinId,
+      );
     }
 
     // Сначала синхронизируем список красок, чтобы в просмотре заказа

--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -1,0 +1,449 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'order_model.dart';
+import 'order_queue_sync_service.dart';
+import 'stage_queue_builder.dart';
+
+export 'order_queue_sync_service.dart' show OrderQueueSyncBlockedException;
+
+/// Source priority for a persisted order queue.
+///
+/// `stageTemplateId` is intentionally not an order queue source of truth. It is
+/// kept on the order only as an editing hint/legacy reference; the factual queue
+/// must come from the saved order queue first, then normalized plan rows, then
+/// legacy `production_plans.stages`, and only then from the template as a
+/// fallback for old orders that were never saved with an explicit queue.
+enum SavedOrderQueueSource {
+  savedOrderQueue,
+  normalizedPlanRows,
+  legacyProductionPlanStages,
+  templateFallback,
+  none,
+}
+
+class SavedOrderQueue {
+  const SavedOrderQueue({
+    required this.orderId,
+    required this.rows,
+    required this.source,
+  });
+
+  final String orderId;
+  final List<Map<String, dynamic>> rows;
+  final SavedOrderQueueSource source;
+
+  bool get isEmpty => rows.isEmpty;
+  bool get isNotEmpty => rows.isNotEmpty;
+}
+
+class OrderQueueService {
+  OrderQueueService(this._sb);
+
+  final SupabaseClient _sb;
+
+  List<Map<String, dynamic>> buildPreviewQueue(
+    OrderStageQueueDraft draft, {
+    List<Map<String, dynamic>> existingStages = const <Map<String, dynamic>>[],
+    List<Map<String, dynamic>> templateStages = const <Map<String, dynamic>>[],
+  }) {
+    return buildOrderStageQueue(
+      productTypeId: draft.productTypeId,
+      hasCutting: draft.hasTrimming,
+      hasCardboard: draft.hasCardboard,
+      hasFlexPrinting: draft.hasPaint,
+      handleType: draft.handleType,
+      orderWidthB: draft.orderWidthB,
+      materialWidth: draft.materialWidth,
+      switchableStageKey: draft.switchableStageKey,
+      selectedSwitchableStageId: draft.selectedSwitchableStageId,
+      selectedSwitchableStageIdsByStageKey:
+          draft.selectedSwitchableStageIdsByStageKey,
+      existingStages: existingStages,
+      templateStages: templateStages,
+    );
+  }
+
+  Future<SavedOrderQueue> loadSavedQueue(String orderId) async {
+    final id = orderId.trim();
+    if (id.isEmpty) {
+      return const SavedOrderQueue(
+        orderId: '',
+        rows: <Map<String, dynamic>>[],
+        source: SavedOrderQueueSource.none,
+      );
+    }
+
+    // 1. Explicit saved queue columns on the order row (newer schemas).
+    try {
+      final order = await _sb
+          .from('orders')
+          .select('stage_queue, saved_stage_queue, order_stage_queue')
+          .eq('id', id)
+          .maybeSingle();
+      if (order is Map) {
+        for (final key in const [
+          'stage_queue',
+          'saved_stage_queue',
+          'order_stage_queue',
+        ]) {
+          final rows = _decodeRows(order[key]);
+          if (rows.isNotEmpty) {
+            return SavedOrderQueue(
+              orderId: id,
+              rows: rows,
+              source: SavedOrderQueueSource.savedOrderQueue,
+            );
+          }
+        }
+      }
+    } catch (_) {}
+
+    try {
+      final order =
+          await _sb.from('orders').select('data').eq('id', id).maybeSingle();
+      final data = order is Map && order['data'] is Map
+          ? Map<String, dynamic>.from(order['data'] as Map)
+          : const <String, dynamic>{};
+      for (final key in const [
+        'stage_queue',
+        'saved_stage_queue',
+        'order_stage_queue',
+      ]) {
+        final rows = _decodeRows(data[key]);
+        if (rows.isNotEmpty) {
+          return SavedOrderQueue(
+            orderId: id,
+            rows: rows,
+            source: SavedOrderQueueSource.savedOrderQueue,
+          );
+        }
+      }
+    } catch (_) {}
+
+    // 2. Normalized plan rows are the preferred shared storage for active plans.
+    final normalized = await _loadNormalizedRows(id);
+    if (normalized.isNotEmpty) {
+      return SavedOrderQueue(
+        orderId: id,
+        rows: normalized,
+        source: SavedOrderQueueSource.normalizedPlanRows,
+      );
+    }
+
+    // 3. Legacy JSON production_plans.stages.
+    try {
+      final plan = await _sb
+          .from('production_plans')
+          .select('stages')
+          .eq('order_id', id)
+          .maybeSingle();
+      if (plan is Map) {
+        final rows = _decodeRows(plan['stages']);
+        if (rows.isNotEmpty) {
+          return SavedOrderQueue(
+            orderId: id,
+            rows: rows,
+            source: SavedOrderQueueSource.legacyProductionPlanStages,
+          );
+        }
+      }
+    } catch (_) {}
+
+    // 4. Template is only a compatibility fallback for old data.
+    final templateRows = await _loadTemplateFallbackRows(id);
+    if (templateRows.isNotEmpty) {
+      return SavedOrderQueue(
+        orderId: id,
+        rows: templateRows,
+        source: SavedOrderQueueSource.templateFallback,
+      );
+    }
+
+    return SavedOrderQueue(
+      orderId: id,
+      rows: const <Map<String, dynamic>>[],
+      source: SavedOrderQueueSource.none,
+    );
+  }
+
+  Future<void> saveBuiltQueue(
+    String orderId,
+    List<Map<String, dynamic>> queue,
+    Map<String, String?> selections,
+    Map<String, dynamic>? signature, {
+    bool completeBobbin = false,
+    String? bobbinStageId,
+  }) async {
+    final id = orderId.trim();
+    if (id.isEmpty) return;
+    final rows = queue.map((row) => Map<String, dynamic>.from(row)).toList();
+
+    await _upsertLegacyProductionPlan(id, rows);
+
+    try {
+      await _sb.from('orders').update({
+        'queue_build_status': QueueBuildStatus.built,
+        'selected_v_stage': selections['selected_v_stage'],
+        'selected_p_stage': selections['selected_p_stage'],
+        'queue_signature': signature,
+      }).eq('id', id);
+    } catch (_) {}
+
+    try {
+      await syncQueueForExistingOrder(
+        id,
+        rows,
+        completeBobbin: completeBobbin,
+        bobbinStageId: bobbinStageId,
+      );
+    } on OrderQueueSyncBlockedException {
+      rethrow;
+    } catch (_) {
+      // Older deployments may not have normalized plan tables yet; the legacy
+      // saved queue above remains available for loadSavedQueue().
+    }
+  }
+
+  Future<List<OrderQueueSyncOperation>> syncQueueForExistingOrder(
+    String orderId,
+    List<Map<String, dynamic>> newQueue, {
+    bool completeBobbin = false,
+    String? bobbinStageId,
+  }) {
+    return OrderQueueSyncService(_sb).sync(
+      orderId: orderId,
+      nextQueue: OrderQueueMapper.toSyncEntries(newQueue),
+      completeBobbin: completeBobbin,
+      bobbinStageId: bobbinStageId,
+    );
+  }
+
+  Future<void> createTasksFromSavedQueue(String orderId) async {
+    final saved = await loadSavedQueue(orderId);
+    if (saved.rows.isEmpty) {
+      throw StateError('Не найдена сохранённая очередь этапов заказа.');
+    }
+    await OrderQueueSyncService(_sb).sync(
+      orderId: orderId,
+      nextQueue: OrderQueueMapper.toSyncEntries(saved.rows),
+    );
+    await _restoreCompletedSavedStages(orderId, saved.rows);
+  }
+
+  Future<List<Map<String, dynamic>>> _loadNormalizedRows(String orderId) async {
+    try {
+      final plan = await _sb
+          .from('prod_plans')
+          .select('id')
+          .eq('order_id', orderId)
+          .maybeSingle();
+      final planId = plan is Map ? plan['id']?.toString() : null;
+      if (planId == null || planId.isEmpty) {
+        return const <Map<String, dynamic>>[];
+      }
+      final rows = await _sb
+          .from('prod_plan_stages')
+          .select('*')
+          .eq('plan_id', planId)
+          .order('step', ascending: true);
+      return _decodeRows(rows);
+    } catch (_) {
+      return const <Map<String, dynamic>>[];
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> _loadTemplateFallbackRows(
+    String orderId,
+  ) async {
+    try {
+      final order = await _sb
+          .from('orders')
+          .select('stage_template_id')
+          .eq('id', orderId)
+          .maybeSingle();
+      final templateId = order is Map
+          ? (order['stage_template_id'] ?? '').toString().trim()
+          : '';
+      if (templateId.isEmpty) return const <Map<String, dynamic>>[];
+      final tpl = await _sb
+          .from('plan_templates')
+          .select('stages')
+          .eq('id', templateId)
+          .maybeSingle();
+      return tpl is Map
+          ? _decodeRows(tpl['stages'])
+          : const <Map<String, dynamic>>[];
+    } catch (_) {
+      return const <Map<String, dynamic>>[];
+    }
+  }
+
+  Future<void> _upsertLegacyProductionPlan(
+    String orderId,
+    List<Map<String, dynamic>> rows,
+  ) async {
+    final existing = await _sb
+        .from('production_plans')
+        .select('id')
+        .eq('order_id', orderId)
+        .maybeSingle();
+    if (existing is Map && existing['id'] != null) {
+      await _sb
+          .from('production_plans')
+          .update({'stages': rows})
+          .eq('id', existing['id']);
+    } else {
+      await _sb.from('production_plans').insert({
+        'order_id': orderId,
+        'stages': rows,
+      });
+    }
+  }
+
+  Future<void> _restoreCompletedSavedStages(
+    String orderId,
+    List<Map<String, dynamic>> rows,
+  ) async {
+    for (final entry in OrderQueueMapper.toSyncEntries(rows)) {
+      final status = entry.status.toLowerCase().trim();
+      if (status != 'done' && status != 'completed') continue;
+      await _sb.from('tasks').update({
+        'status': 'done',
+        'completed_at': DateTime.now().toIso8601String(),
+      })
+          .eq('order_id', orderId)
+          .eq('stage_group_key', entry.stageGroupKey)
+          .eq('stage_id', entry.stageId);
+    }
+  }
+
+  static List<Map<String, dynamic>> _decodeRows(dynamic rows) {
+    if (rows is List) {
+      return rows
+          .whereType<Map>()
+          .map((row) => Map<String, dynamic>.from(row))
+          .toList(growable: false);
+    }
+    if (rows is Map) {
+      final entries = rows.entries.toList()
+        ..sort((a, b) => a.key.toString().compareTo(b.key.toString()));
+      return entries
+          .where((entry) => entry.value is Map)
+          .map((entry) => Map<String, dynamic>.from(entry.value as Map))
+          .toList(growable: false);
+    }
+    return const <Map<String, dynamic>>[];
+  }
+}
+
+class OrderQueueMapper {
+  const OrderQueueMapper._();
+
+  static List<OrderQueueSyncEntry> toSyncEntries(
+    List<Map<String, dynamic>> rows,
+  ) {
+    final result = <OrderQueueSyncEntry>[];
+    final createdKeys = <String>{};
+    var fallbackStep = 1;
+    String? previousGroupKey;
+
+    for (final row in rows) {
+      final stageIds = stageIdsFromRow(row);
+      if (stageIds.isEmpty) continue;
+      final groupKey = stageGroupKeyFromRow(row, stageIds);
+      if (groupKey.isNotEmpty && groupKey == previousGroupKey) {
+        continue;
+      }
+      previousGroupKey = groupKey;
+      final step = readStep(row, fallbackStep);
+      final status = (row['status'] ?? 'waiting').toString();
+
+      for (final stageId in stageIds) {
+        final effectiveGroupKey = groupKey.isEmpty ? stageId : groupKey;
+        final key = '$effectiveGroupKey::$stageId';
+        if (!createdKeys.add(key)) continue;
+        result.add(OrderQueueSyncEntry(
+          stageId: stageId,
+          stageGroupKey: effectiveGroupKey,
+          step: step,
+          status: status,
+          row: row,
+        ));
+      }
+      fallbackStep += 1;
+    }
+
+    return result;
+  }
+
+  static List<String> stageIdsFromRow(Map<String, dynamic> row) {
+    final result = <String>[];
+
+    void add(dynamic value) {
+      final id = value?.toString().trim() ?? '';
+      if (id.isEmpty || result.contains(id)) return;
+      result.add(id);
+    }
+
+    void addAll(dynamic value) {
+      if (value is List) {
+        for (final item in value) {
+          add(item);
+        }
+      } else if (value is String) {
+        for (final token in value.split(',')) {
+          add(token);
+        }
+      }
+    }
+
+    addAll(row['workplaceIds'] ?? row['workplace_ids']);
+    if (result.isEmpty) {
+      add(row['selectedWorkplaceId'] ??
+          row['stageId'] ??
+          row['stage_id'] ??
+          row['stageid'] ??
+          row['workplaceId'] ??
+          row['workplace_id'] ??
+          row['id']);
+    }
+    addAll(row['alternativeStageIds'] ??
+        row['alternative_stage_ids'] ??
+        row['stageIds'] ??
+        row['stage_ids'] ??
+        row['allStageIds'] ??
+        row['all_stage_ids']);
+
+    return result;
+  }
+
+  static String stageGroupKeyFromRow(
+    Map<String, dynamic> row,
+    List<String> stageIds,
+  ) {
+    final explicit = (row['stage_group_key'] ??
+            row['stageGroupKey'] ??
+            row['queue_stage_key'] ??
+            row['queueStageKey'] ??
+            row['stageKey'] ??
+            row['stage_key'] ??
+            row['group_key'])
+        ?.toString()
+        .trim();
+    if (explicit != null && explicit.isNotEmpty) return explicit;
+    final canonical = List<String>.from(stageIds)..sort();
+    return canonical.join('|');
+  }
+
+  static int readStep(Map<String, dynamic> row, int fallback) {
+    final raw = row['step'] ??
+        row['step_no'] ??
+        row['stepNo'] ??
+        row['seq'] ??
+        row['order'] ??
+        row['position'];
+    if (raw is int) return raw;
+    if (raw is num) return raw.toInt();
+    return int.tryParse(raw?.toString() ?? '') ?? fallback;
+  }
+}

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -5,7 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'material_model.dart';
 import 'order_model.dart';
-import 'order_queue_sync_service.dart';
+import 'order_queue_service.dart';
 import 'product_model.dart';
 import '../../utils/auth_helper.dart';
 
@@ -754,159 +754,11 @@ class OrdersProvider with ChangeNotifier {
     }
 
     try {
-      final List<Map<String, dynamic>> stageRows = <Map<String, dynamic>>[];
-      List<String> _readStageIds(Map<String, dynamic> row) {
-        final ids = <String>[];
-        void add(dynamic value) {
-          final id = value?.toString().trim() ?? '';
-          if (id.isEmpty || ids.contains(id)) return;
-          ids.add(id);
-        }
-
-        final workplaceIds = row['workplace_ids'] ?? row['workplaceIds'];
-        if (workplaceIds is List) {
-          for (final id in workplaceIds) {
-            add(id);
-          }
-        } else if (workplaceIds is String) {
-          for (final token in workplaceIds.split(',')) {
-            add(token);
-          }
-        }
-
-        if (ids.isEmpty) {
-          add(row['stage_id'] ?? row['stageId'] ?? row['workplace_id']);
-        }
-        final alternatives = row['alternative_stage_ids'] ??
-            row['alternativeStageIds'] ??
-            row['stage_ids'] ??
-            row['stageIds'] ??
-            row['all_stage_ids'] ??
-            row['allStageIds'];
-        if (alternatives is List) {
-          for (final id in alternatives) {
-            add(id);
-          }
-        } else if (alternatives is String) {
-          for (final token in alternatives.split(',')) {
-            add(token);
-          }
-        }
-        return ids;
-      }
-
       try {
-        final plan = await _supabase
-            .from('prod_plans')
-            .select('id')
-            .eq('order_id', launchOrder.id)
-            .maybeSingle();
-        final String? planId = plan?['id']?.toString();
-        if (planId != null && planId.isNotEmpty) {
-          final rows = await _supabase
-              .from('prod_plan_stages')
-              .select('stage_id, alternative_stage_ids, status, step, step_no, seq, stage_group_key')
-              .eq('plan_id', planId)
-              .order('step', ascending: true);
-          if (rows is List) {
-            stageRows.addAll(rows
-                .whereType<Map>()
-                .map((r) => Map<String, dynamic>.from(r as Map)));
-          }
-        }
-      } catch (_) {}
-
-      if (stageRows.isEmpty) {
-        try {
-          final legacyPlan = await _supabase
-              .from('production_plans')
-              .select('stages')
-              .eq('order_id', launchOrder.id)
-              .maybeSingle();
-          final dynamic stages = legacyPlan?['stages'];
-          if (stages is List) {
-            for (final raw in stages.whereType<Map>()) {
-              final map = Map<String, dynamic>.from(raw as Map);
-              final workplaceIds = map['workplaceIds'] ?? map['workplace_ids'];
-              final stageId = (map['stageId'] ??
-                      map['stage_id'] ??
-                      map['stageid'] ??
-                      map['workplaceId'] ??
-                      map['workplace_id'] ??
-                      map['id'])
-                  ?.toString();
-              if (stageId == null || stageId.trim().isEmpty) continue;
-              stageRows.add({
-                'stage_id': stageId.trim(),
-                if (workplaceIds != null) 'workplace_ids': workplaceIds,
-                if (map['alternativeStageIds'] != null)
-                  'alternative_stage_ids': map['alternativeStageIds'],
-                if (map['alternative_stage_ids'] != null)
-                  'alternative_stage_ids': map['alternative_stage_ids'],
-                'status': 'waiting',
-              });
-            }
-          }
-        } catch (_) {}
-      }
-
-      if (stageRows.isEmpty) {
-        return 'Не удалось запустить заказ: не найдена очередь этапов.';
-      }
-
-      final nextQueue = <OrderQueueSyncEntry>[];
-      final doneStageKeys = <String>{};
-      final Set<String> createdTaskKeys = <String>{};
-      var fallbackStep = 1;
-      for (final row in stageRows) {
-        final stageIds = _readStageIds(row);
-        if (stageIds.isEmpty) continue;
-        final persistedGroupKey = (row['stage_group_key'] ??
-                row['stageGroupKey'] ??
-                row['queue_stage_key'] ??
-                row['queueStageKey'])
-            ?.toString()
-            .trim();
-        final groupIds = List<String>.from(stageIds)..sort();
-        final stageGroupKey =
-            (persistedGroupKey != null && persistedGroupKey.isNotEmpty)
-                ? persistedGroupKey
-                : groupIds.join('|');
-        final step = int.tryParse(
-              (row['step'] ?? row['step_no'] ?? row['seq'] ?? fallbackStep)
-                  .toString(),
-            ) ??
-            fallbackStep;
-        final String stageStatus = (row['status'] ?? '').toString().toLowerCase();
-        final bool isDoneStage = stageStatus == 'done' || stageStatus == 'completed';
-        for (final stageId in stageIds) {
-          final dedupeKey = '$stageGroupKey::$stageId';
-          if (!createdTaskKeys.add(dedupeKey)) continue;
-          nextQueue.add(OrderQueueSyncEntry(
-            stageId: stageId,
-            stageGroupKey: stageGroupKey.isEmpty ? stageId : stageGroupKey,
-            step: step,
-            status: isDoneStage ? 'done' : 'waiting',
-          ));
-          if (isDoneStage) doneStageKeys.add(dedupeKey);
-        }
-        fallbackStep += 1;
-      }
-
-      await OrderQueueSyncService(_supabase).sync(
-        orderId: launchOrder.id,
-        nextQueue: nextQueue,
-      );
-      for (final key in doneStageKeys) {
-        final parts = key.split('::');
-        if (parts.length != 2) continue;
-        await _supabase.from('tasks').update({
-          'status': 'done',
-          'completed_at': DateTime.now().toIso8601String(),
-        })
-            .eq('order_id', launchOrder.id)
-            .eq('stage_group_key', parts[0])
-            .eq('stage_id', parts[1]);
+        await OrderQueueService(_supabase)
+            .createTasksFromSavedQueue(launchOrder.id);
+      } on StateError catch (e) {
+        return 'Не удалось запустить заказ: ${e.message}';
       }
 
       // Бизнес-правило резерва: до перевода в in_production

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -108,6 +108,23 @@ class OrderStageQueueDraft {
   final String? switchableStageKey;
   final String? selectedSwitchableStageId;
   final Map<String, String> selectedSwitchableStageIdsByStageKey;
+
+  OrderStageQueueDraft copyWithSwitchableSelections(
+    Map<String, String> selections,
+  ) {
+    return OrderStageQueueDraft(
+      productTypeId: productTypeId,
+      orderWidthB: orderWidthB,
+      materialWidth: materialWidth,
+      hasPaint: hasPaint,
+      hasTrimming: hasTrimming,
+      hasCardboard: hasCardboard,
+      handleType: handleType,
+      switchableStageKey: switchableStageKey,
+      selectedSwitchableStageId: selectedSwitchableStageId,
+      selectedSwitchableStageIdsByStageKey: selections,
+    );
+  }
 }
 
 class BuiltOrderStage {

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import '../../services/app_auth.dart';
 
 import '../orders/order_model.dart';
+import '../orders/order_queue_service.dart';
 import 'task_completion_rules.dart';
 import 'stage_sequence_utils.dart';
 import 'task_model.dart';
@@ -604,18 +605,16 @@ class TaskProvider with ChangeNotifier {
   Future<_StageSequenceData> _fetchStageSequence(String orderId) async {
     await _ensureAuthed();
     String? orderCode;
-    String? stageTemplateId;
     try {
       final order = await _supabase
           .from('orders')
-          .select('assignment_id, stage_template_id')
+          .select('assignment_id')
           .eq('id', orderId)
           .maybeSingle();
       final orderMap = order is Map
           ? Map<String, dynamic>.from(order as Map)
           : const <String, dynamic>{};
       orderCode = orderMap['assignment_id']?.toString();
-      stageTemplateId = orderMap['stage_template_id']?.toString();
     } catch (_) {}
 
     Future<_StageSequenceData> fromRows(dynamic rows) async {
@@ -763,52 +762,17 @@ class TaskProvider with ChangeNotifier {
       );
     }
 
-    // Priority: preserve the exact queue saved during order creation/edit.
-    // This source is written by the order form and must stay authoritative
-    // for tasks/start-order gating.
-    try {
-      final plan = await _supabase
-          .from('production_plans')
-          .select('stages')
-          .eq('order_id', orderId)
-          .maybeSingle();
-      if (plan != null && plan is Map && plan['stages'] != null) {
-        final seq = await fromRows(plan['stages']);
-        if (seq.ids.isNotEmpty) return seq;
-      }
-    } catch (_) {}
-
-    // Try normalized legacy public tables.
-    try {
-      final plan = await _supabase
-          .from('prod_plans')
-          .select('id')
-          .eq('order_id', orderId)
-          .maybeSingle();
-      if (plan != null && plan is Map && plan['id'] != null) {
-        final rows = await _supabase
-            .from('prod_plan_stages')
-            .select(
-              'stage_id, stage_group_key, order, position, idx, step, step_no, seq',
-            )
-            .eq('plan_id', plan['id'].toString());
-        final seq = await fromRows(rows);
-        if (seq.ids.isNotEmpty) return seq;
-      }
-    } catch (_) {}
-
-    // Try the stage template attached to the order (plan_templates).
-    if (stageTemplateId != null && stageTemplateId!.isNotEmpty) {
-      try {
-        final tpl = await _supabase
-            .from('plan_templates')
-            .select('stages')
-            .eq('id', stageTemplateId!)
-            .maybeSingle();
-        final seq = await fromRows(tpl?['stages']);
-        if (seq.ids.isNotEmpty) return seq;
-      } catch (_) {}
+    // Shared priority: saved order queue -> normalized rows -> legacy
+    // production_plans.stages -> template fallback for old orders only.
+    final savedQueue =
+        await OrderQueueService(_supabase).loadSavedQueue(orderId);
+    if (savedQueue.isNotEmpty) {
+      final seq = await fromRows(savedQueue.rows);
+      if (seq.ids.isNotEmpty) return seq;
     }
+
+    // stageTemplateId is not read directly here: OrderQueueService already
+    // applies templates only as the last fallback for legacy orders.
 
     // Fallback: derived/public views. They can contain auto-added or repeated
     // stages, so they are intentionally lower priority.

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -486,15 +486,11 @@ String _workplaceName(PersonnelProvider personnel, String stageId,
 
 String _stageLabelForOrder(
     PersonnelProvider personnel,
-    TemplateProvider templates,
-    OrdersProvider orders,
+    TemplateProvider _templates,
+    OrdersProvider _orders,
     TaskProvider tasks,
     String orderId,
     String stageId) {
-  OrderModel? order;
-  try {
-    order = orders.orders.firstWhere((o) => o.id == orderId);
-  } catch (_) {}
   final savedGroupMap = tasks.stageGroupMapForOrder(orderId);
   if (savedGroupMap != null && savedGroupMap.containsKey(stageId.trim())) {
     final savedName = tasks.stageNameForOrder(orderId, stageId)?.trim();
@@ -502,67 +498,23 @@ String _stageLabelForOrder(
     return _workplaceName(personnel, stageId, tasks: tasks, orderId: orderId);
   }
 
-  final templateId = order?.stageTemplateId;
-  if (templateId == null || templateId.isEmpty) {
-    return _workplaceName(personnel, stageId, tasks: tasks, orderId: orderId);
-  }
-
-  PlannedStage? planned;
-  for (final tpl in templates.templates) {
-    if (tpl.id != templateId) continue;
-    for (final stage in tpl.stages) {
-      if (stage.allStageIds.contains(stageId)) {
-        planned = stage;
-        break;
-      }
-    }
-  }
-
-  if (planned == null) {
-    return _workplaceName(personnel, stageId, tasks: tasks, orderId: orderId);
-  }
-
-  final labels = <String>{};
-  for (final id in planned.allStageIds) {
-    labels.add(_workplaceName(personnel, id, tasks: tasks, orderId: orderId));
-  }
-  return labels.join(' / ');
+  // Stage labels/grouping come from TaskProvider, which loads the shared
+  // saved queue mapper and applies template data only as old-data fallback.
+  return _workplaceName(personnel, stageId, tasks: tasks, orderId: orderId);
 }
 
 Map<String, String> _stageGroupMapForOrder(
   OrderModel order,
-  TemplateProvider templates, {
+  TemplateProvider _templates, {
   TaskProvider? tasks,
 }) {
   final saved = tasks?.stageGroupMapForOrder(order.id);
   if (saved != null && saved.isNotEmpty) return saved;
 
-  final templateId = order.stageTemplateId;
-  if (templateId == null || templateId.isEmpty) return const {};
-  final tpl = templates.templates
-      .firstWhere(
-        (t) => t.id == templateId,
-        orElse: () =>
-            TemplateModel(id: '', name: '', stages: const <PlannedStage>[]),
-      );
-  if (tpl.id.isEmpty) return const {};
-
-  final map = <String, String>{};
-  for (final stage in tpl.stages) {
-    final ids = <String>[];
-    for (final id in stage.allStageIds) {
-      final normalized = id.trim();
-      if (normalized.isEmpty || ids.contains(normalized)) continue;
-      ids.add(normalized);
-    }
-    if (ids.isEmpty) continue;
-    final canonicalIds = List<String>.from(ids)..sort();
-    final key = canonicalIds.join('|');
-    for (final id in ids) {
-      map[id] = key;
-    }
-  }
-  return map;
+  // Do not derive factual grouping directly from stageTemplateId here.
+  // TaskProvider has already applied the shared queue priority and returns a
+  // template-derived map only for legacy orders without a saved queue.
+  return const <String, String>{};
 }
 
 String? _workplaceUnit(PersonnelProvider personnel, String stageId) {
@@ -1814,30 +1766,8 @@ class _TasksScreenState extends State<TasksScreen>
       return savedMembers;
     }
 
-    final order = _orderById(orderId);
-    final templateId = order?.stageTemplateId;
-    if (order == null || templateId == null || templateId.isEmpty) {
-      return [stageId];
-    }
-
-    final templateProvider =
-        Provider.of<TemplateProvider?>(context, listen: false);
-    final templates = templateProvider?.templates ?? const [];
-    for (final tpl in templates) {
-      if (tpl.id != templateId) continue;
-      for (final stage in tpl.stages) {
-        if (stage.allStageIds.contains(stageId)) {
-          final ids = <String>[];
-          for (final id in stage.allStageIds) {
-            final normalized = id.trim();
-            if (normalized.isEmpty || ids.contains(normalized)) continue;
-            ids.add(normalized);
-          }
-          if (ids.isNotEmpty) return ids;
-        }
-      }
-    }
-
+    // Template-derived grouping is intentionally centralized in TaskProvider via
+    // OrderQueueService and is only allowed as a legacy fallback there.
     return [stageId];
   }
 


### PR DESCRIPTION
### Motivation

- Reduce duplication and centralize all order queue operations (preview build, persistence, sync and task creation) into a single reusable service. 
- Make the factual source of an order's technological queue explicit and deterministic so UI and task logic read the same source. 
- Preserve `stage_queue_builder.dart` as the single builder implementation while removing `stageTemplateId` as the primary source of truth for the queue.

### Description

- Add `OrderQueueService` (`lib/modules/orders/order_queue_service.dart`) with methods `buildPreviewQueue`, `loadSavedQueue`, `saveBuiltQueue`, `syncQueueForExistingOrder`, and `createTasksFromSavedQueue`, and a mapper to convert saved rows into sync entries; the service enforces source priority (saved order queue → normalized plan rows → legacy `production_plans.stages` → template fallback). 
- Keep `stage_queue_builder.dart` as the only queue builder and add `OrderStageQueueDraft.copyWithSwitchableSelections` to pass UI switchable selections into the shared service when building previews. 
- Refactor `edit_order_screen.dart` to keep UI only and call the new service for queue preview/build/save (`_orderQueueService.buildPreviewQueue` and `_orderQueueService.saveBuiltQueue`). 
- Change `OrdersProvider.launchOrder()` to create tasks via `OrderQueueService.createTasksFromSavedQueue(order.id)` instead of inlined queue/plan parsing logic. 
- Update task-related code so ordering/grouping resolves via the shared saved-queue path: `TaskProvider` now loads saved queue via `OrderQueueService.loadSavedQueue(...)` before falling back to other sources, and `tasks_screen.dart` no longer derives factual grouping directly from `stageTemplateId`. 
- Document the new behavior in `README.md` and export `OrderQueueSyncBlockedException` from the service module.

### Testing

- Ran `git diff --check` to validate no obvious whitespace/merge issues (passed). 
- Tried to run `flutter test` and `flutter analyze` but they were not available in the execution environment (`flutter: command not found` / `dart: command not found`), so full static analysis / test suite execution was not performed here. 
- Local code compiles/behavior should be validated in a Flutter environment (run `flutter analyze` and `flutter test`) after pulling this branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4944aca4832f876ebca9b7133b9a)