### PR TITLE
Support legacy prod_plan_stages schema when `stage_group_key` is missing

### DIFF
--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -336,17 +336,45 @@ class OrderQueueSyncService {
     return int.tryParse(value?.toString() ?? '') ?? 0;
   }
 
+  static bool _isMissingProdPlanStageGroupKey(Object error) {
+    if (error is! PostgrestException) return false;
+    final message = error.message.toLowerCase();
+    return error.code == 'PGRST204' &&
+        message.contains('stage_group_key') &&
+        message.contains('prod_plan_stages');
+  }
+
+  static Map<String, dynamic> _withoutStageGroupKey(
+    Map<String, dynamic> payload,
+  ) {
+    return Map<String, dynamic>.from(payload)..remove('stage_group_key');
+  }
+
+  Future<void> _deletePlanStageByQueueSlot(
+    OrderQueueSyncEntry current, {
+    required bool includeStageGroupKey,
+  }) async {
+    final query = _sb
+        .from('prod_plan_stages')
+        .delete()
+        .eq('stage_id', current.stageId);
+    if (includeStageGroupKey) {
+      query.eq('stage_group_key', current.stageGroupKey);
+    }
+    await query.eq('seq', current.step);
+  }
+
   Future<void> _deletePendingPlanStage(OrderQueueSyncEntry current) async {
     if (current.id != null && current.id!.isNotEmpty) {
       await _sb.from('prod_plan_stages').delete().eq('id', current.id!);
       return;
     }
-    await _sb
-        .from('prod_plan_stages')
-        .delete()
-        .eq('stage_id', current.stageId)
-        .eq('stage_group_key', current.stageGroupKey)
-        .eq('seq', current.step);
+    try {
+      await _deletePlanStageByQueueSlot(current, includeStageGroupKey: true);
+    } catch (error) {
+      if (!_isMissingProdPlanStageGroupKey(error)) rethrow;
+      await _deletePlanStageByQueueSlot(current, includeStageGroupKey: false);
+    }
   }
 
   Future<void> _updatePendingPlanStage(
@@ -377,8 +405,31 @@ class OrderQueueSyncService {
       await _sb
           .from('prod_plan_stages')
           .insert({...row, 'step_no': next.step});
+    } catch (error) {
+      if (_isMissingProdPlanStageGroupKey(error)) {
+        await _insertPlanStageWithoutStageGroupKey(row, next.step);
+        return;
+      }
+      try {
+        await _sb.from('prod_plan_stages').insert(row);
+      } catch (fallbackError) {
+        if (!_isMissingProdPlanStageGroupKey(fallbackError)) rethrow;
+        await _insertPlanStageWithoutStageGroupKey(row, next.step);
+      }
+    }
+  }
+
+  Future<void> _insertPlanStageWithoutStageGroupKey(
+    Map<String, dynamic> row,
+    int stepNo,
+  ) async {
+    final legacyRow = _withoutStageGroupKey(row);
+    try {
+      await _sb
+          .from('prod_plan_stages')
+          .insert({...legacyRow, 'step_no': stepNo});
     } catch (_) {
-      await _sb.from('prod_plan_stages').insert(row);
+      await _sb.from('prod_plan_stages').insert(legacyRow);
     }
   }
 
@@ -387,7 +438,10 @@ class OrderQueueSyncService {
     Map<String, dynamic> updates,
     int stepNo,
   ) async {
-    Future<void> run(Map<String, dynamic> payload) async {
+    Future<void> run(
+      Map<String, dynamic> payload, {
+      required bool includeStageGroupKeyFilter,
+    }) async {
       if (current.id != null && current.id!.isNotEmpty) {
         await _sb
             .from('prod_plan_stages')
@@ -395,18 +449,38 @@ class OrderQueueSyncService {
             .eq('id', current.id!);
         return;
       }
-      await _sb
+      final query = _sb
           .from('prod_plan_stages')
           .update(payload)
-          .eq('stage_id', current.stageId)
-          .eq('stage_group_key', current.stageGroupKey)
-          .eq('seq', current.step);
+          .eq('stage_id', current.stageId);
+      if (includeStageGroupKeyFilter) {
+        query.eq('stage_group_key', current.stageGroupKey);
+      }
+      await query.eq('seq', current.step);
     }
 
     try {
-      await run({...updates, 'step_no': stepNo});
-    } catch (_) {
-      await run(updates);
+      await run(
+        {...updates, 'step_no': stepNo},
+        includeStageGroupKeyFilter: true,
+      );
+    } catch (error) {
+      if (_isMissingProdPlanStageGroupKey(error)) {
+        await run(
+          _withoutStageGroupKey(updates),
+          includeStageGroupKeyFilter: false,
+        );
+        return;
+      }
+      try {
+        await run(updates, includeStageGroupKeyFilter: true);
+      } catch (fallbackError) {
+        if (!_isMissingProdPlanStageGroupKey(fallbackError)) rethrow;
+        await run(
+          _withoutStageGroupKey(updates),
+          includeStageGroupKeyFilter: false,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Fix launch/queue sync failures when the Supabase schema cache (or older DB schema) does not contain the `prod_plan_stages.stage_group_key` column which triggers PostgREST `PGRST204` errors.
- Preserve compatibility with both migrated schemas that include `stage_group_key` and legacy schemas that do not, so order launch and queue sync continue to work across environments.

### Description
- Added detection helper ` _isMissingProdPlanStageGroupKey` to recognize Supabase `PGRST204` errors tied to `prod_plan_stages.stage_group_key` and a helper ` _withoutStageGroupKey` to remove the field from payloads. 
- Added `_deletePlanStageByQueueSlot` and updated `_deletePendingPlanStage` to try deleting using `stage_group_key` and fall back to deleting without it if the column is missing. 
- Updated `_insertPlanStage` to catch the missing-column error and retry insertion via a new `_insertPlanStageWithoutStageGroupKey` path that omits `stage_group_key`, preserving `step_no` behavior where possible. 
- Modified `_updatePlanStageWithOptionalStepNo` to optionally include the `stage_group_key` filter and to retry updates without the column on `PGRST204` errors. 
- All changes are in `lib/modules/orders/order_queue_sync_service.dart` and keep the existing behavior for migrated schemas while providing safe fallbacks for legacy schemas.

### Testing
- `git diff --check` was run and returned no problems. 
- Attempted to run `dart format lib/modules/orders/order_queue_sync_service.dart` but the Dart SDK is not installed in the environment, so formatting/analysis could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7026f9c0832f9c247974e45c80c0)