### PR TITLE
Sync launched order queues through shared service

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -2945,12 +2945,15 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       SaveBuiltQueueResult queueSaveResult;
       try {
         if (!isCreating && wasAlreadyLaunched) {
-          await _orderQueueService.syncQueueForExistingOrder(
+          queueSaveResult = await _orderQueueService.saveLaunchedOrderQueue(
             createdOrUpdatedOrder.id,
             stageMaps,
+            <String, String?>{
+              'selected_v_stage': _selectedVStage,
+              'selected_p_stage': _selectedPStage,
+            },
+            currentQueueSignature,
           );
-          queueSaveResult =
-              const SaveBuiltQueueResult(productionTasksCreated: true);
         } else {
           queueSaveResult = await _orderQueueService.saveBuiltQueue(
             createdOrUpdatedOrder.id,

--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -369,6 +369,50 @@ class OrderQueueService {
     );
   }
 
+  /// Persists queue edits for an order that has already been launched.
+  ///
+  /// The normalized plan/task sync intentionally runs before legacy JSON and
+  /// order metadata updates. That keeps already-started/completed stages
+  /// protected by [OrderQueueSyncService.diff] and prevents the UI from saving
+  /// a new queue signature when the normalized queue could not be reconciled.
+  Future<SaveBuiltQueueResult> saveLaunchedOrderQueue(
+    String orderId,
+    List<Map<String, dynamic>> queue,
+    Map<String, String?> selections,
+    Map<String, dynamic>? signature, {
+    bool completeBobbin = false,
+    String? bobbinStageId,
+  }) async {
+    final id = orderId.trim();
+    if (id.isEmpty) {
+      return const SaveBuiltQueueResult(productionTasksCreated: false);
+    }
+    final rows = queue.map((row) => Map<String, dynamic>.from(row)).toList();
+
+    try {
+      await syncQueueForExistingOrder(
+        id,
+        rows,
+        completeBobbin: completeBobbin,
+        bobbinStageId: bobbinStageId,
+      );
+    } on OrderQueueSyncBlockedException {
+      rethrow;
+    } catch (error) {
+      final tableName = _syncFailureTableName(error);
+      _debugPrintQueueSyncFailure(id, tableName, error);
+      throw OrderQueueSaveException(
+        kCreateProductionTasksFailedMessage,
+        error,
+      );
+    }
+
+    await _upsertLegacyProductionPlan(id, rows);
+    await _updateOrderBuildMetadata(id, rows, selections, signature);
+
+    return const SaveBuiltQueueResult(productionTasksCreated: true);
+  }
+
   Future<void> createTasksFromSavedQueue(String orderId) async {
     final saved = await loadSavedQueue(orderId);
     if (saved.rows.isEmpty) {

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -843,18 +843,6 @@ class TaskProvider with ChangeNotifier {
       if (seq.ids.isNotEmpty) return seq;
     } catch (_) {}
 
-    try {
-      final plan = await _supabase
-          .from('production_plans')
-          .select('stages')
-          .eq('order_id', orderId)
-          .maybeSingle();
-      if (plan != null && plan is Map && plan['stages'] != null) {
-        final seq = await fromRows(plan['stages']);
-        if (seq.ids.isNotEmpty) return seq;
-      }
-    } catch (_) {}
-
     return const _StageSequenceData.empty();
   }
 


### PR DESCRIPTION
### Motivation
- Avoid screens and task code reading `production_plans.stages` directly and centralize queue load/save logic in a single service to keep UI consistent with normalized plan rows.
- Ensure edits to already-launched orders first reconcile normalized `prod_plan_stages`/`tasks` so started/completed stages remain protected and the UI does not apply a new queue signature when reconciliation fails.
- Provide a public API that updates legacy `production_plans.stages` and order metadata only after the normalized sync succeeds for launched orders.

### Description
- Add `OrderQueueService.saveLaunchedOrderQueue(...)` which first calls `syncQueueForExistingOrder`, then `_upsertLegacyProductionPlan`, and finally `_updateOrderBuildMetadata` to persist edits for already-launched orders without recreating started/completed stages. (`lib/modules/orders/order_queue_service.dart`).
- Switch `EditOrderScreen` launched-order save path to call `saveLaunchedOrderQueue` (passing selections and current signature) instead of invoking `syncQueueForExistingOrder` directly. (`lib/modules/orders/edit_order_screen.dart`).
- Remove the direct legacy `production_plans.stages` lookup from `TaskProvider` so stage sequence loading goes through `OrderQueueService.loadSavedQueue()` and the queue source is centralized. (`lib/modules/tasks/task_provider.dart`).

### Testing
- Ran `git diff --check` to validate diffs and it reported clean changes.
- Searched with `rg` for direct `from('production_plans')`/`production_plans.stages` usages in UI/queue/task places and confirmed the `TaskProvider` direct read was removed and queue handling is centralized in `OrderQueueService.loadSavedQueue()`.
- Attempted to run `dart format` but Dart/Flutter SDK is not present in the container so formatting/analysis and unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc8a4d134832f9189ec45be3ee9e8)