### PR TITLE
Build production tabs from active stage groups

### DIFF
--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -686,8 +686,10 @@ class _ProductionScreenState extends State<ProductionScreen>
     }.toList()
       ..sort();
 
-    final workplaces = List.of(personnelProvider.workplaces)
-      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    final workplaceNamesById = {
+      for (final workplace in personnelProvider.workplaces)
+        workplace.id: workplace.name,
+    };
 
     final tasksByOrder = <String, List<TaskModel>>{};
     for (final task in tasks) {
@@ -710,19 +712,37 @@ class _ProductionScreenState extends State<ProductionScreen>
       );
     }
 
-    final activeWorkplaceIds = <String>{};
+    final activeStageTabs = <String, _ProductionTabInfo>{};
     for (final order in orders) {
       if (order.statusEnum != OrderStatus.in_production) continue;
       final grouping = groupingByOrder[order.id];
       if (grouping == null || grouping.isCompleted) continue;
-      activeWorkplaceIds.addAll(grouping.visibleWorkplaceIds);
+
+      for (final group in grouping.stageGroups.values) {
+        if (group.stageIds.isEmpty) continue;
+
+        final tabId = group.stageIds.first.trim();
+        if (tabId.isEmpty || !grouping.visibleWorkplaceIds.contains(tabId)) {
+          continue;
+        }
+
+        final groupTasks =
+            grouping.tasksByGroup[group.key] ?? const <TaskModel>[];
+        if (_groupCompleted(groupTasks)) continue;
+
+        activeStageTabs.putIfAbsent(
+          tabId,
+          () => _ProductionTabInfo(
+            id: tabId,
+            label: workplaceNamesById[tabId] ?? group.label,
+          ),
+        );
+      }
     }
 
     final tabs = [
       const _ProductionTabInfo(id: _allTabId, label: _allLabel, isAll: true),
-      for (final w in workplaces)
-        if (activeWorkplaceIds.contains(w.id))
-          _ProductionTabInfo(id: w.id, label: w.name),
+      ...activeStageTabs.values,
       const _ProductionTabInfo(
         id: _completedTabId,
         label: _completedLabel,
@@ -1070,7 +1090,8 @@ class _ProductionTab extends StatelessWidget {
       orElse: () => const _StageGroupInfo(key: '', stageIds: [], label: ''),
     );
     if (group.stageIds.isEmpty) return false;
-    final tasksForGroup = grouping.tasksByGroup[group.key] ?? const <TaskModel>[];
+    final tasksForGroup =
+        grouping.tasksByGroup[group.key] ?? const <TaskModel>[];
     return tasksForGroup.any((task) => task.status == TaskStatus.inProgress);
   }
 


### PR DESCRIPTION
### Motivation
- Вкладки в производственном экране должны отражать реальные активные этапы из очередей заказов, а не только справочник рабочих мест, чтобы показывать этапы, существующие только в конфигурации очереди.

### Description
- Изменил построение списка вкладок в `ProductionScreen.build` в `lib/modules/production/production_screen.dart`, теперь собираю `activeStageTabs` из `grouping.stageGroups` активных заказов (`OrderStatus.in_production`).
- Для каждой группы беру первый `stageId` как `tab.id` и использую `group.label` как запасное название, но при наличии рабочего места в `PersonnelProvider.workplaces` предпочитаю его имя (сборка `workplaceNamesById`).
- Добавляю вкладку только если `tabId` присутствует в `grouping.visibleWorkplaceIds` и группа не завершена, а итоговый `tabs` формируется как `Все` → активные stage/workplace вкладки в порядке вставки → `Завершенные`.
- Сохранена совместимость фильтрации и блокировки: `_isOrderLockedInCurrentWorkplace` и проверки `grouping.visibleWorkplaceIds.contains(tab.id)` продолжают работать с id этапов, отсутствующих в `PersonnelProvider.workplaces`.

### Testing
- Запущена проверка изменений: `git diff --check` — прошло без предупреждений.
- Попытка прогнать форматтер: `dart format lib/modules/production/production_screen.dart` — не выполнена в среде: команда `dart` не найдена.
- Попытка запустить тесты: `flutter test` — не выполнена в среде: команда `flutter` не найдена.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd830cf784832f9833ab6186df1d14)