### PR TITLE
Fix Flutter startup and chat teardown errors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,32 +24,32 @@ import 'my_app.dart';
 import 'utils/http_overrides.dart';
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-
-  _BootLogger.log('main() started');
-
-  FlutterError.onError = (FlutterErrorDetails details) {
-    if (isTransientFlutterVisualAssertion(details)) {
-      _BootLogger.log(
-        'Suppressed transient Flutter visual assertion: '
-        '${details.exceptionAsString()}',
-      );
-      return;
-    }
-
-    FlutterError.presentError(details);
-    _BootLogger.log(
-      'FLUTTER ERROR: ${details.exceptionAsString()}\n${details.stack}',
-    );
-  };
-
-  PlatformDispatcher.instance.onError = (error, stack) {
-    _BootLogger.log('PLATFORM ERROR: $error\n$stack');
-    return true;
-  };
-
   runZonedGuarded(
-    () {
+    () async {
+      WidgetsFlutterBinding.ensureInitialized();
+
+      _BootLogger.log('main() started');
+
+      FlutterError.onError = (FlutterErrorDetails details) {
+        if (isTransientFlutterVisualAssertion(details)) {
+          _BootLogger.log(
+            'Suppressed transient Flutter visual assertion: '
+            '${details.exceptionAsString()}',
+          );
+          return;
+        }
+
+        FlutterError.presentError(details);
+        _BootLogger.log(
+          'FLUTTER ERROR: ${details.exceptionAsString()}\n${details.stack}',
+        );
+      };
+
+      PlatformDispatcher.instance.onError = (error, stack) {
+        _BootLogger.log('PLATFORM ERROR: $error\n$stack');
+        return true;
+      };
+
       try {
         HttpOverrides.global = MyHttpOverrides();
         _BootLogger.log('HttpOverrides configured');

--- a/lib/modules/analytics/analytics_provider.dart
+++ b/lib/modules/analytics/analytics_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'analytics_record.dart';
@@ -10,6 +12,9 @@ class AnalyticsProvider with ChangeNotifier {
   final SupabaseClient _supabase = Supabase.instance.client;
 
   final List<AnalyticsRecord> _logs = [];
+  StreamSubscription<List<Map<String, dynamic>>>? _analyticsSubscription;
+  bool _analyticsUnavailable = false;
+  bool _disposed = false;
 
   AnalyticsProvider() {
     _listenToLogs();
@@ -18,17 +23,22 @@ class AnalyticsProvider with ChangeNotifier {
   List<AnalyticsRecord> get logs => List.unmodifiable(_logs);
 
   void _listenToLogs() {
+    if (_analyticsUnavailable) return;
     // Listen to realtime updates from the `analytics` table. In some
     // deployments the table might be missing which would normally throw
     // an unhandled [PostgrestException]. To prevent the application from
     // crashing we handle errors from the stream explicitly.
     try {
-      _supabase.from('analytics').stream(primaryKey: ['id']).listen(
+      _analyticsSubscription = _supabase
+          .from('analytics')
+          .stream(primaryKey: ['id'])
+          .listen(
         (rows) {
+          if (_disposed) return;
           _logs
             ..clear()
             ..addAll(rows.map((row) {
-              final data = Map<String, dynamic>.from(row as Map);
+              final data = Map<String, dynamic>.from(row);
               final id = row['id'].toString();
               return AnalyticsRecord.fromMap(data, id);
             }));
@@ -38,6 +48,13 @@ class AnalyticsProvider with ChangeNotifier {
         onError: (error, stackTrace) {
           // Log the error but keep the app running. If the table is missing
           // we simply skip analytics collection.
+          if (error is PostgrestException && error.code == 'PGRST205') {
+            _analyticsUnavailable = true;
+            unawaited(_analyticsSubscription?.cancel());
+            _analyticsSubscription = null;
+            debugPrint('Analytics disabled: table public.analytics is missing');
+            return;
+          }
           debugPrint('Analytics stream error: $error');
         },
       );
@@ -45,7 +62,12 @@ class AnalyticsProvider with ChangeNotifier {
       // The initial call to `stream` itself can throw synchronously if the
       // table does not exist in the schema cache. We catch it here so that the
       // exception does not bubble up to the framework.
-      debugPrint('Failed to subscribe to analytics: ${e.message}');
+      if (e.code == 'PGRST205') {
+        _analyticsUnavailable = true;
+        debugPrint('Analytics disabled: table public.analytics is missing');
+      } else {
+        debugPrint('Failed to subscribe to analytics: ${e.message}');
+      }
     }
   }
 
@@ -59,6 +81,7 @@ class AnalyticsProvider with ChangeNotifier {
     String category = '',
     String details = '',
   }) async {
+    if (_analyticsUnavailable) return;
     final timestamp = DateTime.now().millisecondsSinceEpoch;
     try {
       await _supabase.from('analytics').insert({
@@ -73,7 +96,20 @@ class AnalyticsProvider with ChangeNotifier {
     } on PostgrestException catch (e) {
       // If the table is missing or insertion fails for any reason we simply
       // log the issue and move on.
-      debugPrint('Failed to log analytics event: ${e.message}');
+      if (e.code == 'PGRST205') {
+        _analyticsUnavailable = true;
+        debugPrint('Analytics disabled: table public.analytics is missing');
+      } else {
+        debugPrint('Failed to log analytics event: ${e.message}');
+      }
     }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    unawaited(_analyticsSubscription?.cancel());
+    _analyticsSubscription = null;
+    super.dispose();
   }
 }

--- a/lib/modules/chat/widgets/input_bar.dart
+++ b/lib/modules/chat/widgets/input_bar.dart
@@ -46,6 +46,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   int? _mentionTriggerIndex;
   final List<_PendingMention> _selectedMentions = <_PendingMention>[];
   int _mentionRequestId = 0;
+  bool _isDisposed = false;
 
   /// Снимает фото через камеру устройства и отправляет его в чат. Если
   /// пользователь отменяет съёмку, ничего не происходит. Этот метод
@@ -53,13 +54,16 @@ class _ChatInputBarState extends State<ChatInputBar> {
   /// из приложения. Для сохранения совместимости с Web вызовы камеры
   /// доступны только на мобильных платформах.
   Future<void> _takePhoto() async {
+    if (_isDisposed || !mounted) return;
+    final chat = context.read<ChatProvider>();
     final picker = ImagePicker();
     try {
       final XFile? image = await picker.pickImage(source: ImageSource.camera, imageQuality: 85);
       if (image == null) return;
       final bytes = await image.readAsBytes();
       final mime = lookupMimeType(image.path) ?? 'image/jpeg';
-      await context.read<ChatProvider>().sendFile(
+      if (_isDisposed || !mounted) return;
+      await chat.sendFile(
             roomId: widget.roomId,
             senderId: widget.senderId,
             senderName: widget.senderName,
@@ -77,26 +81,33 @@ class _ChatInputBarState extends State<ChatInputBar> {
   void initState() {
     super.initState();
     _controller.addListener(_handleControllerChanged);
-    _focusNode.addListener(() {
-      if (!_focusNode.hasFocus) {
-        _hideMentionOverlay();
-      } else {
-        unawaited(_refreshMentionSuggestions());
-      }
-    });
+    _focusNode.addListener(_handleFocusChanged);
   }
 
   @override
   void dispose() {
+    _isDisposed = true;
+    _mentionRequestId++;
     _controller.removeListener(_handleControllerChanged);
+    _focusNode.removeListener(_handleFocusChanged);
     _hideMentionOverlay();
     _focusNode.dispose();
     _controller.dispose();
-    _stopRecordingIfNeeded(notify: false);
+    unawaited(_disposeRecorder());
     super.dispose();
   }
 
+  void _handleFocusChanged() {
+    if (_isDisposed || !mounted) return;
+    if (!_focusNode.hasFocus) {
+      _hideMentionOverlay();
+    } else {
+      unawaited(_refreshMentionSuggestions());
+    }
+  }
+
   Future<void> _sendText() async {
+    if (_isDisposed || !mounted) return;
     _cleanupObsoleteMentions();
     var prepared = _controller.text;
     if (prepared.trim().isEmpty) return;
@@ -118,6 +129,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   void _handleControllerChanged() {
+    if (_isDisposed || !mounted) return;
     _cleanupObsoleteMentions();
     unawaited(_refreshMentionSuggestions());
   }
@@ -207,6 +219,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   Future<void> _refreshMentionSuggestions() async {
+    if (_isDisposed || !mounted) return;
     final requestId = ++_mentionRequestId;
     if (!_focusNode.hasFocus) {
       _hideMentionOverlay();
@@ -235,7 +248,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
     }
     if (atIndex > 0) {
       final before = prefix.substring(atIndex - 1, atIndex);
-      final allowedBefore = RegExp("[\s.,!?;:()\[\]{}<>\"-]");
+      final allowedBefore = RegExp(r'[\s.,!?;:()\[\]{}<>"-]');
       if (!allowedBefore.hasMatch(before)) {
         _hideMentionOverlay();
         return;
@@ -248,7 +261,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
     }
     final chat = context.read<ChatProvider>();
     final suggestions = await chat.mentionCandidates(query: querySegment.trimLeft());
-    if (!mounted || requestId != _mentionRequestId) return;
+    if (_isDisposed || !mounted || requestId != _mentionRequestId) return;
     if (suggestions.isEmpty) {
       _hideMentionOverlay();
       return;
@@ -261,9 +274,9 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   void _showMentionOverlay() {
+    if (_isDisposed || !mounted) return;
     if (_mentionOverlay == null) {
       final overlayState = Overlay.of(context);
-      if (overlayState == null) return;
       _mentionOverlay = OverlayEntry(builder: _buildMentionOverlay);
       overlayState.insert(_mentionOverlay!);
     } else {
@@ -272,18 +285,24 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   void _hideMentionOverlay() {
-    _mentionOverlay?.remove();
+    final overlay = _mentionOverlay;
+    if (overlay != null && overlay.mounted) {
+      overlay.remove();
+    }
     _mentionOverlay = null;
     _mentionSuggestions = const [];
     _mentionTriggerIndex = null;
   }
 
   Widget _buildMentionOverlay(BuildContext context) {
-    if (_mentionSuggestions.isEmpty) {
+    if (_isDisposed || !mounted || _mentionSuggestions.isEmpty) {
       return const SizedBox.shrink();
     }
     final renderBox = _fieldKey.currentContext?.findRenderObject() as RenderBox?;
-    final size = renderBox?.size ?? Size.zero;
+    if (renderBox == null || !renderBox.attached) {
+      return const SizedBox.shrink();
+    }
+    final size = renderBox.size;
     final width = size.width > 0 ? size.width : MediaQuery.of(context).size.width * 0.6;
     final offsetY = size.height + 4 * widget.scale;
     final density = widget.compact
@@ -322,6 +341,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   void _insertMention(ChatMentionCandidate candidate) {
+    if (_isDisposed || !mounted) return;
     final trigger = _mentionTriggerIndex;
     if (trigger == null) return;
     final selection = _controller.selection;
@@ -354,12 +374,15 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   Future<void> _pickImage() async {
+    if (_isDisposed || !mounted) return;
+    final chat = context.read<ChatProvider>();
     final picker = ImagePicker();
     final x = await picker.pickImage(source: ImageSource.gallery, imageQuality: 85);
     if (x == null) return;
     final bytes = await x.readAsBytes();
     final mime = lookupMimeType(x.path) ?? 'image/jpeg';
-    await context.read<ChatProvider>().sendFile(
+    if (_isDisposed || !mounted) return;
+    await chat.sendFile(
           roomId: widget.roomId,
           senderId: widget.senderId,
           senderName: widget.senderName,
@@ -371,12 +394,15 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   Future<void> _pickVideo() async {
+    if (_isDisposed || !mounted) return;
+    final chat = context.read<ChatProvider>();
     final picker = ImagePicker();
     final x = await picker.pickVideo(source: ImageSource.gallery);
     if (x == null) return;
     final bytes = await x.readAsBytes();
     final mime = lookupMimeType(x.path) ?? 'video/mp4';
-    await context.read<ChatProvider>().sendFile(
+    if (_isDisposed || !mounted) return;
+    await chat.sendFile(
           roomId: widget.roomId,
           senderId: widget.senderId,
           senderName: widget.senderName,
@@ -388,6 +414,8 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   Future<void> _pickAnyFile() async {
+    if (_isDisposed || !mounted) return;
+    final chat = context.read<ChatProvider>();
     final res = await FilePicker.platform.pickFiles(withReadStream: true);
     if (res == null || res.files.isEmpty) return;
     final f = res.files.first;
@@ -402,7 +430,8 @@ class _ChatInputBarState extends State<ChatInputBar> {
     if ((mime).startsWith('image/')) kind = 'image';
     else if (mime.startsWith('video/')) kind = 'video';
     else if (mime.startsWith('audio/')) kind = 'audio';
-    await context.read<ChatProvider>().sendFile(
+    if (_isDisposed || !mounted) return;
+    await chat.sendFile(
           roomId: widget.roomId,
           senderId: widget.senderId,
           senderName: widget.senderName,
@@ -414,6 +443,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   Future<void> _toggleRecord() async {
+    if (_isDisposed || !mounted) return;
     if (kIsWeb) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Запись аудио не поддерживается в Web')),
@@ -422,6 +452,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
     }
     _recorder ??= AudioRecorder();
     if (!await _recorder!.hasPermission()) {
+      if (_isDisposed || !mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Нет разрешения на запись')),
       );
@@ -433,12 +464,14 @@ class _ChatInputBarState extends State<ChatInputBar> {
       final dir = Directory.systemTemp.createTempSync('chat_audio_');
       final path = p.join(dir.path, 'voice_${DateTime.now().millisecondsSinceEpoch}.m4a');
       await _recorder!.start(const RecordConfig(encoder: AudioEncoder.aacLc), path: path);
+      if (_isDisposed || !mounted) return;
       setState(() => _recording = true);
     }
   }
 
   Future<void> _stopRecordingIfNeeded({bool notify = true}) async {
     if (!_recording || _recorder == null) return;
+    final chat = mounted && !_isDisposed ? context.read<ChatProvider>() : null;
     final path = await _recorder!.stop();
     if (notify && mounted) {
       setState(() => _recording = false);
@@ -446,11 +479,12 @@ class _ChatInputBarState extends State<ChatInputBar> {
       _recording = false;
     }
     if (path == null) return;
+    if (chat == null || _isDisposed || !mounted) return;
     final file = File(path);
     if (!await file.exists()) return;
     final bytes = await file.readAsBytes();
     // duration неизвестна: плеер на стороне клиента покажет длину по факту воспроизведения
-    await context.read<ChatProvider>().sendFile(
+    await chat.sendFile(
           roomId: widget.roomId,
           senderId: widget.senderId,
           senderName: widget.senderName,
@@ -461,6 +495,20 @@ class _ChatInputBarState extends State<ChatInputBar> {
         );
     // очистка
     try { await file.delete(); } catch (_) {}
+  }
+
+  Future<void> _disposeRecorder() async {
+    final recorder = _recorder;
+    _recorder = null;
+    if (recorder == null) return;
+    try {
+      if (_recording) {
+        await recorder.stop();
+      }
+      await recorder.dispose();
+    } catch (_) {
+      // Recorder cleanup is best-effort during widget teardown.
+    }
   }
 
   @override

--- a/lib/modules/personnel/personnel_provider.dart
+++ b/lib/modules/personnel/personnel_provider.dart
@@ -434,27 +434,26 @@ class PersonnelProvider extends ChangeNotifier {
   }
 
   Future<void> ensureManagerPosition() async {
-    final exists = _positions.any((p) => p.id == kManagerId);
-    if (!exists) {
-      await _db.insertPosition(id: kManagerId, name: 'Manager');
-      await _loadPositionsFromSql();
-    }
+    await _ensurePosition(id: kManagerId, name: 'Manager');
   }
 
   Future<void> ensureWarehouseHeadPosition() async {
-    final exists = _positions.any((p) => p.id == kWarehouseHeadId);
-    if (!exists) {
-      await _db.insertPosition(id: kWarehouseHeadId, name: 'Warehouse Head');
-      await _loadPositionsFromSql();
-    }
+    await _ensurePosition(id: kWarehouseHeadId, name: 'Warehouse Head');
   }
 
   Future<void> ensureCmmSpecialistPosition() async {
-    final exists = _positions.any((p) => p.id == kCmmSpecialistId);
-    if (!exists) {
-      await _db.insertPosition(id: kCmmSpecialistId, name: 'CMM специалист');
-      await _loadPositionsFromSql();
+    await _ensurePosition(id: kCmmSpecialistId, name: 'CMM специалист');
+  }
+
+  Future<void> _ensurePosition({required String id, required String name}) async {
+    if (_positions.any((p) => p.id == id)) return;
+    try {
+      await _db.insertPosition(id: id, name: name);
+    } on PostgrestException catch (e) {
+      if (e.code != '23505') rethrow;
+      // Another client/session has already inserted this fixed position.
     }
+    await _loadPositionsFromSql();
   }
 
   // ---------- realtime ----------


### PR DESCRIPTION
### Motivation
- Prevent runtime exceptions seen during startup and UI interactions (zone mismatch / debug warnings) by ensuring binding initialization and app run are in the same guarded zone.  
- Stop use-after-dispose and overlay/global-key related crashes coming from the chat input (FocusNode/Overlay/Editable) by making teardown and async callbacks safe.  
- Make analytics and fixed-position bootstrapping resilient when optional DB objects are missing or concurrently created (missing `public.analytics` table and duplicate-key inserts).  

### Description
- Move `WidgetsFlutterBinding.ensureInitialized()` and `runApp()` inside a single `runZonedGuarded` to avoid debug zone mismatches and related warning conditions (`lib/main.dart`).  
- Harden `ChatInputBar` teardown by adding an `_isDisposed` guard, removing the `FocusNode` listener on dispose, cancelling/defensive-checking async mention requests, protecting `OverlayEntry` removal, and cleaning up the recorder without using `BuildContext` after unmount (`lib/modules/chat/widgets/input_bar.dart`).  
- Guard all chat async flows (send file / pick media / start/stop recorder / mention refresh) to no-op when the widget is disposed to avoid calling `setState` or `context.read` after unmount.  
- Make analytics provider tolerant of the optional `public.analytics` table by catching `PGRST205`, disabling analytics collection, cancelling the realtime subscription when the table is missing, and avoiding repeated errors; also cancel realtime subscription on provider disposal (`lib/modules/analytics/analytics_provider.dart`).  
- Make fixed special-position creation idempotent by handling duplicate-key `23505` from the DB when inserting manager/warehouse/CMM positions and reloading positions afterwards (`lib/modules/personnel/personnel_provider.dart`).  

### Testing
- Ran `git diff --check` which reported no whitespace/patch problems. (succeeded)  
- Attempted to run `dart format` and `flutter analyze` but the container does not have the Dart/Flutter SDK installed, so automated formatting/analysis could not be executed in this environment. (could not run)  
- Manual code inspection and targeted edits were applied and committed; no runtime test harness was available in this environment. (no runtime tests executed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb9b7c144832f8ae908557f4b824e)