### PR TITLE
Handle order queue sync failures and surface save errors

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3441,17 +3441,67 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (willSaveBuiltStageQueue) {
       // Сохраняем фактическую очередь заказа через общий сервис.
       // stageTemplateId остаётся метаданным выбора в UI, а не источником истины.
-      await _orderQueueService.saveBuiltQueue(
-        createdOrUpdatedOrder.id,
-        stageMaps,
-        <String, String?>{
-          'selected_v_stage': _selectedVStage,
-          'selected_p_stage': _selectedPStage,
-        },
-        currentQueueSignature,
-        completeBobbin: outcome.shouldCompleteBobbin,
-        bobbinStageId: outcome.bobbinId,
-      );
+      SaveBuiltQueueResult queueSaveResult;
+      try {
+        queueSaveResult = await _orderQueueService.saveBuiltQueue(
+          createdOrUpdatedOrder.id,
+          stageMaps,
+          <String, String?>{
+            'selected_v_stage': _selectedVStage,
+            'selected_p_stage': _selectedPStage,
+          },
+          currentQueueSignature,
+          completeBobbin: outcome.shouldCompleteBobbin,
+          bobbinStageId: outcome.bobbinId,
+        );
+      } catch (error) {
+        final failedOrder = createdOrUpdatedOrder.copyWith(
+          status: OrderStatus.draft.name,
+          hasMaterialShortage: false,
+          materialShortageMessage: '',
+          queueBuildStatus: QueueBuildStatus.notBuilt,
+          selectedVStage: '',
+          selectedPStage: '',
+          queueSignature: const <String, dynamic>{},
+        );
+        await provider.updateOrder(failedOrder);
+        _queueBuildStatus = QueueBuildStatus.notBuilt;
+        _queueSignature = null;
+        if (mounted) {
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text(
+                error is OrderQueueSaveException
+                    ? error.message
+                    : '$kCreateProductionTasksFailedMessage: $error',
+              ),
+            ),
+          );
+        }
+        return;
+      }
+      if (!queueSaveResult.productionTasksCreated) {
+        final failedOrder = createdOrUpdatedOrder.copyWith(
+          status: OrderStatus.draft.name,
+          hasMaterialShortage: false,
+          materialShortageMessage: '',
+          queueBuildStatus: QueueBuildStatus.notBuilt,
+          selectedVStage: '',
+          selectedPStage: '',
+          queueSignature: const <String, dynamic>{},
+        );
+        await provider.updateOrder(failedOrder);
+        _queueBuildStatus = QueueBuildStatus.notBuilt;
+        _queueSignature = null;
+        if (mounted) {
+          messenger.showSnackBar(
+            const SnackBar(
+              content: Text(kCreateProductionTasksFailedMessage),
+            ),
+          );
+        }
+        return;
+      }
       createdOrUpdatedOrder = createdOrUpdatedOrder.copyWith(
         queueBuildStatus: QueueBuildStatus.built,
         selectedVStage: _selectedVStage,

--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'order_model.dart';
@@ -6,6 +7,9 @@ import 'stage_queue_builder.dart';
 
 export 'order_queue_sync_service.dart'
     show OrderQueueSyncBlockedException, OrderQueueSyncSchemaOutdatedException;
+
+const String kCreateProductionTasksFailedMessage =
+    'Не удалось создать производственные задания';
 
 /// Source priority for a persisted order queue.
 ///
@@ -35,6 +39,29 @@ class SavedOrderQueue {
 
   bool get isEmpty => rows.isEmpty;
   bool get isNotEmpty => rows.isNotEmpty;
+}
+
+class SaveBuiltQueueResult {
+  const SaveBuiltQueueResult({
+    required this.productionTasksCreated,
+    this.legacySchemaFallback = false,
+  });
+
+  final bool productionTasksCreated;
+  final bool legacySchemaFallback;
+}
+
+class OrderQueueSaveException implements Exception {
+  const OrderQueueSaveException([
+    this.message = kCreateProductionTasksFailedMessage,
+    this.cause,
+  ]);
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => message;
 }
 
 class OrderQueueService {
@@ -167,7 +194,7 @@ class OrderQueueService {
     );
   }
 
-  Future<void> saveBuiltQueue(
+  Future<SaveBuiltQueueResult> saveBuiltQueue(
     String orderId,
     List<Map<String, dynamic>> queue,
     Map<String, String?> selections,
@@ -176,7 +203,9 @@ class OrderQueueService {
     String? bobbinStageId,
   }) async {
     final id = orderId.trim();
-    if (id.isEmpty) return;
+    if (id.isEmpty) {
+      return const SaveBuiltQueueResult(productionTasksCreated: false);
+    }
     final rows = queue.map((row) => Map<String, dynamic>.from(row)).toList();
 
     await _upsertLegacyProductionPlan(id, rows);
@@ -188,7 +217,9 @@ class OrderQueueService {
         'selected_p_stage': selections['selected_p_stage'],
         'queue_signature': signature,
       }).eq('id', id);
-    } catch (_) {}
+    } catch (error) {
+      _debugPrintQueueSyncFailure(id, 'orders', error);
+    }
 
     try {
       await syncQueueForExistingOrder(
@@ -197,12 +228,65 @@ class OrderQueueService {
         completeBobbin: completeBobbin,
         bobbinStageId: bobbinStageId,
       );
+      return const SaveBuiltQueueResult(productionTasksCreated: true);
     } on OrderQueueSyncBlockedException {
       rethrow;
-    } catch (_) {
-      // Older deployments may not have normalized plan tables yet; the legacy
-      // saved queue above remains available for loadSavedQueue().
+    } catch (error) {
+      final tableName = _syncFailureTableName(error);
+      _debugPrintQueueSyncFailure(id, tableName, error);
+      if (_isLegacyNormalizedQueueSchemaError(error)) {
+        // Older deployments may not have normalized plan tables yet; the
+        // legacy saved queue above remains available for loadSavedQueue().
+        return const SaveBuiltQueueResult(
+          productionTasksCreated: false,
+          legacySchemaFallback: true,
+        );
+      }
+      throw OrderQueueSaveException(
+        kCreateProductionTasksFailedMessage,
+        error,
+      );
     }
+  }
+
+  static bool _isLegacyNormalizedQueueSchemaError(Object error) {
+    if (error is! PostgrestException) return false;
+    final code = (error.code ?? '').trim();
+    final message = error.message.toLowerCase();
+    final mentionsNormalizedPlanTable =
+        message.contains('prod_plans') || message.contains('prod_plan_stages');
+    if (!mentionsNormalizedPlanTable) return false;
+    return code == '42P01' ||
+        code == '42703' ||
+        code == 'PGRST204' ||
+        code == 'PGRST205';
+  }
+
+  static String _syncFailureTableName(Object error) {
+    if (error is PostgrestException) {
+      final message = error.message.toLowerCase();
+      for (final table in const <String>[
+        'prod_plan_stages',
+        'prod_plans',
+        'tasks',
+        'orders',
+        'production_plans',
+      ]) {
+        if (message.contains(table)) return table;
+      }
+    }
+    return 'prod_plan_stages/tasks';
+  }
+
+  static void _debugPrintQueueSyncFailure(
+    String orderId,
+    String tableName,
+    Object error,
+  ) {
+    debugPrint(
+      'OrderQueueService.saveBuiltQueue failed: orderId=$orderId '
+      'table=$tableName error=$error',
+    );
   }
 
   Future<List<OrderQueueSyncOperation>> syncQueueForExistingOrder(

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 const String kStartedStageQueueChangeMessage =
@@ -225,9 +226,21 @@ class OrderQueueSyncService {
     bool completeBobbin = false,
     String? bobbinStageId,
   }) async {
-    final planId = await _ensurePlan(orderId);
-    final currentStages = await _loadPlanStages(planId);
-    final currentTasks = await _loadTasks(orderId);
+    final planId = await _runTableStep(
+      orderId: orderId,
+      tableName: 'prod_plans',
+      action: () => _ensurePlan(orderId),
+    );
+    final currentStages = await _runTableStep(
+      orderId: orderId,
+      tableName: 'prod_plan_stages',
+      action: () => _loadPlanStages(planId),
+    );
+    final currentTasks = await _runTableStep(
+      orderId: orderId,
+      tableName: 'tasks',
+      action: () => _loadTasks(orderId),
+    );
     final operations = diff(
       currentStages: currentStages,
       currentTasks: currentTasks,
@@ -248,22 +261,42 @@ class OrderQueueSyncService {
         case OrderQueueSyncOperationType.cancelOrDeletePending:
           final current = op.current;
           if (current != null) {
-            await _deletePendingPlanStage(current);
-            await _deletePendingTasks(orderId, current);
+            await _runTableStep<void>(
+              orderId: orderId,
+              tableName: 'prod_plan_stages',
+              action: () => _deletePendingPlanStage(current),
+            );
+            await _runTableStep<void>(
+              orderId: orderId,
+              tableName: 'tasks',
+              action: () => _deletePendingTasks(orderId, current),
+            );
           }
           break;
         case OrderQueueSyncOperationType.updatePending:
           final current = op.current;
           final next = op.next;
           if (current != null && next != null) {
-            await _updatePendingPlanStage(current, next);
-            await _syncPendingTaskGroup(orderId, current, next);
+            await _runTableStep<void>(
+              orderId: orderId,
+              tableName: 'prod_plan_stages',
+              action: () => _updatePendingPlanStage(current, next),
+            );
+            await _runTableStep<void>(
+              orderId: orderId,
+              tableName: 'tasks',
+              action: () => _syncPendingTaskGroup(orderId, current, next),
+            );
           }
           break;
         case OrderQueueSyncOperationType.insert:
           final next = op.next;
           if (next != null) {
-            await _insertPlanStage(planId, next);
+            await _runTableStep<void>(
+              orderId: orderId,
+              tableName: 'prod_plan_stages',
+              action: () => _insertPlanStage(planId, next),
+            );
           }
           break;
         case OrderQueueSyncOperationType.keep:
@@ -272,13 +305,39 @@ class OrderQueueSyncService {
       }
     }
 
-    await _createMissingTasks(orderId, nextQueue);
+    await _runTableStep<void>(
+      orderId: orderId,
+      tableName: 'tasks',
+      action: () => _createMissingTasks(orderId, nextQueue),
+    );
 
-    if (completeBobbin && bobbinStageId != null && bobbinStageId.trim().isNotEmpty) {
-      await _markBobbinDone(planId, orderId, bobbinStageId.trim());
+    if (completeBobbin &&
+        bobbinStageId != null &&
+        bobbinStageId.trim().isNotEmpty) {
+      await _runTableStep<void>(
+        orderId: orderId,
+        tableName: 'prod_plan_stages/tasks',
+        action: () => _markBobbinDone(planId, orderId, bobbinStageId.trim()),
+      );
     }
 
     return operations;
+  }
+
+  Future<T> _runTableStep<T>({
+    required String orderId,
+    required String tableName,
+    required Future<T> Function() action,
+  }) async {
+    try {
+      return await action();
+    } catch (error) {
+      debugPrint(
+        'OrderQueueSyncService.sync failed: orderId=$orderId '
+        'table=$tableName error=$error',
+      );
+      rethrow;
+    }
   }
 
   Future<String> _ensurePlan(String orderId) async {


### PR DESCRIPTION
### Motivation

- Не проглатывать ошибки при сохранении собранной очереди: либо пробрасывать понятное исключение, либо возвращать результат о том, создались ли production tasks, чтобы UI не помечал заказ как готовый к запуску при частичной/фейловой синхронизации.
- Оставить совместимый fallback только для действительно старых схем, определяя конкретные ошибки `PostgrestException` по коду/тексту, и добавить диагностический `debugPrint` с `orderId`/таблицей для быстрого дебага.
- Обработать в UI ошибку сохранения очереди через `SnackBar` и откатить флаг готовности, если задачи/нормализованные план-строки не были созданы.

### Description

- Изменён `saveBuiltQueue` в `lib/modules/orders/order_queue_service.dart` на возвращаемый тип `Future<SaveBuiltQueueResult>` и добавлены типы `SaveBuiltQueueResult` и `OrderQueueSaveException`, а также константа `kCreateProductionTasksFailedMessage`.
- Теперь `saveBuiltQueue` логирует ошибки через `_debugPrintQueueSyncFailure`, распознаёт легаси-схемные ошибки через `_isLegacyNormalizedQueueSchemaError` (проверки `PostgrestException.code/message`) и в случае не-совместимых ошибок бросает `OrderQueueSaveException` с сообщением `Не удалось создать производственные задания`.
- В `lib/modules/orders/order_queue_sync_service.dart` добавлен `_runTableStep`-обёртка, которая логирует `orderId` и `tableName` через `debugPrint` и применяется ко всем операциям чтения/записи таблиц (`prod_plans`, `prod_plan_stages`, `tasks`) для удобной диагностики и единообразной обработки исключений.
- В `lib/modules/orders/edit_order_screen.dart` добавлена обработка результата/исключений от `saveBuiltQueue`: в случае ошибки или в случае legacy-fallback откатывается состояние очереди в `notBuilt`/`draft` (сброс `selectedV/PStage`/`queueSignature`) и показывается `SnackBar` с понятным текстом; успешное помечание заказа как готового делается только если `productionTasksCreated == true`.
- Добавлены необходимые `import 'package:flutter/foundation.dart';` в изменённых файлах для использования `debugPrint`.

### Testing

- Выполнены локальные проверки изменений с `git diff --check`, которые прошли успешно.
- `flutter test` не запускался в контейнере из-за отсутствия Flutter SDK (`/bin/bash: line 1: flutter: command not found`).
- Изменения были закоммичены (`Handle order queue sync failures`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7b04f454832f91b7f8bc58fdeb4f)