### PR TITLE
Refine edit order queue sync

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -2765,30 +2765,16 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (wasAlreadyLaunched) {
       await _loadRuntimeEditLocks();
     }
-    final bool stageQueueChangedForLaunchedOrder = wasAlreadyLaunched &&
-        ((_stageTemplateId ?? '') != (widget.order?.stageTemplateId ?? '') ||
-            _stageOrderManuallyChanged);
-    final bool queueChangeBlockedByStartedStages =
-        stageQueueChangedForLaunchedOrder && _launchedWithStartedStages;
-    if (queueChangeBlockedByStartedStages) {
-      throw const OrderQueueSyncBlockedException();
-    }
-    final bool canResetForRelaunchAfterQueueEdit =
-        stageQueueChangedForLaunchedOrder && _launchedNoStartedStages;
-    // Перестраивать normalized/JSON-план можно только для нового заказа,
-    // незапущенного заказа или запущенного заказа без активности задач,
-    // который будет снят с производства для ручного повторного запуска.
-    final bool canRebuildProductionPlan = isCreating ||
-        !wasAlreadyLaunched ||
-        (wasAlreadyLaunched && canResetForRelaunchAfterQueueEdit);
+    // Запущенный заказ больше не снимается с производства только из-за
+    // редактирования очереди. OrderQueueSyncService точечно обновляет pending
+    // этапы/задачи и блокирует только изменение защищённых этапов.
     // Перед сохранением всегда строим эффективную очередь из текущего черновика,
     // даже если пользователь не нажимал «Собрать очередь» или шаблон не выбран.
     final stageMaps = _buildStageQueueFromCurrentDraft(
       templateStages: _selectedTemplateStageMaps(),
     );
     final bool hasEffectiveStageQueue = stageMaps.isNotEmpty;
-    final bool willSaveBuiltStageQueue =
-        canRebuildProductionPlan && hasEffectiveStageQueue;
+    final bool willSaveBuiltStageQueue = hasEffectiveStageQueue;
     if (willSaveBuiltStageQueue) {
       _syncSwitchableStageSelectionFields(stageMaps);
       nextQueueBuildStatus = QueueBuildStatus.built;
@@ -2817,7 +2803,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 ? ''
                 : 'Недостаточно материала на складе. Пополните склад и запустите заказ вручную.'));
     late OrderModel createdOrUpdatedOrder;
-    bool resetForRelaunchAfterEdit = false;
     if (widget.order == null) {
       // создаём новый заказ
       final _created = await provider.createOrder(
@@ -2907,9 +2892,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         makeready: _makeready,
         val: _val,
         pdfUrl: widget.order!.pdfUrl,
-        stageTemplateId: queueChangeBlockedByStartedStages
-            ? widget.order!.stageTemplateId
-            : _stageTemplateId,
+        stageTemplateId: _stageTemplateId,
         // На этапе базового сохранения не перетираем уже привязанную форму.
         // Фактическая запись формы всегда выполняется позже в _processFormAssignment.
         hasForm: effectivePersistedHasForm,
@@ -2935,24 +2918,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       );
       await provider.updateOrder(updated);
       createdOrUpdatedOrder = updated;
-      if (wasAlreadyLaunched &&
-          canResetForRelaunchAfterQueueEdit &&
-          mounted) {
-        // Бизнес-правило: если изменили очередь этапов у запущенного заказа,
-        // а этапы ещё не начинались — снимаем заказ с производства и ждём
-        // ручного повторного запуска.
-        await provider.resetLaunchedOrderForRelaunch(updated.id);
-        createdOrUpdatedOrder = createdOrUpdatedOrder.copyWith(
-          assignmentCreated: false,
-          status: nextOrderStatus,
-        );
-        resetForRelaunchAfterEdit = true;
-      }
     }
 
-    final String effectiveNextOrderStatus = resetForRelaunchAfterEdit
-        ? createdOrUpdatedOrder.status
-        : nextOrderStatus;
+    final String effectiveNextOrderStatus = nextOrderStatus;
     if (createdOrUpdatedOrder.status != effectiveNextOrderStatus ||
         createdOrUpdatedOrder.hasMaterialShortage != nextHasMaterialShortage ||
         createdOrUpdatedOrder.materialShortageMessage != shortageMessage) {
@@ -3017,28 +2985,76 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       // stageTemplateId остаётся метаданным выбора в UI, а не источником истины.
       SaveBuiltQueueResult queueSaveResult;
       try {
-        queueSaveResult = await _orderQueueService.saveBuiltQueue(
-          createdOrUpdatedOrder.id,
-          stageMaps,
-          <String, String?>{
-            'selected_v_stage': _selectedVStage,
-            'selected_p_stage': _selectedPStage,
-          },
-          currentQueueSignature,
-        );
+        if (!isCreating && wasAlreadyLaunched) {
+          await _orderQueueService.syncQueueForExistingOrder(
+            createdOrUpdatedOrder.id,
+            stageMaps,
+          );
+          queueSaveResult =
+              const SaveBuiltQueueResult(productionTasksCreated: true);
+        } else {
+          queueSaveResult = await _orderQueueService.saveBuiltQueue(
+            createdOrUpdatedOrder.id,
+            stageMaps,
+            <String, String?>{
+              'selected_v_stage': _selectedVStage,
+              'selected_p_stage': _selectedPStage,
+            },
+            currentQueueSignature,
+          );
+        }
+      } on OrderQueueSyncBlockedException catch (error) {
+        if (!isCreating && widget.order != null) {
+          final restoredQueueState = createdOrUpdatedOrder.copyWith(
+            stageTemplateId: widget.order!.stageTemplateId,
+            queueBuildStatus: widget.order!.queueBuildStatus,
+            selectedVStage: widget.order!.selectedVStage,
+            selectedPStage: widget.order!.selectedPStage,
+            queueSignature: widget.order!.queueSignature,
+          );
+          await provider.updateOrder(restoredQueueState);
+          createdOrUpdatedOrder = restoredQueueState;
+          _queueBuildStatus = widget.order!.queueBuildStatus;
+          _queueSignature = widget.order!.queueSignature;
+        }
+        if (mounted) {
+          messenger.showSnackBar(SnackBar(content: Text(error.message)));
+        }
+        return;
       } catch (error) {
         final failedOrder = createdOrUpdatedOrder.copyWith(
-          status: OrderStatus.draft.name,
-          hasMaterialShortage: false,
-          materialShortageMessage: '',
-          queueBuildStatus: QueueBuildStatus.notBuilt,
-          selectedVStage: '',
-          selectedPStage: '',
-          queueSignature: const <String, dynamic>{},
+          status: isCreating
+              ? OrderStatus.draft.name
+              : createdOrUpdatedOrder.status,
+          hasMaterialShortage:
+              isCreating ? false : createdOrUpdatedOrder.hasMaterialShortage,
+          materialShortageMessage:
+              isCreating ? '' : createdOrUpdatedOrder.materialShortageMessage,
+          stageTemplateId: !isCreating && widget.order != null
+              ? widget.order!.stageTemplateId
+              : createdOrUpdatedOrder.stageTemplateId,
+          queueBuildStatus: isCreating
+              ? QueueBuildStatus.notBuilt
+              : (widget.order?.queueBuildStatus ??
+                  createdOrUpdatedOrder.queueBuildStatus),
+          selectedVStage: isCreating
+              ? ''
+              : (widget.order?.selectedVStage ??
+                  createdOrUpdatedOrder.selectedVStage),
+          selectedPStage: isCreating
+              ? ''
+              : (widget.order?.selectedPStage ??
+                  createdOrUpdatedOrder.selectedPStage),
+          queueSignature: isCreating
+              ? const <String, dynamic>{}
+              : (widget.order?.queueSignature ??
+                  createdOrUpdatedOrder.queueSignature),
         );
         await provider.updateOrder(failedOrder);
-        _queueBuildStatus = QueueBuildStatus.notBuilt;
-        _queueSignature = null;
+        if (isCreating) {
+          _queueBuildStatus = QueueBuildStatus.notBuilt;
+          _queueSignature = null;
+        }
         if (mounted) {
           messenger.showSnackBar(
             SnackBar(
@@ -3099,23 +3115,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
     // Бизнес-правило: в создании/редактировании заказа списание бумаги отключено полностью.
 
-    if (queueChangeBlockedByStartedStages) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text(
-            'Изменены только разрешённые поля заказа. Очередь этапов нельзя изменить после начала выполнения этапов.',
-          ),
-        ),
-      );
-    } else if (resetForRelaunchAfterEdit) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text(
-            'Заказ обновлён и снят с производства. Для продолжения запустите его повторно.',
-          ),
-        ),
-      );
-    } else if (!createdOrUpdatedOrder.assignmentCreated &&
+    if (!createdOrUpdatedOrder.assignmentCreated &&
         nextQueueBuildStatus == QueueBuildStatus.outdated) {
       messenger.showSnackBar(
         const SnackBar(

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 const String kStartedStageQueueChangeMessage =
-    'Нельзя изменить этап, который уже находится в работе. Завершите или отмените текущий этап перед изменением очереди.';
+    'Нельзя изменить уже начатый или завершённый этап.';
 
 const String kOutdatedProdPlanStageIdSchemaMessage =
     'Схема базы данных устарела: отсутствует prod_plan_stages.stage_id. Примените миграции Supabase';
@@ -147,6 +147,13 @@ class OrderQueueSyncService {
   static String _normalizeStatus(dynamic status) =>
       (status?.toString() ?? '').trim().toLowerCase().replaceAll('-', '_');
 
+  static String protectedStageChangeMessage(OrderQueueSyncEntry entry) {
+    final status = entry.status.trim();
+    final statusSuffix = status.isEmpty ? '' : ' (статус: $status)';
+    return 'Нельзя изменить уже начатый или завершённый этап '
+        '«${entry.displayName}»$statusSuffix. Измените только ожидающие этапы.';
+  }
+
   static List<OrderQueueSyncOperation> diff({
     required List<OrderQueueSyncEntry> currentStages,
     required List<OrderQueueSyncEntry> currentTasks,
@@ -167,7 +174,7 @@ class OrderQueueSyncService {
           operations.add(OrderQueueSyncOperation(
             type: OrderQueueSyncOperationType.block,
             current: current,
-            reason: kStartedStageQueueChangeMessage,
+            reason: protectedStageChangeMessage(current),
           ));
         } else {
           operations.add(OrderQueueSyncOperation(
@@ -178,11 +185,18 @@ class OrderQueueSyncService {
         continue;
       }
 
-      if (current.sameQueueSlot(next) || isProtectedStatus(current.status)) {
+      if (current.sameQueueSlot(next)) {
         operations.add(OrderQueueSyncOperation(
           type: OrderQueueSyncOperationType.keep,
           current: current,
           next: next,
+        ));
+      } else if (isProtectedStatus(current.status)) {
+        operations.add(OrderQueueSyncOperation(
+          type: OrderQueueSyncOperationType.block,
+          current: current,
+          next: next,
+          reason: protectedStageChangeMessage(current),
         ));
       } else {
         operations.add(OrderQueueSyncOperation(
@@ -194,14 +208,16 @@ class OrderQueueSyncService {
     }
 
     for (final task in currentTasks) {
-      if (nextByKey.containsKey(task.identityKey)) continue;
+      final next = nextByKey[task.identityKey];
+      if (next != null && task.sameQueueSlot(next)) continue;
       if (isProtectedStatus(task.status)) {
         operations.add(OrderQueueSyncOperation(
           type: OrderQueueSyncOperationType.block,
           current: task,
-          reason: kStartedStageQueueChangeMessage,
+          next: next,
+          reason: protectedStageChangeMessage(task),
         ));
-      } else {
+      } else if (next == null) {
         operations.add(OrderQueueSyncOperation(
           type: OrderQueueSyncOperationType.cancelOrDeletePending,
           current: task,

--- a/test/order_queue_sync_service_test.dart
+++ b/test/order_queue_sync_service_test.dart
@@ -22,4 +22,77 @@ void main() {
 
     expect(entry.displayName, 'stage-1');
   });
+
+  test('diff updates pending stages even when protected stages stay unchanged', () {
+    const protectedStage = OrderQueueSyncEntry(
+      stageId: 'print',
+      stageGroupKey: 'print',
+      step: 1,
+      status: 'in_progress',
+      row: {'name': 'Печать'},
+    );
+    const pendingStage = OrderQueueSyncEntry(
+      stageId: 'pack',
+      stageGroupKey: 'pack',
+      step: 2,
+      status: 'waiting',
+      row: {'name': 'Упаковка'},
+    );
+    const nextProtectedStage = OrderQueueSyncEntry(
+      stageId: 'print',
+      stageGroupKey: 'print',
+      step: 1,
+    );
+    const nextPendingStage = OrderQueueSyncEntry(
+      stageId: 'pack',
+      stageGroupKey: 'pack',
+      step: 3,
+    );
+
+    final operations = OrderQueueSyncService.diff(
+      currentStages: const [protectedStage, pendingStage],
+      currentTasks: const [protectedStage, pendingStage],
+      nextQueue: const [nextProtectedStage, nextPendingStage],
+    );
+
+    expect(
+      operations.where((op) => op.type == OrderQueueSyncOperationType.block),
+      isEmpty,
+    );
+    expect(
+      operations.any((op) =>
+          op.type == OrderQueueSyncOperationType.updatePending &&
+          op.current?.stageId == 'pack' &&
+          op.next?.step == 3),
+      isTrue,
+    );
+  });
+
+  test('diff blocks moving a protected stage with a concrete message', () {
+    const protectedStage = OrderQueueSyncEntry(
+      stageId: 'print',
+      stageGroupKey: 'print',
+      step: 1,
+      status: 'started',
+      row: {'name': 'Печать'},
+    );
+    const movedProtectedStage = OrderQueueSyncEntry(
+      stageId: 'print',
+      stageGroupKey: 'print',
+      step: 2,
+    );
+
+    final operations = OrderQueueSyncService.diff(
+      currentStages: const [protectedStage],
+      currentTasks: const [protectedStage],
+      nextQueue: const [movedProtectedStage],
+    );
+
+    final blocked = operations.where(
+      (op) => op.type == OrderQueueSyncOperationType.block,
+    );
+    expect(blocked, isNotEmpty);
+    expect(blocked.first.reason, contains('Печать'));
+    expect(blocked.first.reason, contains('started'));
+  });
 }


### PR DESCRIPTION
### Motivation

- Ensure saving an edited order always recomputes the effective stage queue from the current draft so plan rows/tasks reflect UI changes (paints, width B, trimming, cardboard, handles, etc.).
- Allow safe automatic updates of pending stages/tasks for already-launched orders instead of leaving the order in an `outdated` state or forcing a production reset. 
- Block only concrete changes to started/completed stages/tasks and present the user with a specific, actionable message when such protected changes are attempted. 

### Description

- Rebuild effective queue on every save and, when saving a launched order, call `OrderQueueService.syncQueueForExistingOrder` to apply targeted updates to `prod_plan_stages`/`tasks` instead of marking the order outdated or resetting production; changes are applied using existing queue mapper/normalized plan flows (`lib/modules/orders/edit_order_screen.dart`).
- Update `OrderQueueSyncService.diff` and messaging to: allow updates of pending slots, only block operations that would move/remove protected stages/tasks, and produce a concrete message including the stage display name and status (`lib/modules/orders/order_queue_sync_service.dart`).
- When sync is blocked by protected stages/tasks, the editor restores the prior queue state for the order and shows the `OrderQueueSyncBlockedException` message to the user (`lib/modules/orders/edit_order_screen.dart`).
- Add unit tests covering the diff behavior for mixed protected/pending scenarios and ensuring blocked operations carry a concrete message (`test/order_queue_sync_service_test.dart`).

### Testing

- Added unit tests in `test/order_queue_sync_service_test.dart` validating that pending stage updates are produced alongside unchanged protected stages and that protected-stage moves are blocked with a message; tests exist but were not executed in this environment.
- Basic repository checks passed locally; code formatting and `flutter test` were not executed because `dart`/`flutter` were not available in the runtime used for these changes.
- Manual review of affected flows ensured that changes to paints, product width B, trimming, cardboard and handle selections are represented in the rebuilt queue so `prod_plan_stages` and `tasks` will be updated through the sync path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7ee24880832f8f0a36c69dd6f0ec)