### PR TITLE
Compute order status from effective draft queue and keep queue on material shortage

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3221,25 +3221,27 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       _syncSwitchableStageSelectionFields(stageMaps);
       nextQueueBuildStatus = QueueBuildStatus.built;
     }
-    final bool hasBuiltStageQueue =
-        nextQueueBuildStatus == QueueBuildStatus.built;
+    // Статус заказа рассчитываем от эффективной очереди текущего черновика,
+    // а не от того, нажимал ли пользователь кнопку «Собрать очередь».
+    final bool hasQueueForStatus = hasEffectiveStageQueue;
+    final bool hasEnoughMaterialsForQueue = hasEnoughPaperForLaunch();
     final bool canLaunchProductionNow =
-        hasBuiltStageQueue && hasEnoughPaperForLaunch();
+        hasQueueForStatus && hasEnoughMaterialsForQueue;
     final String nextOrderStatus = wasAlreadyLaunched
         ? widget.order!.status
-        : (!hasBuiltStageQueue
+        : (!hasQueueForStatus
             ? OrderStatus.draft.name
             : (canLaunchProductionNow
                 ? OrderStatus.ready_to_start.name
                 : OrderStatus.waiting_materials.name));
     final bool nextHasMaterialShortage = wasAlreadyLaunched
         ? widget.order!.hasMaterialShortage
-        : (hasBuiltStageQueue ? !canLaunchProductionNow : false);
+        : (hasQueueForStatus && !hasEnoughMaterialsForQueue);
     final String shortageMessage = wasAlreadyLaunched
         ? widget.order!.materialShortageMessage
-        : (!hasBuiltStageQueue
+        : (!hasQueueForStatus
             ? ''
-            : (canLaunchProductionNow
+            : (hasEnoughMaterialsForQueue
                 ? ''
                 : 'Недостаточно материала на складе. Пополните склад и запустите заказ вручную.'));
     late OrderModel createdOrUpdatedOrder;
@@ -3553,7 +3555,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         ),
       );
     } else if (!createdOrUpdatedOrder.assignmentCreated &&
-        !hasBuiltStageQueue) {
+        !hasQueueForStatus) {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
@@ -3561,7 +3563,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           ),
         ),
       );
-    } else if (!createdOrUpdatedOrder.assignmentCreated && !canLaunchProductionNow) {
+    } else if (!createdOrUpdatedOrder.assignmentCreated &&
+        !canLaunchProductionNow) {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
@@ -3570,7 +3573,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
           ),
         ),
       );
-    } else if (!createdOrUpdatedOrder.assignmentCreated && canLaunchProductionNow) {
+    } else if (!createdOrUpdatedOrder.assignmentCreated &&
+        canLaunchProductionNow) {
       messenger.showSnackBar(
         const SnackBar(
           content: Text('Заказ сохранён и готов к запуску. Нажмите «Запустить».'),


### PR DESCRIPTION
### Motivation
- Ensure order status and material-shortage flags are derived from the effective queue built from the current draft rather than from prior `queueBuildStatus`, so automatically constructed queues don't leave valid orders in `draft` simply because the user didn't click "Собрать очередь".

### Description
- Build the effective queue from the current draft before status computation and treat a queue as present when `stageMaps.isNotEmpty` (usable via `hasEffectiveStageQueue`).
- Replace the `hasBuiltStageQueue` dependency with `hasQueueForStatus` and compute `hasEnoughMaterialsForQueue` using `hasEnoughPaperForLaunch()` so `nextOrderStatus`, `nextHasMaterialShortage` and `shortageMessage` use the effective queue and actual material availability.
- For new orders set `ready_to_start` when an effective queue exists and materials are sufficient, otherwise set `waiting_materials` while still allowing the queue to be saved (so the queue remains ready after restocking).
- Adjust UI messaging to stop treating an automatically built effective queue as missing just because the user did not press the build button, by showing the "Сначала соберите очередь этапов" hint only when the effective queue is actually empty.

### Testing
- Ran automated static/format checks with `git diff --check` and it reported no issues.
- Attempted to run `flutter test` but the `flutter` tool was not available in the execution environment so widget/unit tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7c49ff70832f809bff742d110b35)