### PR TITLE
Fix persisted order null check in launchOrder

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -719,7 +719,7 @@ class OrdersProvider with ChangeNotifier {
           .select()
           .eq('id', order.id)
           .maybeSingle();
-      if (persisted is Map) {
+      if (persisted != null) {
         launchOrder = OrderModel.fromMap(
           Map<String, dynamic>.from(persisted),
         );


### PR DESCRIPTION
### Motivation
- Ensure safe deserialization of a potentially absent persisted row returned by `maybeSingle()` by using an explicit null check instead of a type check.

### Description
- In `lib/modules/orders/orders_provider.dart` inside `launchOrder` (around lines 717-725) replaced `if (persisted is Map)` with `if (persisted != null)`, keeping the `OrderModel.fromMap(Map<String, dynamic>.from(persisted))` mapping.

### Testing
- Ran `git diff --check` with no issues; attempted `dart format lib/modules/orders/orders_provider.dart` but the `dart` command was unavailable in the environment, so formatting was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc50d0a3f8832f9fe74fd281f6379d)