### PR TITLE
Show planned production stages without tasks

### DIFF
--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -116,6 +116,34 @@ bool _orderCompletedByGroups(
   return true;
 }
 
+Map<String, String> _stageGroupLookupForGroups(
+  Map<String, _StageGroupInfo> groups,
+) {
+  final lookup = <String, String>{};
+  for (final entry in groups.entries) {
+    for (final stageId in entry.value.stageIds) {
+      lookup[stageId] = entry.key;
+    }
+  }
+  return lookup;
+}
+
+Map<String, List<TaskModel>> _tasksByStageGroup(
+  List<TaskModel> orderTasks,
+  Map<String, String> lookup,
+) {
+  final byGroup = <String, List<TaskModel>>{};
+  for (final task in orderTasks) {
+    final normalizedStageId = task.stageId.trim();
+    final persistedGroup = task.stageGroupKey.trim();
+    final groupKey = persistedGroup.isNotEmpty
+        ? persistedGroup
+        : (lookup[normalizedStageId] ?? normalizedStageId);
+    byGroup.putIfAbsent(groupKey, () => []).add(task);
+  }
+  return byGroup;
+}
+
 String _stageLabel(
   String stageId,
   TaskProvider tasks,
@@ -329,6 +357,30 @@ List<String> productionStageLabelsForTesting({
   return groups.values.map((group) => group.label).toList(growable: false);
 }
 
+@visibleForTesting
+List<TaskStatus> productionStageStatusesForTesting({
+  required OrderModel order,
+  required List<TaskModel> orderTasks,
+  required Iterable<String> plannedSequence,
+  Map<String, String> stageGroupMap = const <String, String>{},
+  Map<String, String> stageNames = const <String, String>{},
+  List<TemplateModel> templates = const <TemplateModel>[],
+}) {
+  final groups = _buildProductionStageGroupsForOrder(
+    order: order,
+    orderTasks: orderTasks,
+    plannedSequence: plannedSequence,
+    stageGroupMap: stageGroupMap,
+    templates: templates,
+    labelForStage: (stageId) => stageNames[stageId] ?? stageId,
+  );
+  final lookup = _stageGroupLookupForGroups(groups);
+  final tasksByGroup = _tasksByStageGroup(orderTasks, lookup);
+  return groups.values
+      .map((group) => _groupStatus(tasksByGroup[group.key] ?? const []))
+      .toList(growable: false);
+}
+
 class ProductionScreen extends StatefulWidget {
   const ProductionScreen({super.key});
 
@@ -479,9 +531,6 @@ class _ProductionScreenState extends State<ProductionScreen>
 
     for (final group in groups) {
       final tasksForStage = tasksByGroup[group.key] ?? const <TaskModel>[];
-      if (tasksForStage.isEmpty) {
-        continue;
-      }
       final status = _groupStatus(tasksForStage);
       final color = _stageColor(status);
       final label = group.label;
@@ -507,13 +556,6 @@ class _ProductionScreenState extends State<ProductionScreen>
           ],
         ),
       ));
-    }
-
-    if (chips.isEmpty) {
-      return const Text(
-        'Этапы не назначены',
-        style: TextStyle(color: Colors.black54),
-      );
     }
 
     return SingleChildScrollView(
@@ -874,39 +916,13 @@ class _ProductionTab extends StatelessWidget {
     );
   }
 
-  Map<String, String> _stageGroupLookup(Map<String, _StageGroupInfo> groups) {
-    final lookup = <String, String>{};
-    for (final entry in groups.entries) {
-      for (final stageId in entry.value.stageIds) {
-        lookup[stageId] = entry.key;
-      }
-    }
-    return lookup;
-  }
-
-  Map<String, List<TaskModel>> _tasksByGroup(
-    List<TaskModel> orderTasks,
-    Map<String, String> lookup,
-  ) {
-    final byGroup = <String, List<TaskModel>>{};
-    for (final task in orderTasks) {
-      final normalizedStageId = task.stageId.trim();
-      final persistedGroup = task.stageGroupKey.trim();
-      final groupKey = persistedGroup.isNotEmpty
-          ? persistedGroup
-          : (lookup[normalizedStageId] ?? normalizedStageId);
-      byGroup.putIfAbsent(groupKey, () => []).add(task);
-    }
-    return byGroup;
-  }
-
   _OrderGroupingData _groupingForOrder(
     OrderModel order,
     List<TaskModel> orderTasks,
   ) {
     final stageGroups = _stageGroupsForOrder(order, orderTasks);
-    final lookup = _stageGroupLookup(stageGroups);
-    final tasksByGroup = _tasksByGroup(orderTasks, lookup);
+    final lookup = _stageGroupLookupForGroups(stageGroups);
+    final tasksByGroup = _tasksByStageGroup(orderTasks, lookup);
     final visibleWorkplaceIds = <String>{};
     for (final task in orderTasks) {
       final normalizedStageId = task.stageId.trim();
@@ -1019,6 +1035,12 @@ class _ProductionTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      taskProvider.ensureStageSequencesForOrders(
+        orders.map((order) => order.id),
+      );
+    });
+
     final tasksByOrder = <String, List<TaskModel>>{};
     for (final task in allTasks) {
       tasksByOrder.putIfAbsent(task.orderId, () => []).add(task);

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -40,6 +40,7 @@ class TaskProvider with ChangeNotifier {
   final Map<String, List<String>> _orderStageSequences = {};
   final Map<String, Map<String, String>> _orderStageNames = {};
   final Map<String, Map<String, String>> _orderStageGroupMaps = {};
+  final Set<String> _loadedStageSequenceOrderIds = <String>{};
   RealtimeChannel? _tasksChannel;
   final List<RealtimeChannel> _stageSyncChannels = <RealtimeChannel>[];
 
@@ -292,6 +293,7 @@ class TaskProvider with ChangeNotifier {
         ..clear()
         ..addAll(List<Map<String, dynamic>>.from(rows as List).map(_rowToTask));
       final orderIds = _tasks.map((t) => t.orderId).toSet();
+      _loadedStageSequenceOrderIds.clear();
       await _preloadStageSequences(orderIds);
       notifyListeners();
     } catch (e, st) {
@@ -388,12 +390,25 @@ class TaskProvider with ChangeNotifier {
 
   // ===== updates =====
 
+  Future<void> ensureStageSequencesForOrders(Iterable<String> orderIds) async {
+    final missingOrderIds = orderIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .where((id) => !_loadedStageSequenceOrderIds.contains(id))
+        .toSet();
+    if (missingOrderIds.isEmpty) return;
+
+    await _preloadStageSequences(missingOrderIds);
+    notifyListeners();
+  }
+
   Future<void> _preloadStageSequences(Iterable<String> orderIds) async {
     for (final orderId in orderIds) {
       if (orderId.isEmpty) {
         continue;
       }
       final data = await _fetchStageSequence(orderId);
+      _loadedStageSequenceOrderIds.add(orderId);
       if (data.ids.isNotEmpty) {
         _orderStageSequences[orderId] = data.ids;
       } else {

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -185,6 +185,59 @@ void main() {
     );
   });
 
+  test('production All chips include planned stages without task rows', () {
+    final order = OrderModel(
+      id: 'order-with-plan-without-tasks',
+      manager: '',
+      customer: 'Planned customer',
+      orderDate: DateTime(2026, 5, 8),
+      dueDate: null,
+      product: ProductModel(
+        id: 'product',
+        type: kPTypePackageProduct,
+        quantity: 1000,
+        width: 0,
+        height: 0,
+        depth: 0,
+      ),
+      status: OrderStatus.in_production.name,
+    );
+
+    const plannedSequence = [
+      kBobbinStageId,
+      kAutoBigStageId,
+      kCuttingStageId,
+      kPackagingStageId,
+    ];
+    const stageNames = {
+      kBobbinStageId: 'Бобинорезка',
+      kAutoBigStageId: 'Автомат большой',
+      kCuttingStageId: 'Резка',
+      kPackagingStageId: 'Упаковка',
+    };
+
+    final labels = productionStageLabelsForTesting(
+      order: order,
+      orderTasks: const [],
+      plannedSequence: plannedSequence,
+      stageNames: stageNames,
+    );
+    final statuses = productionStageStatusesForTesting(
+      order: order,
+      orderTasks: const [],
+      plannedSequence: plannedSequence,
+      stageNames: stageNames,
+    );
+
+    expect(labels, [
+      'Бобинорезка',
+      'Автомат большой',
+      'Резка',
+      'Упаковка',
+    ]);
+    expect(statuses, everyElement(TaskStatus.waiting));
+  });
+
   test('inserts product stage after bobbin/flexo base stages', () {
     final queue = [
       {'stageId': kBobbinStageId, 'stageName': 'Бобинорезка'},


### PR DESCRIPTION
### Motivation
- UI must show planned stage chips for an order even when there are no task rows, reflecting the real saved queue and plan. 
- Empty groups should display a neutral/waiting status (`TaskStatus.waiting`) instead of being skipped. 
- The message `Этапы не назначены` must appear only when there are no `stageGroups` at all, not when there are groups without matching tasks. 
- Ensure grouping uses the saved order queue so the "Все" tab shows persisted plan entries even for orders without tasks.

### Description
- Changed `_buildStageRow` to always render chips for every `stageGroups` entry and removed the `continue` for empty `tasksForStage`, letting `_groupStatus` yield `TaskStatus.waiting` for empty groups. 
- Added helpers ` _stageGroupLookupForGroups` and `_tasksByStageGroup` to unify lookup/grouping logic between UI and tests. 
- Added `productionStageStatusesForTesting` helper to assert computed statuses for groups in unit tests. 
- In `_ProductionTab.build` added a post-frame call to `taskProvider.ensureStageSequencesForOrders(...)` so saved stage queues are preloaded for visible orders. 
- Extended `TaskProvider` with `ensureStageSequencesForOrders`, `_loadedStageSequenceOrderIds` tracking and small changes to `_preloadStageSequences` to avoid skipping persisted plan rows for orders without task rows. 
- Added regression test `production All chips include planned stages without task rows` in `test/stage_queue_builder_test.dart` that verifies labels and that statuses are `TaskStatus.waiting` when `orderTasks` is empty but a planned sequence exists. 

### Testing
- `git diff --check` passed locally. 
- Attempted `dart format` on modified files but it was not run in this environment because `dart` is not installed. 
- Attempted to run `flutter test test/stage_queue_builder_test.dart` but it was not executed because `flutter` is not available in this environment. 
- Added unit test coverage for planned stages without tasks (test file updated), but the test execution was not performed here due to missing toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7ab47a48832fa338984cdd5a8a08)