### PR TITLE
Populate prod_plan_stages.name from saved queue and handle legacy schemas

### DIFF
--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -69,6 +69,21 @@ class OrderQueueSyncEntry {
 
   String get identityKey => '$stageGroupKey::$stageId';
 
+  String get displayName {
+    for (final key in const [
+      'name',
+      'stageName',
+      'stage_name',
+      'workplaceName',
+      'workplace_name',
+      'title',
+    ]) {
+      final value = row[key]?.toString().trim() ?? '';
+      if (value.isNotEmpty) return value;
+    }
+    return stageId;
+  }
+
   bool sameQueueSlot(OrderQueueSyncEntry other) =>
       stageId == other.stageId &&
       stageGroupKey == other.stageGroupKey &&
@@ -366,6 +381,14 @@ class OrderQueueSyncService {
         message.contains('prod_plan_stages');
   }
 
+  static bool _isMissingProdPlanStageName(Object error) {
+    if (error is! PostgrestException) return false;
+    final message = error.message.toLowerCase();
+    return error.code == 'PGRST204' &&
+        message.contains('name') &&
+        message.contains('prod_plan_stages');
+  }
+
   static void _throwIfMissingProdPlanStageId(Object error) {
     if (_isMissingProdPlanStageId(error)) {
       throw const OrderQueueSyncSchemaOutdatedException();
@@ -376,6 +399,12 @@ class OrderQueueSyncService {
     Map<String, dynamic> payload,
   ) {
     return Map<String, dynamic>.from(payload)..remove('stage_group_key');
+  }
+
+  static Map<String, dynamic> _withoutStageName(
+    Map<String, dynamic> payload,
+  ) {
+    return Map<String, dynamic>.from(payload)..remove('name');
   }
 
   Future<void> _deletePlanStageByQueueSlot(
@@ -431,26 +460,41 @@ class OrderQueueSyncService {
       'plan_id': planId,
       'stage_id': next.stageId,
       'stage_group_key': next.stageGroupKey,
+      'name': next.displayName,
       'seq': next.step,
       'status': 'waiting',
     };
     try {
-      await _sb
-          .from('prod_plan_stages')
-          .insert({...row, 'step_no': next.step});
+      await _insertPlanStageWithOptionalStepNo(row, next.step);
     } catch (error) {
       _throwIfMissingProdPlanStageId(error);
       if (_isMissingProdPlanStageGroupKey(error)) {
         await _insertPlanStageWithoutStageGroupKey(row, next.step);
         return;
       }
-      try {
-        await _sb.from('prod_plan_stages').insert(row);
-      } catch (fallbackError) {
-        _throwIfMissingProdPlanStageId(fallbackError);
-        if (!_isMissingProdPlanStageGroupKey(fallbackError)) rethrow;
-        await _insertPlanStageWithoutStageGroupKey(row, next.step);
+      if (_isMissingProdPlanStageName(error)) {
+        await _insertPlanStageWithoutStageName(row, next.step);
+        return;
       }
+      rethrow;
+    }
+  }
+
+  Future<void> _insertPlanStageWithOptionalStepNo(
+    Map<String, dynamic> row,
+    int stepNo,
+  ) async {
+    try {
+      await _sb
+          .from('prod_plan_stages')
+          .insert({...row, 'step_no': stepNo});
+    } catch (error) {
+      _throwIfMissingProdPlanStageId(error);
+      if (_isMissingProdPlanStageGroupKey(error) ||
+          _isMissingProdPlanStageName(error)) {
+        rethrow;
+      }
+      await _sb.from('prod_plan_stages').insert(row);
     }
   }
 
@@ -460,17 +504,31 @@ class OrderQueueSyncService {
   ) async {
     final legacyRow = _withoutStageGroupKey(row);
     try {
-      await _sb
-          .from('prod_plan_stages')
-          .insert({...legacyRow, 'step_no': stepNo});
+      await _insertPlanStageWithOptionalStepNo(legacyRow, stepNo);
     } catch (error) {
       _throwIfMissingProdPlanStageId(error);
-      try {
-        await _sb.from('prod_plan_stages').insert(legacyRow);
-      } catch (fallbackError) {
-        _throwIfMissingProdPlanStageId(fallbackError);
-        rethrow;
-      }
+      if (!_isMissingProdPlanStageName(error)) rethrow;
+      await _insertPlanStageWithOptionalStepNo(
+        _withoutStageName(legacyRow),
+        stepNo,
+      );
+    }
+  }
+
+  Future<void> _insertPlanStageWithoutStageName(
+    Map<String, dynamic> row,
+    int stepNo,
+  ) async {
+    final legacyRow = _withoutStageName(row);
+    try {
+      await _insertPlanStageWithOptionalStepNo(legacyRow, stepNo);
+    } catch (error) {
+      _throwIfMissingProdPlanStageId(error);
+      if (!_isMissingProdPlanStageGroupKey(error)) rethrow;
+      await _insertPlanStageWithOptionalStepNo(
+        _withoutStageGroupKey(legacyRow),
+        stepNo,
+      );
     }
   }
 

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -2113,6 +2113,21 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       // При неполном workplaceLookup (например, из-за RLS) не теряем валидные UUID,
       // но и не пытаемся вставлять невалидные идентификаторы этапов.
       final List<String> __validStageIds = [];
+      String _stageDisplayName(Map<String, dynamic> sm, String fallback) {
+        for (final key in const [
+          'name',
+          'stageName',
+          'stage_name',
+          'workplaceName',
+          'workplace_name',
+          'title',
+        ]) {
+          final value = sm[key]?.toString().trim() ?? '';
+          if (value.isNotEmpty) return value;
+        }
+        return fallback;
+      }
+
       for (final sm in stageMaps) {
         final stageIds = _extractStageIds(sm);
         for (final sid in stageIds) {
@@ -2226,6 +2241,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 'plan_id': planId,
                 'stage_id': stageId,
                 'stage_group_key': groupKey,
+                'name': _stageDisplayName(sm, stageId),
                 'seq': step,
                 'step_no': step,
                 'status': 'waiting',

--- a/test/order_queue_sync_service_test.dart
+++ b/test/order_queue_sync_service_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/order_queue_sync_service.dart';
+
+void main() {
+  test('OrderQueueSyncEntry uses saved stage name for legacy plan inserts', () {
+    const entry = OrderQueueSyncEntry(
+      stageId: 'stage-1',
+      stageGroupKey: 'stage-1',
+      step: 1,
+      row: {'stageName': 'Флексопечать'},
+    );
+
+    expect(entry.displayName, 'Флексопечать');
+  });
+
+  test('OrderQueueSyncEntry falls back to stage id when name is absent', () {
+    const entry = OrderQueueSyncEntry(
+      stageId: 'stage-1',
+      stageGroupKey: 'stage-1',
+      step: 1,
+    );
+
+    expect(entry.displayName, 'stage-1');
+  });
+}


### PR DESCRIPTION
### Motivation
- Fix insertion errors when syncing or launching order queues where `prod_plan_stages.name` was NULL, causing not‑null constraint violations. 
- Preserve compatibility with older database schemas that may lack optional columns like `stage_group_key`, `step_no`, or `name` so synchronization works across deployments. 
- Ensure human‑readable stage names from saved queues are preserved when rebuilding normalized plan stages.

### Description
- Add `displayName` to `OrderQueueSyncEntry` which picks a stage name from `row` keys (`name`, `stageName`, `stage_name`, `workplaceName`, `workplace_name`, `title`) and falls back to `stageId` when absent. (`lib/modules/orders/order_queue_sync_service.dart`).
- Include `name` in payloads written to `prod_plan_stages` and introduce resilient insert/update helpers that try variants (with/without `step_no`, `stage_group_key`, `name`) when the target schema is older. New helpers and checks include `_isMissingProdPlanStageName`, `_withoutStageName`, `_insertPlanStageWithOptionalStepNo`, `_insertPlanStageWithoutStageName` and updated fallback logic. (`lib/modules/orders/order_queue_sync_service.dart`).
- When rebuilding normalized plan rows from the production planning form, populate `name` for inserted `prod_plan_stages` using a `_stageDisplayName` helper to preserve readable names. (`lib/modules/production_planning/form_editor_screen.dart`).
- Add unit tests covering `OrderQueueSyncEntry.displayName` fallback behavior in `test/order_queue_sync_service_test.dart`.

### Testing
- Ran `git diff --check` which produced no warnings. (succeeded)
- Attempted to run `dart format` on changed files but `dart` was not available in the environment (format step not executed). (skipped)
- Attempted to run `flutter test` but `flutter` was not available in the environment, so broader test suite was not executed here. (skipped)
- Added a focused unit test file `test/order_queue_sync_service_test.dart` for the new behavior but it was not executed in CI here due to missing Flutter/Dart runtimes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc756ff504832f9e6f93e2ae38f8b2)