### PR TITLE
Add migration to create and backfill prod_plan_stages.stage_id

### DIFF
--- a/supabase/migrations/20260507_add_stage_id_to_prod_plan_stages.sql
+++ b/supabase/migrations/20260507_add_stage_id_to_prod_plan_stages.sql
@@ -1,31 +1,36 @@
 alter table if exists public.prod_plan_stages
   add column if not exists stage_id text;
 
+alter table if exists public.prod_plan_stages
+  add column if not exists stage_group_key text;
+
 do $$
 declare
-  source_column text;
+  source_expression text;
 begin
-  select column_name
-  into source_column
-  from information_schema.columns
-  where table_schema = 'public'
-    and table_name = 'prod_plan_stages'
-    and column_name in ('workplace_id', 'workplaceId', 'id')
-    and data_type in ('text', 'character varying', 'character')
-  order by case column_name
-    when 'workplace_id' then 1
-    when 'workplaceId' then 2
-    when 'id' then 3
-  end
-  limit 1;
+  select string_agg(format('nullif(%I, %L)', column_name, ''), ', ' order by priority)
+  into source_expression
+  from (
+    select column_name,
+      case column_name
+        when 'workplace_id' then 1
+        when 'workplaceId' then 2
+        when 'id' then 3
+      end as priority
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'prod_plan_stages'
+      and column_name in ('workplace_id', 'workplaceId', 'id')
+      and data_type in ('text', 'character varying', 'character')
+  ) legacy_columns;
 
-  if source_column is not null then
+  if source_expression is not null then
     execute format(
       'update public.prod_plan_stages
-       set stage_id = %1$I
+       set stage_id = coalesce(%1$s)
        where coalesce(stage_id, '''') = ''''
-         and coalesce(%1$I, '''') <> ''''',
-      source_column
+         and coalesce(%1$s) is not null',
+      source_expression
     );
   end if;
 end $$;

--- a/supabase/migrations/20260507_add_stage_id_to_prod_plan_stages.sql
+++ b/supabase/migrations/20260507_add_stage_id_to_prod_plan_stages.sql
@@ -1,0 +1,41 @@
+alter table if exists public.prod_plan_stages
+  add column if not exists stage_id text;
+
+do $$
+declare
+  source_column text;
+begin
+  select column_name
+  into source_column
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'prod_plan_stages'
+    and column_name in ('workplace_id', 'workplaceId', 'id')
+    and data_type in ('text', 'character varying', 'character')
+  order by case column_name
+    when 'workplace_id' then 1
+    when 'workplaceId' then 2
+    when 'id' then 3
+  end
+  limit 1;
+
+  if source_column is not null then
+    execute format(
+      'update public.prod_plan_stages
+       set stage_id = %1$I
+       where coalesce(stage_id, '''') = ''''
+         and coalesce(%1$I, '''') <> ''''',
+      source_column
+    );
+  end if;
+end $$;
+
+create index if not exists prod_plan_stages_plan_stage_idx
+  on public.prod_plan_stages(plan_id, stage_id);
+
+update public.prod_plan_stages
+set stage_group_key = stage_id
+where coalesce(stage_group_key, '') = ''
+  and coalesce(stage_id, '') <> '';
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- Ensure `public.prod_plan_stages` has a canonical `stage_id` column and that legacy workplaces are migrated into it for consistent downstream usage. 
- Provide an index optimized for common filters and populate `stage_group_key` where possible so existing code paths continue to work. 

### Description
- Add new migration file `supabase/migrations/20260507_add_stage_id_to_prod_plan_stages.sql` that runs `alter table if exists public.prod_plan_stages add column if not exists stage_id text;`.
- Backfill `stage_id` from legacy columns using a safe dynamic SQL block that inspects `information_schema.columns` for `workplace_id`, `workplaceId`, or text `id` and updates only empty `stage_id` values.
- Create the index `prod_plan_stages_plan_stage_idx` on `(plan_id, stage_id)`, set `stage_group_key = stage_id` for empty group keys when `stage_id` is present, and issue `notify pgrst, 'reload schema';` to refresh PostgREST schema cache.
- Verified code locations that consume `prod_plan_stages` (`lib/modules/orders/order_queue_sync_service.dart`, `lib/modules/orders/order_queue_service.dart`, `lib/modules/production/production_details_screen.dart`, `lib/modules/tasks/task_provider.dart`) already handle legacy variations (`stage_id`, `stageId`, `workplace_id`, `workplaceId`, `id`).

### Testing
- Ran `git diff --check` to ensure no whitespace/errors reported and it completed without issues.
- Searched usages with `rg -n "prod_plan_stages|stage_id|stage_group_key|workplace_id|workplaceId"` to confirm callers read legacy fields and it returned expected references.
- Executed a `python3` check that verified the migration contains the required statements (column addition, index creation, `stage_group_key` update, and PostgREST notify) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc72082138832f967b459669959df0)