### PR TITLE
Use prod_plan_stages.seq for ordering and sync (fix missing step column)

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -949,7 +949,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               .from('prod_plan_stages')
               .select('stage_id')
               .eq('plan_id', planId)
-              .order('step', ascending: true)
+              .order('seq', ascending: true)
               .limit(1)
               .maybeSingle();
           firstStageId = firstStage?['stage_id']?.toString();

--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -245,7 +245,7 @@ class OrderQueueService {
           .from('prod_plan_stages')
           .select('*')
           .eq('plan_id', planId)
-          .order('step', ascending: true);
+          .order('seq', ascending: true);
       return _decodeRows(rows);
     } catch (_) {
       return const <Map<String, dynamic>>[];

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -274,7 +274,7 @@ class OrderQueueSyncService {
         .from('prod_plan_stages')
         .select('*')
         .eq('plan_id', planId)
-        .order('step', ascending: true);
+        .order('seq', ascending: true);
     if (rows is! List) return const <OrderQueueSyncEntry>[];
     return rows
         .whereType<Map>()
@@ -307,7 +307,7 @@ class OrderQueueSyncService {
       id: row['id']?.toString(),
       stageId: stageId,
       stageGroupKey: groupKey.isEmpty ? stageId : groupKey,
-      step: _readInt(row['step'] ?? row['step_no'] ?? row['seq']),
+      step: _readInt(row['seq'] ?? row['step_no'] ?? row['step']),
       status: (row['status'] ?? 'waiting').toString(),
       row: row,
     );
@@ -346,7 +346,7 @@ class OrderQueueSyncService {
         .delete()
         .eq('stage_id', current.stageId)
         .eq('stage_group_key', current.stageGroupKey)
-        .eq('step', current.step);
+        .eq('seq', current.step);
   }
 
   Future<void> _updatePendingPlanStage(
@@ -356,7 +356,7 @@ class OrderQueueSyncService {
     final updates = {
       'stage_id': next.stageId,
       'stage_group_key': next.stageGroupKey,
-      'step': next.step,
+      'seq': next.step,
       'status': 'waiting',
     };
     await _updatePlanStageWithOptionalStepNo(current, updates, next.step);
@@ -370,7 +370,7 @@ class OrderQueueSyncService {
       'plan_id': planId,
       'stage_id': next.stageId,
       'stage_group_key': next.stageGroupKey,
-      'step': next.step,
+      'seq': next.step,
       'status': 'waiting',
     };
     try {
@@ -400,7 +400,7 @@ class OrderQueueSyncService {
           .update(payload)
           .eq('stage_id', current.stageId)
           .eq('stage_group_key', current.stageGroupKey)
-          .eq('step', current.step);
+          .eq('seq', current.step);
     }
 
     try {

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -275,7 +275,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
           final String planId = plan['id'] as String;
           final rows = await sb
               .from('prod_plan_stages')
-              .select('stage_id, stage_name, workplace_name, name, step, step_no, seq, stage_group_key')
+              .select('stage_id, stage_name, workplace_name, name, step_no, seq, stage_group_key')
               .eq('plan_id', planId);
 
           if (rows is List && rows.isNotEmpty) {

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -2226,7 +2226,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 'plan_id': planId,
                 'stage_id': stageId,
                 'stage_group_key': groupKey,
-                'step': step,
+                'seq': step,
                 'step_no': step,
                 'status': 'waiting',
               });

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -1414,13 +1414,25 @@ class TaskProvider with ChangeNotifier {
           if (rows is List && rows.isNotEmpty) {
             int maxOrder = 0;
             for (final r in rows) {
-              final o = r['order'] ?? r['position'] ?? r['idx'] ?? 0;
+              final o = r['order'] ??
+                  r['position'] ??
+                  r['idx'] ??
+                  r['seq'] ??
+                  r['step_no'] ??
+                  r['step'] ??
+                  0;
               final oi = (o is int) ? o : int.tryParse(o.toString()) ?? 0;
               if (oi > maxOrder) maxOrder = oi;
             }
             final lastIds = <String>{};
             for (final r in rows) {
-              final o = r['order'] ?? r['position'] ?? r['idx'] ?? 0;
+              final o = r['order'] ??
+                  r['position'] ??
+                  r['idx'] ??
+                  r['seq'] ??
+                  r['step_no'] ??
+                  r['step'] ??
+                  0;
               final oi = (o is int) ? o : int.tryParse(o.toString()) ?? 0;
               if (oi == maxOrder) {
                 final sid =


### PR DESCRIPTION
### Motivation
- Orders could not be launched because code assumed a non-existent `prod_plan_stages.step` column, causing DB errors when reading/updating plan stages.
- The codebase uses different column names in various environments (`seq`, `step_no`, `step`), so the sync/load logic must prefer the existing `seq` column and tolerate fallbacks.

### Description
- Replaced usages of the missing `step` column with `seq` when loading, inserting, updating, and matching `prod_plan_stages` rows in order queue sync and service logic (files: `order_queue_sync_service.dart`, `order_queue_service.dart`).
- Adjusted `OrderQueueSyncEntry`/parsing to prefer `seq`/`step_no`/`step` in that order when computing `step` values (file: `order_queue_sync_service.dart`).
- Made the plan-population path write `seq` (and keep `step_no`) when rebuilding `prod_plan_stages` (file: `form_editor_screen.dart`).
- Updated production UI/load logic to avoid selecting the missing `step` column and to sort by `seq` when identifying first/ordered stages (files: `production_details_screen.dart`, `edit_order_screen.dart`).
- Enhanced last-stage detection to consider `seq` and `step_no` as well as legacy keys when deciding if a stage is final for quantity propagation (file: `task_provider.dart`).

### Testing
- `flutter test test/order_launch_rules_test.dart test/stage_sequence_utils_test.dart` — not executed in this environment because the Flutter SDK is not installed (`flutter: command not found`).
- `dart analyze` — not executed because Dart SDK is not installed (`dart: command not found`).
- Verified via repository search that there are no remaining direct uses of ordering queries expecting `prod_plan_stages.step` (performed with `rg`), and the search returned no matches for the problematic patterns, indicating the codebase now prefers `seq`/`step_no` fallbacks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6d73f1a0832fa71daff66e6f2e07)