### PR TITLE
Preserve saved stage queue order

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -310,10 +310,39 @@ List<Map<String, dynamic>> normalizeBuiltOrderStageQueue(
     normalized.add(map);
   }
 
+  final ordered = _hasPersistedStageOrder(normalized)
+      ? normalized
+      : _withPackagingStagesLast(normalized);
+
+  for (var i = 0; i < ordered.length; i++) {
+    ordered[i]['sortOrder'] = i + 1;
+    ordered[i]['order'] = i + 1;
+  }
+  return ordered;
+}
+
+bool _hasPersistedStageOrder(List<Map<String, dynamic>> stages) {
+  return stages.any((stage) {
+    for (final key in const <String>[
+      'sortOrder',
+      'order',
+      'step',
+      'step_no',
+      'seq',
+    ]) {
+      if (stage.containsKey(key) && stage[key] != null) return true;
+    }
+    return false;
+  });
+}
+
+List<Map<String, dynamic>> _withPackagingStagesLast(
+  List<Map<String, dynamic>> stages,
+) {
   final products = <Map<String, dynamic>>[];
   final packaging = <Map<String, dynamic>>[];
 
-  for (final stage in normalized) {
+  for (final stage in stages) {
     final id = _stageIdFromMap(stage);
     if (_isPackagingStage(stage, id)) {
       packaging.add(stage);
@@ -322,15 +351,10 @@ List<Map<String, dynamic>> normalizeBuiltOrderStageQueue(
     }
   }
 
-  final ordered = <Map<String, dynamic>>[
+  return <Map<String, dynamic>>[
     ...products,
     ...packaging,
   ];
-  for (var i = 0; i < ordered.length; i++) {
-    ordered[i]['sortOrder'] = i + 1;
-    ordered[i]['order'] = i + 1;
-  }
-  return ordered;
 }
 
 String? _stageIdFromMap(Map<String, dynamic> map) => (map['stageId'] ??

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -488,6 +488,58 @@ void main() {
     expect(result.map((stage) => stage.stageKey), contains(kBobbinStageId));
   });
 
+  test('preserves saved queue order when packaging is not last', () {
+    final savedRows = <Map<String, dynamic>>[
+      {
+        'stageId': kAutoBigStageId,
+        'stageName': 'Большой',
+        'seq': 1,
+      },
+      {
+        'stageId': kCuttingStageId,
+        'stageName': 'Резка',
+        'seq': 2,
+      },
+      {
+        'stageId': kCardboardCuttingStageId,
+        'stageName': 'Резка картона',
+        'seq': 3,
+      },
+      {
+        'stageId': kCardboardInsertStageId,
+        'stageName': 'Вставка картона',
+        'seq': 4,
+      },
+      {
+        'stageId': kPackagingStageId,
+        'stageName': 'Упаковка',
+        'seq': 5,
+      },
+      {
+        'stageId': kTwistedHandleStageId,
+        'stageName': 'Кручёная ручка',
+        'seq': 6,
+      },
+    ];
+    const expectedOrder = [
+      'Большой',
+      'Резка',
+      'Резка картона',
+      'Вставка картона',
+      'Упаковка',
+      'Кручёная ручка',
+    ];
+
+    final normalized = normalizeBuiltOrderStageQueue(savedRows);
+
+    expect(normalized.map((stage) => stage['stageName']), expectedOrder);
+    expect(
+      productionDetailsPlannedStagesFromQueueRowsForTesting(rows: savedRows)
+          .map((stage) => stage.stageName),
+      expectedOrder,
+    );
+  });
+
   test('normalizes base stage aliases without changing composition', () {
     final result = normalizeBuiltOrderStageQueue([
       {'stageId': kPackagingStageId, 'stageName': 'Упаковка'},


### PR DESCRIPTION
### Motivation
- Avoid forcing `Упаковка` to the end when a queue was already persisted with explicit ordering metadata. 
- Keep the legacy behavior of moving packaging to the end only for newly generated queues that lack saved order markers. 
- Ensure `productionDetailsPlannedStagesFromQueueRowsForTesting` and UI consumers present stages strictly in the saved rows order when rows contain persisted order fields. 

### Description
- Updated `normalizeBuiltOrderStageQueue` to detect persisted row order and, when present, keep `normalized` rows in their original order instead of moving packaging to the end. 
- Added helper `bool _hasPersistedStageOrder(List<Map<String, dynamic>>)` which checks for any of the fields `sortOrder`, `order`, `step`, `step_no`, or `seq`, and extracted packaging-last logic into `_withPackagingStagesLast(List<Map<String, dynamic>>)`. 
- Added a regression test in `test/stage_queue_builder_test.dart` that builds a saved queue with the sequence `Большой`, `Резка`, `Резка картона`, `Вставка картона`, `Упаковка`, `Кручёная ручка` and asserts that `normalizeBuiltOrderStageQueue` and `productionDetailsPlannedStagesFromQueueRowsForTesting` preserve that order. 

### Testing
- Attempted to run unit tests with `flutter test test/stage_queue_builder_test.dart`, but the command failed in this environment because `flutter` is not installed, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd840e39bc832f90d9d1f101c262d3)