### PR TITLE
Синхронизация очередей этапов между заказом, МУПЗ и рабочим пространством

### DIFF
--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -429,7 +429,8 @@ class OrderQueueService {
   Future<List<Map<String, dynamic>>> _loadNormalizedRows(String orderId) async {
     final loadSources = _loadSources;
     if (loadSources != null) {
-      return loadSources.loadNormalizedRows(orderId);
+      final rows = await loadSources.loadNormalizedRows(orderId);
+      return _groupNormalizedPlanRows(rows);
     }
     try {
       final plan = await _client
@@ -449,6 +450,17 @@ class OrderQueueService {
 
   Future<List<Map<String, dynamic>>> _selectPlanStageRows(String planId) async {
     const attempts = <({String columns, String orderColumn})>[
+      (
+        columns: 'stage_id,stage_group_key,name,stage_name,step_no,seq,status,'
+            'started_at,finished_at,completed_at,executor_id,'
+            'assigned_employee_id',
+        orderColumn: 'seq',
+      ),
+      (
+        columns: 'stage_id,stage_group_key,name,stage_name,step_no,seq,status,'
+            'started_at,finished_at,executor_id,assigned_employee_id',
+        orderColumn: 'seq',
+      ),
       (
         columns: 'stage_id,stage_group_key,name,stage_name,step_no,seq,status',
         orderColumn: 'seq',
@@ -479,10 +491,49 @@ class OrderQueueService {
             .eq('plan_id', planId)
             .order(attempt.orderColumn, ascending: true);
         final decoded = _decodeRows(rows);
-        if (decoded.isNotEmpty) return decoded;
+        if (decoded.isNotEmpty) return _groupNormalizedPlanRows(decoded);
       } catch (_) {}
     }
     return const <Map<String, dynamic>>[];
+  }
+
+  static List<Map<String, dynamic>> _groupNormalizedPlanRows(
+    List<Map<String, dynamic>> rows,
+  ) {
+    if (rows.isEmpty) return const <Map<String, dynamic>>[];
+    final grouped = <_NormalizedPlanGroup>[];
+    final byKey = <String, _NormalizedPlanGroup>{};
+
+    for (var i = 0; i < rows.length; i++) {
+      final row = Map<String, dynamic>.from(rows[i]);
+      final stageIds = OrderQueueMapper.stageIdsFromRow(row);
+      if (stageIds.isEmpty) continue;
+      final stageId = stageIds.first;
+      final groupKey = OrderQueueMapper.stageGroupKeyFromRow(row, stageIds);
+      final effectiveGroupKey = groupKey.isEmpty ? stageId : groupKey;
+      final step = OrderQueueMapper.readStep(row, i + 1);
+      final key = effectiveGroupKey;
+
+      final group = byKey.putIfAbsent(key, () {
+        final created = _NormalizedPlanGroup(
+          key: key,
+          firstRow: row,
+          firstIndex: i,
+          step: step,
+        );
+        grouped.add(created);
+        return created;
+      });
+      group.addRow(row, stageId, step);
+    }
+
+    grouped.sort((a, b) {
+      final byStep = a.step.compareTo(b.step);
+      if (byStep != 0) return byStep;
+      return a.firstIndex.compareTo(b.firstIndex);
+    });
+
+    return grouped.map((group) => group.toRow()).toList(growable: false);
   }
 
   Future<List<Map<String, dynamic>>> _loadTemplateFallbackRows(
@@ -581,6 +632,88 @@ class OrderQueueService {
           .toList(growable: false);
     }
     return const <Map<String, dynamic>>[];
+  }
+}
+
+class _NormalizedPlanGroup {
+  _NormalizedPlanGroup({
+    required this.key,
+    required Map<String, dynamic> firstRow,
+    required this.firstIndex,
+    required this.step,
+  }) : row = Map<String, dynamic>.from(firstRow);
+
+  final String key;
+  final Map<String, dynamic> row;
+  final int firstIndex;
+  int step;
+  final List<String> stageIds = <String>[];
+
+  void addRow(Map<String, dynamic> source, String stageId, int rowStep) {
+    if (!stageIds.contains(stageId)) stageIds.add(stageId);
+    if (rowStep > 0 && (step <= 0 || rowStep < step)) step = rowStep;
+
+    final sourceStatus = source['status']?.toString().trim();
+    final currentStatus = row['status']?.toString().trim();
+    if (_statusRank(sourceStatus) > _statusRank(currentStatus)) {
+      row['status'] = sourceStatus;
+    }
+
+    for (final key in const <String>[
+      'started_at',
+      'startedAt',
+      'finished_at',
+      'finishedAt',
+      'completed_at',
+      'completedAt',
+      'executor_id',
+      'assigned_employee_id',
+    ]) {
+      row[key] ??= source[key];
+    }
+  }
+
+  Map<String, dynamic> toRow() {
+    final result = Map<String, dynamic>.from(row);
+    result['stage_group_key'] = key;
+    result['stageGroupKey'] = key;
+    result['stageId'] =
+        stageIds.isNotEmpty ? stageIds.first : result['stageId'];
+    result['stage_id'] =
+        stageIds.isNotEmpty ? stageIds.first : result['stage_id'];
+    result['workplaceId'] = result['stageId'];
+    result['workplaceIds'] = List<String>.from(stageIds);
+    if (stageIds.length > 1) {
+      result['alternativeStageIds'] = stageIds.skip(1).toList(growable: false);
+    }
+    result['step'] = step;
+    result['step_no'] = step;
+    result['seq'] = step;
+    result['order'] = step;
+    return result;
+  }
+
+  static int _statusRank(String? status) {
+    switch ((status ?? '').toLowerCase().replaceAll('-', '_')) {
+      case 'completed':
+      case 'complete':
+      case 'done':
+        return 5;
+      case 'inprogress':
+      case 'in_progress':
+      case 'started':
+        return 4;
+      case 'paused':
+      case 'problem':
+        return 3;
+      case 'available':
+      case 'ready':
+        return 2;
+      case 'waiting':
+      case 'pending':
+      default:
+        return 1;
+    }
   }
 }
 

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -1005,6 +1005,16 @@ class TaskProvider with ChangeNotifier {
       }
     }
 
+    await _syncStageGroupStatusToSharedSources(
+      updated,
+      status,
+      spentSeconds: updated.spentSeconds,
+      startedAt: updated.startedAt,
+      completedAt: status == TaskStatus.completed
+          ? DateTime.now().millisecondsSinceEpoch
+          : null,
+    );
+
     // if this task just became completed — check last-stage and update actual_qty
     if (status == TaskStatus.completed) {
       final orderId = updated.orderId;
@@ -1034,6 +1044,135 @@ class TaskProvider with ChangeNotifier {
     }
 
     return true;
+  }
+
+  Future<void> _syncStageGroupStatusToSharedSources(
+    TaskModel task,
+    TaskStatus status, {
+    int? spentSeconds,
+    int? startedAt,
+    int? completedAt,
+  }) async {
+    final groupKey = task.stageGroupKey.trim().isNotEmpty
+        ? task.stageGroupKey.trim()
+        : task.stageId.trim();
+    if (task.orderId.trim().isEmpty || groupKey.isEmpty) return;
+
+    final taskUpdates = <String, dynamic>{
+      'status': status.name,
+      if (spentSeconds != null) 'spent_seconds': spentSeconds,
+      if (startedAt != null) 'started_at': startedAt,
+      if (completedAt != null) 'completed_at': completedAt,
+    };
+    final startedIso = startedAt == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(startedAt)
+            .toUtc()
+            .toIso8601String();
+    final completedIso = completedAt == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(completedAt)
+            .toUtc()
+            .toIso8601String();
+    final planUpdates = <String, dynamic>{
+      'status': status.name,
+      if (startedIso != null) 'started_at': startedIso,
+      if (completedIso != null) ...{
+        'finished_at': completedIso,
+        'completed_at': completedIso,
+      },
+    };
+
+    try {
+      await _updateTaskStageGroup(
+        orderId: task.orderId,
+        groupKey: groupKey,
+        updates: taskUpdates,
+      );
+      for (var i = 0; i < _tasks.length; i++) {
+        final local = _tasks[i];
+        if (local.orderId == task.orderId && local.stageGroupKey == groupKey) {
+          _tasks[i] = local.copyWith(
+            status: status,
+            spentSeconds: spentSeconds ?? local.spentSeconds,
+            startedAt: startedAt ?? local.startedAt,
+          );
+        }
+      }
+      notifyListeners();
+    } catch (e, st) {
+      debugPrint('⚠️ stage group task status sync failed: $e\n$st');
+    }
+
+    try {
+      final plan = await _supabase
+          .from('prod_plans')
+          .select('id')
+          .eq('order_id', task.orderId)
+          .maybeSingle();
+      final planId = plan != null ? plan['id']?.toString() : null;
+      if (planId == null || planId.isEmpty) return;
+      await _updateProdPlanStageGroup(
+        planId: planId,
+        groupKey: groupKey,
+        updates: planUpdates,
+      );
+    } catch (e, st) {
+      debugPrint('⚠️ prod_plan_stages status sync failed: $e\n$st');
+    }
+  }
+
+  Future<void> _updateTaskStageGroup({
+    required String orderId,
+    required String groupKey,
+    required Map<String, dynamic> updates,
+  }) async {
+    Future<void> run(Map<String, dynamic> payload) async {
+      await _supabase
+          .from('tasks')
+          .update(payload)
+          .eq('order_id', orderId)
+          .eq('stage_group_key', groupKey);
+    }
+
+    try {
+      await run(updates);
+    } catch (error) {
+      if (!_isMissingColumnError(error, 'completed_at')) rethrow;
+      final fallback = Map<String, dynamic>.from(updates)
+        ..remove('completed_at');
+      await run(fallback);
+    }
+  }
+
+  Future<void> _updateProdPlanStageGroup({
+    required String planId,
+    required String groupKey,
+    required Map<String, dynamic> updates,
+  }) async {
+    Future<void> run(Map<String, dynamic> payload) async {
+      await _supabase
+          .from('prod_plan_stages')
+          .update(payload)
+          .eq('plan_id', planId)
+          .eq('stage_group_key', groupKey);
+    }
+
+    try {
+      await run(updates);
+    } catch (error) {
+      if (!_isMissingColumnError(error, 'completed_at')) rethrow;
+      final fallback = Map<String, dynamic>.from(updates)
+        ..remove('completed_at');
+      await run(fallback);
+    }
+  }
+
+  bool _isMissingColumnError(Object error, String columnName) {
+    if (error is! PostgrestException) return false;
+    final message = error.message.toLowerCase();
+    return message.contains(columnName.toLowerCase()) &&
+        (error.code == '42703' || error.code == 'PGRST204');
   }
 
   Future<void> addComment(

--- a/test/order_queue_service_load_test.dart
+++ b/test/order_queue_service_load_test.dart
@@ -77,12 +77,58 @@ void main() {
           .map((stage) => stage.stageId)
           .toList();
       final taskProviderStageIds = normalizeStageSequence(
-        OrderQueueMapper.toSyncEntries(saved.rows).map((entry) => entry.stageId),
+        OrderQueueMapper.toSyncEntries(saved.rows)
+            .map((entry) => entry.stageId),
       );
 
       expect(saved.source, SavedOrderQueueSource.normalizedPlanRows);
       expect(productionStageIds, ['cut', 'print', 'pack']);
       expect(taskProviderStageIds, productionStageIds);
+    },
+  );
+
+  test(
+    'loadSavedQueue groups normalized multi-workplace stages by group key',
+    () async {
+      final service = OrderQueueService.withLoadSources(_sources(
+        normalizedRows: const [
+          {
+            'stage_id': 'die-a1',
+            'stage_group_key': 'die-cut',
+            'name': 'Высечка A1/A2',
+            'step_no': 5,
+            'seq': 5000,
+            'status': 'waiting',
+          },
+          {
+            'stage_id': 'die-a2',
+            'stage_group_key': 'die-cut',
+            'name': 'Высечка A1/A2',
+            'step_no': 5,
+            'seq': 5001,
+            'status': 'inProgress',
+          },
+          {
+            'stage_id': 'pack',
+            'stage_group_key': 'pack',
+            'name': 'Упаковка',
+            'step_no': 6,
+            'seq': 6,
+          },
+        ],
+      ));
+
+      final saved = await service.loadSavedQueue('order-grouped');
+
+      expect(saved.rows, hasLength(2));
+      expect(saved.rows.first['stage_group_key'], 'die-cut');
+      expect(saved.rows.first['workplaceIds'], ['die-a1', 'die-a2']);
+      expect(saved.rows.first['status'], 'inProgress');
+      expect(
+        OrderQueueMapper.toSyncEntries(saved.rows)
+            .map((entry) => entry.stageId),
+        ['die-a1', 'die-a2', 'pack'],
+      );
     },
   );
 


### PR DESCRIPTION
### Motivation
- Исправить рассинхронизацию очередей: разные модули брали очередь из разных источников и показывали разные варианты одной и той же очереди.
- Сделать единый источник правды для очереди этапов (нормализованные строки плана / сохранённая очередь) и обеспечить корректную работу групповых этапов и статусов.

### Description
- Вынес и расширил чтение нормализованных строк плана в `OrderQueueService`: теперь `_selectPlanStageRows` пытается читать дополнительные колонки статуса/времён/исполнителя и возвращает сгруппированные логические этапы через `_groupNormalizedPlanRows` (новая логика группировки и класс `_NormalizedPlanGroup`).
- Нормализация объединяет физические рабочие места одного логического этапа в одно представление с полями `stage_group_key`, `workplaceIds`, агрегированным `status` и сохранёнными временами/исполнителем, чтобы МУПЗ и рабочее пространство видели один и тот же порядок и состав этапа.
- Обновил `TaskProvider` для синхронизации изменений статусов из рабочего пространства на все задачи группы и в `prod_plan_stages` через новые методы `_syncStageGroupStatusToSharedSources`, `_updateTaskStageGroup` и `_updateProdPlanStageGroup`, с защитой-фолбэком для схем без поля `completed_at`.
- Добавил тест `loadSavedQueue groups normalized multi-workplace stages by group key` в `test/order_queue_service_load_test.dart`, который проверяет, что несколько строк `prod_plan_stages` с общим `stage_group_key` собираются в один логический этап с `workplaceIds` и корректным статусом.

### Testing
- Выполнена быстрая проверка изменений с `git diff --check` и коммит (статические проверки Git прошли успешно).
- Попытки выполнить `flutter analyze`, `flutter test` и `flutter build` не удалось — в окружении отсутствует Flutter SDK (`flutter: command not found`).
- Автотесты добавлены (`test/order_queue_service_load_test.dart`) и локально подготовлены к запуску в CI/локальной среде со Flutter; сам запуск тестов не был выполнен в этом окружении из-за отсутствия SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8b2c00cc832fb02e50be198a736d)