### PR TITLE
Fix sheet cut stage UUID

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -36,7 +36,7 @@ const String kWindowStageId = '8337f16e-c2d1-42dc-966d-6277ba3c1a50';
 const String kAutoBigStageId = 'fdbf1735-a67c-47c9-a7e1-90546effe6ed';
 const String kAutoSmallStageId = 'cbcbe469-b924-4064-ae05-885ccd1b842a';
 const String kTubeStageId = 'e62fc013-4785-4375-b3ee-a3ca51f77199';
-const String kSheetCutStageId = '19a67630-8374-4f9f-ae5b-f2f66828720b';
+const String kSheetCutStageId = '19a67630-8374-49f1-ae5b-f2f66828720b';
 const String kCuttingStageId = cuttingStageId;
 const String kCardboardCuttingStageId =
     'd7d91f75-2f85-446f-8c1d-a20606bdb3b1';

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -990,6 +990,44 @@ void main() {
       expectBuiltStages(result, [kSheetCutStageId, kPackagingStageId]);
     });
 
+    test('Листорезка uses ТЗ UUID when built and read from stage_id', () {
+      const expectedSheetCutStageId = '19a67630-8374-49f1-ae5b-f2f66828720b';
+      expect(kSheetCutStageId, expectedSheetCutStageId);
+
+      for (final productTypeId in const [
+        'Листы',
+        'Пакет из 2х листов',
+      ]) {
+        final queue = buildOrderStageQueue(
+          productTypeId: productTypeId,
+          hasCutting: false,
+          hasCardboard: false,
+          hasFlexPrinting: false,
+        );
+        final sheetCutStage = queue.singleWhere(
+          (stage) => stage['stageName'] == 'Листорезка',
+          orElse: () => fail('Листорезка missing for $productTypeId'),
+        );
+
+        expect(sheetCutStage['stageKey'], expectedSheetCutStageId);
+        expect(sheetCutStage['stageId'], expectedSheetCutStageId);
+        expect(sheetCutStage['id'], expectedSheetCutStageId);
+        expect(sheetCutStage['workplaceId'], expectedSheetCutStageId);
+        expect(sheetCutStage['selectedWorkplaceId'], expectedSheetCutStageId);
+      }
+
+      final readBack = normalizeBuiltOrderStageQueue(const [
+        {
+          'stage_id': expectedSheetCutStageId,
+          'stage_name': 'Листорезка',
+        },
+      ]);
+
+      expect(readBack.single['stageId'], expectedSheetCutStageId);
+      expect(readBack.single['workplaceId'], expectedSheetCutStageId);
+      expect(readBack.single['id'], expectedSheetCutStageId);
+    });
+
     test('Листы: adds Бабинорезка when product width is smaller', () {
       final result = buildOrderStages(
         const OrderStageQueueDraft(


### PR DESCRIPTION
### Motivation
- Исправить неверный UUID константы `kSheetCutStageId` в соответствии с ТЗ чтобы этап «Листорезка» сохранялся и читался с корректным `stage_id` для продуктов `Листы` и `Пакет из 2х листов`.

### Description
- Заменён `kSheetCutStageId` в `lib/modules/orders/stage_queue_builder.dart` на `19a67630-8374-49f1-ae5b-f2f66828720b` и добавлен тест в `test/stage_queue_builder_test.dart`, который проверяет, что при сборке очереди для `Листы` и `Пакет из 2х листов` этап `Листорезка` имеет правильные поля `stageKey`, `stageId`, `id`, `workplaceId` и `selectedWorkplaceId`, а также что `normalizeBuiltOrderStageQueue` корректно читает `stage_id`.

### Testing
- Выполнены статические проверки и поиск контекстов изменений (`git diff --check`, `rg`), изменения закоммичены, но `dart format` и `flutter test` не были выполнены в CI из-за отсутствия `dart`/`flutter` в окружении, поэтому новые тесты добавлены в репозиторий но не запущены локально (`/bin/bash: dart: command not found`, `/bin/bash: flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc70e57e8832f8089be3636155229)