### PR TITLE
Fix duplicate production stage sequence sync

### DIFF
--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -459,7 +459,24 @@ class OrderQueueMapper {
       fallbackStep += 1;
     }
 
-    return result;
+    return _withUniqueSteps(result);
+  }
+
+  static List<OrderQueueSyncEntry> _withUniqueSteps(
+    List<OrderQueueSyncEntry> entries,
+  ) {
+    final normalized = <OrderQueueSyncEntry>[];
+    var lastStep = 0;
+    for (final entry in entries) {
+      final requestedStep = entry.step > 0 ? entry.step : lastStep + 1;
+      final uniqueStep =
+          requestedStep <= lastStep ? lastStep + 1 : requestedStep;
+      normalized.add(
+        uniqueStep == entry.step ? entry : entry.copyWith(step: uniqueStep),
+      );
+      lastStep = uniqueStep;
+    }
+    return normalized;
   }
 
   static List<String> stageIdsFromRow(Map<String, dynamic> row) {

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -272,53 +272,59 @@ class OrderQueueSyncService {
       );
     }
 
-    for (final op in operations) {
-      switch (op.type) {
-        case OrderQueueSyncOperationType.cancelOrDeletePending:
-          final current = op.current;
-          if (current != null) {
-            await _runTableStep<void>(
-              orderId: orderId,
-              tableName: 'prod_plan_stages',
-              action: () => _deletePendingPlanStage(current),
-            );
-            await _runTableStep<void>(
-              orderId: orderId,
-              tableName: 'tasks',
-              action: () => _deletePendingTasks(orderId, current),
-            );
-          }
-          break;
-        case OrderQueueSyncOperationType.updatePending:
-          final current = op.current;
-          final next = op.next;
-          if (current != null && next != null) {
-            await _runTableStep<void>(
-              orderId: orderId,
-              tableName: 'prod_plan_stages',
-              action: () => _updatePendingPlanStage(current, next),
-            );
-            await _runTableStep<void>(
-              orderId: orderId,
-              tableName: 'tasks',
-              action: () => _syncPendingTaskGroup(orderId, current, next),
-            );
-          }
-          break;
-        case OrderQueueSyncOperationType.insert:
-          final next = op.next;
-          if (next != null) {
-            await _runTableStep<void>(
-              orderId: orderId,
-              tableName: 'prod_plan_stages',
-              action: () => _insertPlanStage(planId, next),
-            );
-          }
-          break;
-        case OrderQueueSyncOperationType.keep:
-        case OrderQueueSyncOperationType.block:
-          break;
-      }
+    for (final op in operations.where(
+      (op) => op.type == OrderQueueSyncOperationType.cancelOrDeletePending,
+    )) {
+      final current = op.current;
+      if (current == null) continue;
+      await _runTableStep<void>(
+        orderId: orderId,
+        tableName: 'prod_plan_stages',
+        action: () => _deletePendingPlanStage(current),
+      );
+      await _runTableStep<void>(
+        orderId: orderId,
+        tableName: 'tasks',
+        action: () => _deletePendingTasks(orderId, current),
+      );
+    }
+
+    final updateOperations = operations
+        .where((op) => op.type == OrderQueueSyncOperationType.updatePending)
+        .toList(growable: false);
+    final parkedUpdates = await _runTableStep<Map<String, OrderQueueSyncEntry>>(
+      orderId: orderId,
+      tableName: 'prod_plan_stages',
+      action: () => _parkPendingPlanStageUpdates(updateOperations),
+    );
+
+    for (final op in updateOperations) {
+      final current = op.current;
+      final next = op.next;
+      if (current == null || next == null) continue;
+      final parkedCurrent = parkedUpdates[current.identityKey] ?? current;
+      await _runTableStep<void>(
+        orderId: orderId,
+        tableName: 'prod_plan_stages',
+        action: () => _updatePendingPlanStage(parkedCurrent, next),
+      );
+      await _runTableStep<void>(
+        orderId: orderId,
+        tableName: 'tasks',
+        action: () => _syncPendingTaskGroup(orderId, current, next),
+      );
+    }
+
+    for (final op in operations.where(
+      (op) => op.type == OrderQueueSyncOperationType.insert,
+    )) {
+      final next = op.next;
+      if (next == null) continue;
+      await _runTableStep<void>(
+        orderId: orderId,
+        tableName: 'prod_plan_stages',
+        action: () => _insertPlanStage(planId, next),
+      );
     }
 
     await _runTableStep<void>(
@@ -658,6 +664,29 @@ class OrderQueueSyncService {
         );
       }
     }
+  }
+
+  Future<Map<String, OrderQueueSyncEntry>> _parkPendingPlanStageUpdates(
+    List<OrderQueueSyncOperation> updateOperations,
+  ) async {
+    if (updateOperations.length < 2) {
+      return const <String, OrderQueueSyncEntry>{};
+    }
+    final parked = <String, OrderQueueSyncEntry>{};
+    var offset = 0;
+    for (final op in updateOperations) {
+      final current = op.current;
+      if (current == null) continue;
+      final tempStep = -1000000 - offset;
+      offset += 1;
+      await _updatePlanStageWithOptionalStepNo(
+        current,
+        {'seq': tempStep},
+        tempStep,
+      );
+      parked[current.identityKey] = current.copyWith(step: tempStep);
+    }
+    return parked;
   }
 
   Future<void> _deletePendingTasks(

--- a/test/order_queue_sync_service_test.dart
+++ b/test/order_queue_sync_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/order_queue_service.dart';
 import 'package:sheet_clone/modules/orders/order_queue_sync_service.dart';
 
 void main() {
@@ -94,5 +95,28 @@ void main() {
     expect(blocked, isNotEmpty);
     expect(blocked.first.reason, contains('Печать'));
     expect(blocked.first.reason, contains('started'));
+  });
+
+  test('OrderQueueMapper assigns unique steps for alternative workplaces', () {
+    final entries = OrderQueueMapper.toSyncEntries(const [
+      {
+        'stageKey': 'die_cut',
+        'stageId': 'die-cut-a1',
+        'workplaceIds': ['die-cut-a1', 'die-cut-a2'],
+        'order': 3,
+      },
+      {
+        'stageKey': 'pack',
+        'stageId': 'pack',
+        'order': 4,
+      },
+    ]);
+
+    expect(entries.map((entry) => entry.step), [3, 4, 5]);
+    expect(entries.map((entry) => entry.stageId), [
+      'die-cut-a1',
+      'die-cut-a2',
+      'pack',
+    ]);
   });
 }


### PR DESCRIPTION
### Motivation
- Prevent unique-key violations on `prod_plan_stages(plan_id, seq)` that occurred when expanding alternative workplace IDs into multiple rows with identical `seq` values. 
- Make queue synchronization robust against ordering conflicts when updating/inserting/deleting pending plan-stage rows.

### Description
- Normalize mapped queue entries so expanded workplace alternatives receive unique sequence numbers by adding `_withUniqueSteps` and returning it from `OrderQueueMapper.toSyncEntries()` (changes in `lib/modules/orders/order_queue_service.dart`).
- Rework `OrderQueueSyncService.sync` to apply mutations in phases: delete pending removals first, park pending updates on temporary negative `seq` values with `_parkPendingPlanStageUpdates`, then apply final updates and inserts to avoid `prod_plan_stages_plan_id_seq_key` conflicts (changes in `lib/modules/orders/order_queue_sync_service.dart`).
- Add a unit test to cover the alternative-workplace expansion scenario ensuring unique steps are assigned (`test/order_queue_sync_service_test.dart`).

### Testing
- Ran `git diff --check` which reported no issues. 
- Added a unit test `OrderQueueMapper assigns unique steps for alternative workplaces` but `flutter test` was not executed in this environment because the Flutter SDK is not installed (`flutter: command not found`).
- `dart format` was not executed in this environment because the Dart SDK is not installed (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc83ecc620832fa31daf98e86162a8)