### PR TITLE
Handle missing prod_plan_stages.stage_id schema errors

### DIFF
--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -4,7 +4,8 @@ import 'order_model.dart';
 import 'order_queue_sync_service.dart';
 import 'stage_queue_builder.dart';
 
-export 'order_queue_sync_service.dart' show OrderQueueSyncBlockedException;
+export 'order_queue_sync_service.dart'
+    show OrderQueueSyncBlockedException, OrderQueueSyncSchemaOutdatedException;
 
 /// Source priority for a persisted order queue.
 ///

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -3,6 +3,9 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 const String kStartedStageQueueChangeMessage =
     'Нельзя изменить этап, который уже находится в работе. Завершите или отмените текущий этап перед изменением очереди.';
 
+const String kOutdatedProdPlanStageIdSchemaMessage =
+    'Схема базы данных устарела: отсутствует prod_plan_stages.stage_id. Примените миграции Supabase';
+
 enum OrderQueueSyncOperationType {
   keep,
   insert,
@@ -28,6 +31,17 @@ class OrderQueueSyncOperation {
 class OrderQueueSyncBlockedException implements Exception {
   const OrderQueueSyncBlockedException([
     this.message = kStartedStageQueueChangeMessage,
+  ]);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class OrderQueueSyncSchemaOutdatedException implements Exception {
+  const OrderQueueSyncSchemaOutdatedException([
+    this.message = kOutdatedProdPlanStageIdSchemaMessage,
   ]);
 
   final String message;
@@ -344,6 +358,20 @@ class OrderQueueSyncService {
         message.contains('prod_plan_stages');
   }
 
+  static bool _isMissingProdPlanStageId(Object error) {
+    if (error is! PostgrestException) return false;
+    final message = error.message.toLowerCase();
+    return error.code == 'PGRST204' &&
+        message.contains('stage_id') &&
+        message.contains('prod_plan_stages');
+  }
+
+  static void _throwIfMissingProdPlanStageId(Object error) {
+    if (_isMissingProdPlanStageId(error)) {
+      throw const OrderQueueSyncSchemaOutdatedException();
+    }
+  }
+
   static Map<String, dynamic> _withoutStageGroupKey(
     Map<String, dynamic> payload,
   ) {
@@ -361,7 +389,12 @@ class OrderQueueSyncService {
     if (includeStageGroupKey) {
       query.eq('stage_group_key', current.stageGroupKey);
     }
-    await query.eq('seq', current.step);
+    try {
+      await query.eq('seq', current.step);
+    } catch (error) {
+      _throwIfMissingProdPlanStageId(error);
+      rethrow;
+    }
   }
 
   Future<void> _deletePendingPlanStage(OrderQueueSyncEntry current) async {
@@ -406,6 +439,7 @@ class OrderQueueSyncService {
           .from('prod_plan_stages')
           .insert({...row, 'step_no': next.step});
     } catch (error) {
+      _throwIfMissingProdPlanStageId(error);
       if (_isMissingProdPlanStageGroupKey(error)) {
         await _insertPlanStageWithoutStageGroupKey(row, next.step);
         return;
@@ -413,6 +447,7 @@ class OrderQueueSyncService {
       try {
         await _sb.from('prod_plan_stages').insert(row);
       } catch (fallbackError) {
+        _throwIfMissingProdPlanStageId(fallbackError);
         if (!_isMissingProdPlanStageGroupKey(fallbackError)) rethrow;
         await _insertPlanStageWithoutStageGroupKey(row, next.step);
       }
@@ -428,8 +463,14 @@ class OrderQueueSyncService {
       await _sb
           .from('prod_plan_stages')
           .insert({...legacyRow, 'step_no': stepNo});
-    } catch (_) {
-      await _sb.from('prod_plan_stages').insert(legacyRow);
+    } catch (error) {
+      _throwIfMissingProdPlanStageId(error);
+      try {
+        await _sb.from('prod_plan_stages').insert(legacyRow);
+      } catch (fallbackError) {
+        _throwIfMissingProdPlanStageId(fallbackError);
+        rethrow;
+      }
     }
   }
 
@@ -465,6 +506,7 @@ class OrderQueueSyncService {
         includeStageGroupKeyFilter: true,
       );
     } catch (error) {
+      _throwIfMissingProdPlanStageId(error);
       if (_isMissingProdPlanStageGroupKey(error)) {
         await run(
           _withoutStageGroupKey(updates),
@@ -475,6 +517,7 @@ class OrderQueueSyncService {
       try {
         await run(updates, includeStageGroupKeyFilter: true);
       } catch (fallbackError) {
+        _throwIfMissingProdPlanStageId(fallbackError);
         if (!_isMissingProdPlanStageGroupKey(fallbackError)) rethrow;
         await run(
           _withoutStageGroupKey(updates),
@@ -546,10 +589,15 @@ class OrderQueueSyncService {
     String bobbinStageId,
   ) async {
     final now = DateTime.now().toIso8601String();
-    await _sb.from('prod_plan_stages').update({
-      'status': 'done',
-      'finished_at': now,
-    }).match({'plan_id': planId, 'stage_id': bobbinStageId});
+    try {
+      await _sb.from('prod_plan_stages').update({
+        'status': 'done',
+        'finished_at': now,
+      }).match({'plan_id': planId, 'stage_id': bobbinStageId});
+    } catch (error) {
+      _throwIfMissingProdPlanStageId(error);
+      rethrow;
+    }
     await _sb.from('tasks').update({
       'status': 'done',
       'completed_at': now,

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -757,6 +757,8 @@ class OrdersProvider with ChangeNotifier {
       try {
         await OrderQueueService(_supabase)
             .createTasksFromSavedQueue(launchOrder.id);
+      } on OrderQueueSyncSchemaOutdatedException catch (e) {
+        return e.message;
       } on StateError catch (e) {
         return 'Не удалось запустить заказ: ${e.message}';
       }
@@ -811,6 +813,8 @@ class OrdersProvider with ChangeNotifier {
         'Заказ запущен в производство. Бумага переведена в резерв',
       );
       return null;
+    } on OrderQueueSyncSchemaOutdatedException catch (e) {
+      return e.message;
     } catch (e, st) {
       debugPrint('❌ launchOrder error: $e\n$st');
       return 'Не удалось запустить заказ: $e';


### PR DESCRIPTION
### Motivation
- Обеспечить понятную обработку серверной ошибки `PGRST204`, возникающей при отсутствии колонки `prod_plan_stages.stage_id`, чтобы не пробрасывать сырый `PostgrestException` в UI.
- Поддержать старые схемы/legacy-сторедж (`production_plans.stages`) или показать человеку понятный текст, что нужно применить миграции Supabase.
- Показать короткое сообщение в `launchOrder` вместо технического `PGRST204`.

### Description
- Добавлен пользовательский тип исключения `OrderQueueSyncSchemaOutdatedException` и сообщение `kOutdatedProdPlanStageIdSchemaMessage` с текстом о необходимости миграций Supabase в `lib/modules/orders/order_queue_sync_service.dart`.
- Добавлен хелпер `_isMissingProdPlanStageId(Object error)` и вспомогательная `_throwIfMissingProdPlanStageId(Object error)` для детекции `PGRST204` с упоминанием `stage_id` и `prod_plan_stages`, и используется для конвертации ошибки в понятное исключение.
- В методах взаимодействия с `prod_plan_stages` (вставка/обновление/удаление по слоту и завершение bobbin) вызовы обёрнуты, чтобы при обнаружении отсутствия `stage_id` выкидывать `OrderQueueSyncSchemaOutdatedException` или применять fallback-ветки (legacy вставка без `stage_group_key`), вместо пробрасывания сырых `PostgrestException`.
- Экспорт нового исключения добавлен в `lib/modules/orders/order_queue_service.dart` и `launchOrder` в `lib/modules/orders/orders_provider.dart` теперь перехватывает `OrderQueueSyncSchemaOutdatedException` и возвращает её `message` пользователю.

### Testing
- Запущена проверка изменений стиля/целостности: `git diff --check` — успешно (ошибок diff/check не найдено).
- Попытки запустить `flutter test` не выполнены в данном окружении, так как `flutter` не установлен (тесты не запускались).
- Попытка выполнить `dart format --set-exit-if-changed` не выполнена в данном окружении, так как `dart` не установлен (форматирование не проверялось автоматически).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc73c2a87c832fb67d1440f20c5e1d)