### PR TITLE
Fix duplicate prod_plan_stages sequence conflicts by using physicalSeq

### DIFF
--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -54,6 +54,7 @@ class OrderQueueSyncSchemaOutdatedException implements Exception {
 class OrderQueueSyncEntry {
   const OrderQueueSyncEntry({
     this.id,
+    this.physicalSeq,
     required this.stageId,
     required this.stageGroupKey,
     required this.step,
@@ -62,6 +63,7 @@ class OrderQueueSyncEntry {
   });
 
   final String? id;
+  final int? physicalSeq;
   final String stageId;
   final String stageGroupKey;
   final int step;
@@ -92,6 +94,7 @@ class OrderQueueSyncEntry {
 
   OrderQueueSyncEntry copyWith({
     String? id,
+    int? physicalSeq,
     String? stageId,
     String? stageGroupKey,
     int? step,
@@ -100,6 +103,7 @@ class OrderQueueSyncEntry {
   }) {
     return OrderQueueSyncEntry(
       id: id ?? this.id,
+      physicalSeq: physicalSeq ?? this.physicalSeq,
       stageId: stageId ?? this.stageId,
       stageGroupKey: stageGroupKey ?? this.stageGroupKey,
       step: step ?? this.step,
@@ -298,6 +302,8 @@ class OrderQueueSyncService {
       action: () => _parkPendingPlanStageUpdates(updateOperations),
     );
 
+    final physicalSeqByKey = physicalSeqByIdentityKey(nextQueue);
+
     for (final op in updateOperations) {
       final current = op.current;
       final next = op.next;
@@ -306,7 +312,11 @@ class OrderQueueSyncService {
       await _runTableStep<void>(
         orderId: orderId,
         tableName: 'prod_plan_stages',
-        action: () => _updatePendingPlanStage(parkedCurrent, next),
+        action: () => _updatePendingPlanStage(
+          parkedCurrent,
+          next,
+          physicalSeqByKey[next.identityKey] ?? next.step,
+        ),
       );
       await _runTableStep<void>(
         orderId: orderId,
@@ -323,7 +333,11 @@ class OrderQueueSyncService {
       await _runTableStep<void>(
         orderId: orderId,
         tableName: 'prod_plan_stages',
-        action: () => _insertPlanStage(planId, next),
+        action: () => _insertPlanStage(
+          planId,
+          next,
+          physicalSeqByKey[next.identityKey] ?? next.step,
+        ),
       );
     }
 
@@ -417,7 +431,8 @@ class OrderQueueSyncService {
       id: row['id']?.toString(),
       stageId: stageId,
       stageGroupKey: groupKey.isEmpty ? stageId : groupKey,
-      step: _readInt(row['seq'] ?? row['step_no'] ?? row['step']),
+      step: _readInt(row['step_no'] ?? row['step'] ?? row['seq']),
+      physicalSeq: _readNullableInt(row['seq']),
       status: (row['status'] ?? 'waiting').toString(),
       row: row,
     );
@@ -440,10 +455,46 @@ class OrderQueueSyncService {
     );
   }
 
-  static int _readInt(dynamic value) {
+  static int _readInt(dynamic value) => _readNullableInt(value) ?? 0;
+
+  static int? _readNullableInt(dynamic value) {
     if (value is int) return value;
     if (value is num) return value.toInt();
-    return int.tryParse(value?.toString() ?? '') ?? 0;
+    return int.tryParse(value?.toString() ?? '');
+  }
+
+  @visibleForTesting
+  static Map<String, int> physicalSeqByIdentityKey(
+    List<OrderQueueSyncEntry> queue,
+  ) {
+    final stepCounts = <int, int>{};
+    for (final entry in queue) {
+      stepCounts[entry.step] = (stepCounts[entry.step] ?? 0) + 1;
+    }
+
+    final stepOffsets = <int, int>{};
+    final usedSeqs = <int>{};
+    final result = <String, int>{};
+    for (final entry in queue) {
+      final count = stepCounts[entry.step] ?? 0;
+      if (count <= 1) {
+        result[entry.identityKey] = entry.step;
+        usedSeqs.add(entry.step);
+        continue;
+      }
+
+      var offset = stepOffsets[entry.step] ?? 0;
+      var candidate = entry.step * 1000 + offset;
+      while (usedSeqs.contains(candidate) ||
+          stepCounts.containsKey(candidate)) {
+        offset += 1;
+        candidate = entry.step * 1000 + offset;
+      }
+      stepOffsets[entry.step] = offset + 1;
+      usedSeqs.add(candidate);
+      result[entry.identityKey] = candidate;
+    }
+    return result;
   }
 
   static bool _isMissingProdPlanStageGroupKey(Object error) {
@@ -500,7 +551,7 @@ class OrderQueueSyncService {
       query.eq('stage_group_key', current.stageGroupKey);
     }
     try {
-      await query.eq('seq', current.step);
+      await query.eq('seq', current.physicalSeq ?? current.step);
     } catch (error) {
       _throwIfMissingProdPlanStageId(error);
       rethrow;
@@ -523,11 +574,12 @@ class OrderQueueSyncService {
   Future<void> _updatePendingPlanStage(
     OrderQueueSyncEntry current,
     OrderQueueSyncEntry next,
+    int physicalSeq,
   ) async {
     final updates = {
       'stage_id': next.stageId,
       'stage_group_key': next.stageGroupKey,
-      'seq': next.step,
+      'seq': physicalSeq,
       'status': 'waiting',
     };
     await _updatePlanStageWithOptionalStepNo(current, updates, next.step);
@@ -536,13 +588,14 @@ class OrderQueueSyncService {
   Future<void> _insertPlanStage(
     String planId,
     OrderQueueSyncEntry next,
+    int physicalSeq,
   ) async {
     final row = {
       'plan_id': planId,
       'stage_id': next.stageId,
       'stage_group_key': next.stageGroupKey,
       'name': next.displayName,
-      'seq': next.step,
+      'seq': physicalSeq,
       'status': 'waiting',
     };
     try {
@@ -636,7 +689,7 @@ class OrderQueueSyncService {
       if (includeStageGroupKeyFilter) {
         query.eq('stage_group_key', current.stageGroupKey);
       }
-      await query.eq('seq', current.step);
+      await query.eq('seq', current.physicalSeq ?? current.step);
     }
 
     try {
@@ -684,7 +737,10 @@ class OrderQueueSyncService {
         {'seq': tempStep},
         tempStep,
       );
-      parked[current.identityKey] = current.copyWith(step: tempStep);
+      parked[current.identityKey] = current.copyWith(
+        step: tempStep,
+        physicalSeq: tempStep,
+      );
     }
     return parked;
   }

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -1417,9 +1417,9 @@ class TaskProvider with ChangeNotifier {
               final o = r['order'] ??
                   r['position'] ??
                   r['idx'] ??
-                  r['seq'] ??
                   r['step_no'] ??
                   r['step'] ??
+                  r['seq'] ??
                   0;
               final oi = (o is int) ? o : int.tryParse(o.toString()) ?? 0;
               if (oi > maxOrder) maxOrder = oi;
@@ -1429,9 +1429,9 @@ class TaskProvider with ChangeNotifier {
               final o = r['order'] ??
                   r['position'] ??
                   r['idx'] ??
-                  r['seq'] ??
                   r['step_no'] ??
                   r['step'] ??
+                  r['seq'] ??
                   0;
               final oi = (o is int) ? o : int.tryParse(o.toString()) ?? 0;
               if (oi == maxOrder) {

--- a/test/order_queue_sync_service_test.dart
+++ b/test/order_queue_sync_service_test.dart
@@ -145,4 +145,37 @@ void main() {
     expect(entries.map((entry) => entry.step), [1, 2]);
   });
 
+  test('physical seq stays unique for parallel stages on the same logical step', () {
+    const firstAlternative = OrderQueueSyncEntry(
+      stageId: 'die-cut-a1',
+      stageGroupKey: 'die_cut',
+      step: 3,
+    );
+    const secondAlternative = OrderQueueSyncEntry(
+      stageId: 'die-cut-a2',
+      stageGroupKey: 'die_cut',
+      step: 3,
+    );
+    const nextStage = OrderQueueSyncEntry(
+      stageId: 'pack',
+      stageGroupKey: 'pack',
+      step: 4,
+    );
+    const farStage = OrderQueueSyncEntry(
+      stageId: 'far-stage',
+      stageGroupKey: 'far-stage',
+      step: 3000,
+    );
+
+    final physicalSeq = OrderQueueSyncService.physicalSeqByIdentityKey(
+      const [firstAlternative, secondAlternative, nextStage, farStage],
+    );
+
+    expect(physicalSeq[firstAlternative.identityKey], 3001);
+    expect(physicalSeq[secondAlternative.identityKey], 3002);
+    expect(physicalSeq[nextStage.identityKey], 4);
+    expect(physicalSeq[farStage.identityKey], 3000);
+    expect(physicalSeq.values.toSet(), hasLength(4));
+  });
+
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate-key errors on `prod_plan_stages(plan_id, seq)` when parallel/alternative stages share the same logical queue step by separating persisted physical sequence from logical step ordering.
- Preserve logical ordering semantics (`step` / `step_no`) while ensuring DB-level `seq` used for inserts/updates is unique per `(plan_id, seq)`.

### Description
- Added a nullable `physicalSeq` field to `OrderQueueSyncEntry` and populated it from existing `seq` rows so the code can distinguish logical `step` from the physical DB sequence used for matching. (`OrderQueueSyncEntry` in `lib/modules/orders/order_queue_sync_service.dart`)
- Implemented `physicalSeqByIdentityKey` to allocate unique physical sequence values for entries that share the same logical `step`, with collision avoidance against existing logical sequence values. (new helper in `order_queue_sync_service.dart`)
- Applied the generated `physicalSeq` when inserting and updating `prod_plan_stages`, and when deleting plan-stage rows, while still writing the logical order to `step_no` when applicable. (insertion/update/delete paths in `order_queue_sync_service.dart`)
- Prefer reading logical order from `step_no` before `seq` and expose `seq` as `physicalSeq` to avoid treating synthetic physical values as logical order, and updated last-stage detection to follow the same priority. (`_entryFromPlanRow`, `_readNullableInt` and `lib/modules/tasks/task_provider.dart`)
- Added a unit test that verifies unique physical sequence allocation for parallel stages sharing the same logical step. (`test/order_queue_sync_service_test.dart`)

### Testing
- Ran `git diff --check` to validate no obvious diff/errors produced by the edit and it passed without warnings.
- Attempted to run `flutter test test/order_queue_sync_service_test.dart` but the environment does not have Flutter installed so the unit test could not be executed here (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7487949c832fa65b158f6b8732ed)