### PR TITLE
Do not write unsupported `status` when creating `prod_plans`

### DIFF
--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -263,7 +263,7 @@ class OrderQueueSyncService {
     }
     final inserted = await _sb
         .from('prod_plans')
-        .insert({'order_id': orderId, 'status': 'planned'})
+        .insert({'order_id': orderId})
         .select('id')
         .single();
     return inserted['id'].toString();

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -2197,7 +2197,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 .from('prod_plans')
                 .insert({
                   'order_id': createdOrUpdatedOrder.id,
-                  'status': 'planned',
                 })
                 .select('id')
                 .single();


### PR DESCRIPTION
### Motivation
- Creating `prod_plans` rows attempted to write a `status` column that does not exist in some Supabase schemas, causing server errors when launching orders.

### Description
- Stop sending `status: 'planned'` when inserting into `prod_plans` in `lib/modules/orders/order_queue_sync_service.dart` by inserting only `{'order_id': orderId}`.
- Apply the same compatibility fix in `lib/modules/production_planning/form_editor_screen.dart` to avoid writing `status` when ensuring a `prod_plans` row exists.

### Testing
- Ran `git diff --check` to validate there are no obvious whitespace or patch issues and it passed.
- Attempted `dart format lib/...` but `dart` is not installed in the environment so formatting was not run. 
- Attempted `flutter --version` but `flutter` is not installed in the environment so SDK checks were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5b1b2cb0832f8ea46699ccbe787d)