### PR TITLE
Use null checks for maybeSingle results

### DIFF
--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -80,7 +80,7 @@ class OrderQueueService {
           .select('stage_queue, saved_stage_queue, order_stage_queue')
           .eq('id', id)
           .maybeSingle();
-      if (order is Map) {
+      if (order != null) {
         for (final key in const [
           'stage_queue',
           'saved_stage_queue',
@@ -101,7 +101,7 @@ class OrderQueueService {
     try {
       final order =
           await _sb.from('orders').select('data').eq('id', id).maybeSingle();
-      final data = order is Map && order['data'] is Map
+      final data = order != null && order['data'] is Map
           ? Map<String, dynamic>.from(order['data'] as Map)
           : const <String, dynamic>{};
       for (final key in const [
@@ -137,7 +137,7 @@ class OrderQueueService {
           .select('stages')
           .eq('order_id', id)
           .maybeSingle();
-      if (plan is Map) {
+      if (plan != null) {
         final rows = _decodeRows(plan['stages']);
         if (rows.isNotEmpty) {
           return SavedOrderQueue(
@@ -237,7 +237,7 @@ class OrderQueueService {
           .select('id')
           .eq('order_id', orderId)
           .maybeSingle();
-      final planId = plan is Map ? plan['id']?.toString() : null;
+      final planId = plan != null ? plan['id']?.toString() : null;
       if (planId == null || planId.isEmpty) {
         return const <Map<String, dynamic>>[];
       }
@@ -261,7 +261,7 @@ class OrderQueueService {
           .select('stage_template_id')
           .eq('id', orderId)
           .maybeSingle();
-      final templateId = order is Map
+      final templateId = order != null
           ? (order['stage_template_id'] ?? '').toString().trim()
           : '';
       if (templateId.isEmpty) return const <Map<String, dynamic>>[];
@@ -270,7 +270,7 @@ class OrderQueueService {
           .select('stages')
           .eq('id', templateId)
           .maybeSingle();
-      return tpl is Map
+      return tpl != null
           ? _decodeRows(tpl['stages'])
           : const <Map<String, dynamic>>[];
     } catch (_) {
@@ -287,7 +287,7 @@ class OrderQueueService {
         .select('id')
         .eq('order_id', orderId)
         .maybeSingle();
-    if (existing is Map && existing['id'] != null) {
+    if (existing != null && existing['id'] != null) {
       await _sb
           .from('production_plans')
           .update({'stages': rows})


### PR DESCRIPTION
### Motivation
- Упростить и обезопасить обработку результатов Supabase `maybeSingle()` — заменить ненадёжные типовые проверки `is Map` на явные проверки на `null`, чтобы корректно различать отсутствующее значение и пустую структуру.

### Description
- В `lib/modules/orders/order_queue_service.dart` в `loadSavedQueue` заменены проверки `if (order is Map)` и условие для `data` на `if (order != null)` и `order != null && order['data'] is Map` соответственно, сохранив существующие обращения к полям внутри защищённых блоков.
- В блоке legacy `production_plans.stages` заменена проверка `if (plan is Map)` на `if (plan != null)`.
- В `_loadNormalizedRows` заменено получение `planId` с `plan is Map ? ...` на `plan != null ? ...`.
- В `_loadTemplateFallbackRows` заменены проверки для `templateId` и `tpl` на `order != null` и `tpl != null` соответственно.
- В `_upsertLegacyProductionPlan` заменена проверка `if (existing is Map && existing['id'] != null)` на `if (existing != null && existing['id'] != null)`.

### Testing
- Выполнен `git diff --check` и ошибок не обнаружено.
- Поиск оставшихся вхождений шаблонов `order is Map|plan is Map|tpl is Map|existing is Map` в файле с помощью `rg` не вернул совпадений.
- Попытка запустить `dart format lib/modules/orders/order_queue_service.dart` не выполнена из-за отсутствия Dart SDK в окружении (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc51518b28832fbd919f8825a754e5)