### PR TITLE
Update automatic stage queue messages

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -3082,7 +3082,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
-            'Очередь изменилась, нажмите Собрать очередь',
+            'Очередь изменилась и будет перестроена автоматически '
+            'при сохранении',
           ),
         ),
       );
@@ -3091,7 +3092,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
-            'Сначала соберите очередь этапов',
+            'Очередь этапов пока не построена автоматически: выберите тип '
+            'продукта и параметры заказа',
           ),
         ),
       );
@@ -5950,7 +5952,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         Padding(
           padding: const EdgeInsets.only(bottom: 8),
           child: Text(
-            'Очередь изменилась, нажмите Собрать очередь',
+            'Очередь изменилась и будет перестроена автоматически '
+            'при сохранении',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: Theme.of(context).colorScheme.error,
                   fontWeight: FontWeight.w600,
@@ -6102,7 +6105,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if ((_stageTemplateId == null || _stageTemplateId!.isEmpty) &&
         _stagePreviewStages.isEmpty) {
       return Text(
-        'Выберите очередь, чтобы просмотреть этапы производства',
+        'Очередь будет построена автоматически после выбора типа '
+        'продукта и параметров заказа',
         style: theme.textTheme.bodySmall,
       );
     }
@@ -6135,7 +6139,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
     if (_stagePreviewStages.isEmpty) {
       return Text(
-        'Для выбранной очереди не найдено этапов',
+        'Для выбранных параметров заказа не найдено этапов',
         style: theme.textTheme.bodySmall,
       );
     }


### PR DESCRIPTION
### Motivation
- Сообщения в UI вводили в заблуждение, требуя ручного выбора очереди/шаблона, тогда как очередь сейчас может собираться автоматически из параметров заказа. 

### Description
- Обновлён текст placeholder в `Widget _buildStagePreviewSection` в `lib/modules/orders/edit_order_screen.dart` на `Очередь будет построена автоматически после выбора типа продукта и параметров заказа`.
- Заменены snackbar-сообщения, связанные с устаревшей или отсутствующей очередью, на формулировки, которые не требуют ручного нажатия `Собрать очередь` и указывают на автоматическое перестроение (замены около логики сохранения заказа и в блоке UI рядом с кнопкой сборки).
- Скорректовано сообщение пустого состояния этапов с `Для выбранной очереди не найдено этапов` на `Для выбранных параметров заказа не найдено этапов`.
- Все изменения внесены в `lib/modules/orders/edit_order_screen.dart` и ограничиваются заменой текстовых констант интерфейса.

### Testing
- Выполнен поиск по коду с помощью `rg` для проверки всех вхождений целевых строк и подтверждения замены, проверка прошла успешно.
- Выполнена проверка изменений через `git diff --check`, результат без ошибок.
- Попытка запустить `dart format lib/modules/orders/edit_order_screen.dart` не выполнена, так как в окружении отсутствует исполняемый файл `dart`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc97ffb68832f9a04f230675ff12f)