### PR TITLE
Build effective order queue during save

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -167,17 +167,8 @@ List<Map<String, dynamic>> _buildStageMapsForProductionPlanSave({
     required List<Map<String, dynamic>> templateStages,
   }) buildStageQueueFromCurrentDraft,
 }) {
-  if (stagePreviewStages.isNotEmpty) {
-    return stagePreviewStages
-        .map((stage) => Map<String, dynamic>.from(stage))
-        .toList(growable: true);
-  }
-
-  final hasSelectedTemplate = (stageTemplateId ?? '').trim().isNotEmpty;
   return buildStageQueueFromCurrentDraft(
-    templateStages: hasSelectedTemplate
-        ? selectedTemplateStages
-        : const <Map<String, dynamic>>[],
+    templateStages: selectedTemplateStages,
   );
 }
 
@@ -3196,10 +3187,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       return true;
     }
 
-    final bool hasBuiltStageQueue =
-        nextQueueBuildStatus == QueueBuildStatus.built;
-    final bool canLaunchProductionNow =
-        hasBuiltStageQueue && hasEnoughPaperForLaunch();
     final bool wasAlreadyLaunched = widget.order?.assignmentCreated ?? false;
     if (wasAlreadyLaunched) {
       await _loadRuntimeEditLocks();
@@ -3220,6 +3207,24 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     final bool canRebuildProductionPlan = isCreating ||
         !wasAlreadyLaunched ||
         (wasAlreadyLaunched && canResetForRelaunchAfterQueueEdit);
+    // Перед сохранением всегда строим эффективную очередь из текущего черновика,
+    // даже если пользователь не нажимал «Собрать очередь» или шаблон не выбран.
+    var stageMaps = _buildStageQueueFromCurrentDraft(
+      templateStages: _selectedTemplateStageMaps(),
+    );
+    final outcome = await _applyStageRules(stageMaps);
+    stageMaps = outcome.stages;
+    final bool hasEffectiveStageQueue = stageMaps.isNotEmpty;
+    final bool willSaveBuiltStageQueue =
+        canRebuildProductionPlan && hasEffectiveStageQueue;
+    if (willSaveBuiltStageQueue) {
+      _syncSwitchableStageSelectionFields(stageMaps);
+      nextQueueBuildStatus = QueueBuildStatus.built;
+    }
+    final bool hasBuiltStageQueue =
+        nextQueueBuildStatus == QueueBuildStatus.built;
+    final bool canLaunchProductionNow =
+        hasBuiltStageQueue && hasEnoughPaperForLaunch();
     final String nextOrderStatus = wasAlreadyLaunched
         ? widget.order!.status
         : (!hasBuiltStageQueue
@@ -3433,30 +3438,28 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       createdOrUpdatedOrder.pdfUrl = uploadedPath;
       await provider.updateOrder(createdOrUpdatedOrder);
     }
-    if (canRebuildProductionPlan && hasBuiltStageQueue) {
+    if (willSaveBuiltStageQueue) {
       // Сохраняем фактическую очередь заказа через общий сервис.
       // stageTemplateId остаётся метаданным выбора в UI, а не источником истины.
-      final templateStages = _selectedTemplateStageMaps();
-      var stageMaps = _buildStageMapsForProductionPlanSave(
-        stagePreviewStages: _stagePreviewStages,
-        stageTemplateId: _stageTemplateId,
-        selectedTemplateStages: templateStages,
-        buildStageQueueFromCurrentDraft: ({required templateStages}) =>
-            _buildStageQueueFromCurrentDraft(templateStages: templateStages),
-      );
-      final outcome = await _applyStageRules(stageMaps);
-      stageMaps = outcome.stages;
       await _orderQueueService.saveBuiltQueue(
         createdOrUpdatedOrder.id,
         stageMaps,
         <String, String?>{
-          'selected_v_stage': _persistedSelectedVStage(nextQueueBuildStatus),
-          'selected_p_stage': _persistedSelectedPStage(nextQueueBuildStatus),
+          'selected_v_stage': _selectedVStage,
+          'selected_p_stage': _selectedPStage,
         },
         currentQueueSignature,
         completeBobbin: outcome.shouldCompleteBobbin,
         bobbinStageId: outcome.bobbinId,
       );
+      createdOrUpdatedOrder = createdOrUpdatedOrder.copyWith(
+        queueBuildStatus: QueueBuildStatus.built,
+        selectedVStage: _selectedVStage,
+        selectedPStage: _selectedPStage,
+        queueSignature: currentQueueSignature,
+      );
+      _queueBuildStatus = QueueBuildStatus.built;
+      _queueSignature = currentQueueSignature;
     }
 
     // Сначала синхронизируем список красок, чтобы в просмотре заказа

--- a/test/edit_order_screen_cardboard_test.dart
+++ b/test/edit_order_screen_cardboard_test.dart
@@ -5,7 +5,7 @@ import 'package:sheet_clone/modules/orders/stage_queue_builder.dart';
 void main() {
   group('production plan save stage maps', () {
     test(
-      'creates product-type queue without selected template and ends with packaging',
+      'uses selected template stages even without selected template id',
       () {
         List<Map<String, dynamic>>? receivedTemplateStages;
 
@@ -32,7 +32,7 @@ void main() {
           },
         );
 
-        expect(receivedTemplateStages, isEmpty);
+        expect(receivedTemplateStages, isNotEmpty);
         expect(
           stageMaps.map((stage) => stage['stageKey']),
           [
@@ -43,7 +43,7 @@ void main() {
             kPackagingStageId,
           ],
         );
-        expect(stageMaps.first['stageName'], 'Автомат большой');
+        expect(stageMaps.first['stageName'], 'Труба');
         expect(stageMaps.last['stageName'], 'Упаковка');
       },
     );


### PR DESCRIPTION
### Motivation
- Упростить и упрочнить поведение сохранения заказа: всегда формировать эффективную очередь этапов из текущего черновика перед записью, вместо зависимости от флага `hasBuiltStageQueue`.
- Сделать `outcome.stages` единственным источником истины при сохранении нормализованной/JSON-очереди заказа.

### Description
- Перенёс построение очереди перед блоком сохранения и теперь всегда вызываю `_buildStageQueueFromCurrentDraft(templateStages: _selectedTemplateStageMaps())` перед сохранением, независимо от того, нажимал ли пользователь «Собрать очередь» и независимо от пустого `_stageTemplateId`.
- Применяю `_applyStageRules(stageMaps)` и использую `outcome.stages` как источник истины для дальнейших операций и передачи в `_orderQueueService.saveBuiltQueue(...)`.
- Условия сохранения изменены: при `canRebuildProductionPlan` сохраняю построенную очередь, только если она не пустая; при успешном сохранении выставляю `queueBuildStatus` в `QueueBuildStatus.built`, сохраняю `queueSignature`, `selected_v_stage` и `selected_p_stage`, и обновляю локальные `_queueBuildStatus`/`_queueSignature` и модель заказа.
- Упростил хелпер `_buildStageMapsForProductionPlanSave` чтобы он передавал `selectedTemplateStages` напрямую в сборщик очереди, и обновил тест `test/edit_order_screen_cardboard_test.dart` чтобы ожидать применения выбранных шаблонных этапов даже при пустом `stageTemplateId`.

### Testing
- Выполнена проверка диффа с `git diff --check`, которая прошла успешно. 
- Обновлён и запущен тест `test/edit_order_screen_cardboard_test.dart` в коде, но `flutter test` не удалось выполнить в CI-окружении из-за отсутствия Flutter SDK (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc79df4650832fb27745ce386af05b)