### PR TITLE
Fix order queue sync across production stages and tasks

### DIFF
--- a/lib/modules/orders/order_queue_service.dart
+++ b/lib/modules/orders/order_queue_service.dart
@@ -770,16 +770,10 @@ class OrderQueueMapper {
     final result = <OrderQueueSyncEntry>[];
     final createdKeys = <String>{};
     var fallbackStep = 1;
-    String? previousGroupKey;
-
     for (final row in rows) {
       final stageIds = stageIdsFromRow(row);
       if (stageIds.isEmpty) continue;
       final groupKey = stageGroupKeyFromRow(row, stageIds);
-      if (groupKey.isNotEmpty && groupKey == previousGroupKey) {
-        continue;
-      }
-      previousGroupKey = groupKey;
       final step = readStep(row, fallbackStep);
       final status = (row['status'] ?? 'waiting').toString();
 

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -251,10 +251,15 @@ class OrderQueueSyncService {
       tableName: 'prod_plans',
       action: () => _ensurePlan(orderId),
     );
-    final currentStages = await _runTableStep(
+    final loadedStages = await _runTableStep(
       orderId: orderId,
       tableName: 'prod_plan_stages',
       action: () => _loadPlanStages(planId),
+    );
+    final currentStages = await _runTableStep(
+      orderId: orderId,
+      tableName: 'prod_plan_stages',
+      action: () => _deleteDuplicatePendingPlanStages(loadedStages),
     );
     final currentTasks = await _runTableStep(
       orderId: orderId,
@@ -539,6 +544,25 @@ class OrderQueueSyncService {
     return Map<String, dynamic>.from(payload)..remove('name');
   }
 
+  Future<List<OrderQueueSyncEntry>> _deleteDuplicatePendingPlanStages(
+    List<OrderQueueSyncEntry> existing,
+  ) async {
+    final seen = <String>{};
+    final kept = <OrderQueueSyncEntry>[];
+    for (final entry in existing) {
+      if (seen.add(entry.identityKey)) {
+        kept.add(entry);
+        continue;
+      }
+      if (!isPendingStatus(entry.status)) {
+        kept.add(entry);
+        continue;
+      }
+      await _deletePendingPlanStage(entry);
+    }
+    return kept;
+  }
+
   Future<void> _deletePlanStageByQueueSlot(
     OrderQueueSyncEntry current, {
     required bool includeStageGroupKey,
@@ -782,11 +806,25 @@ class OrderQueueSyncService {
         );
   }
 
+  Future<void> _deleteDuplicatePendingTasks(
+    List<OrderQueueSyncEntry> existing,
+  ) async {
+    final seen = <String>{};
+    for (final entry in existing) {
+      if (seen.add(entry.identityKey)) continue;
+      if (!isPendingStatus(entry.status)) continue;
+      final id = entry.id?.trim() ?? '';
+      if (id.isEmpty) continue;
+      await _sb.from('tasks').delete().eq('id', id);
+    }
+  }
+
   Future<void> _createMissingTasks(
     String orderId,
     List<OrderQueueSyncEntry> nextQueue,
   ) async {
     final existing = await _loadTasks(orderId);
+    await _deleteDuplicatePendingTasks(existing);
     final existingKeys = existing.map((entry) => entry.identityKey).toSet();
     for (final next in nextQueue) {
       if (!existingKeys.add(next.identityKey)) continue;

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -340,7 +340,9 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
         try {
           final rows = await sb
               .from('v_order_plan_stages')
-              .select('stage_id, stage_name, step_no, order_id, order_code')
+              .select(
+                'stage_id, stage_group_key, stage_name, step_no, order_id, order_code',
+              )
               .or('order_id.eq.$orderId,order_code.eq.$orderCode')
               .order('step_no', ascending: true);
 

--- a/lib/modules/production/production_stages_widget.dart
+++ b/lib/modules/production/production_stages_widget.dart
@@ -4,6 +4,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../orders/order_queue_service.dart';
+
 /// Lightweight widget that reads stages for a given order (by id)
 /// from public.v_order_plan_stages and keeps them live via realtime.
 class ProductionStagesWidget extends StatefulWidget {
@@ -42,18 +44,142 @@ class _ProductionStagesWidgetState extends State<ProductionStagesWidget> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final res = await _sb
-        .from('v_order_plan_stages')
-        .select('*')
-        .eq('order_id', widget.orderId)
-        .order('step_no', ascending: true);
-    final list = (res as List).cast<Map<String, dynamic>>();
+    var list = <Map<String, dynamic>>[];
+    try {
+      final res = await _sb
+          .from('v_order_plan_stages')
+          .select('*')
+          .eq('order_id', widget.orderId)
+          .order('step_no', ascending: true);
+      if (res is List) {
+        list = res
+            .whereType<Map>()
+            .map((row) => Map<String, dynamic>.from(row))
+            .toList(growable: false);
+      }
+    } catch (_) {
+      // Older deployments may not have the view; loadSavedQueue falls back to
+      // prod_plan_stages / saved order JSON using the same priority as the
+      // employee workspace.
+    }
+
+    if (list.isEmpty) {
+      final savedQueue = await OrderQueueService(_sb).loadSavedQueue(
+        widget.orderId,
+      );
+      list = savedQueue.rows;
+    }
+
+    list = _logicalStageRows(list);
+    if (!mounted) return;
     setState(() {
       _rows = list;
       _planId = list.isNotEmpty ? list.first['plan_id'] as String? : null;
       _loading = false;
     });
     _resubscribe();
+  }
+
+  List<Map<String, dynamic>> _logicalStageRows(
+    List<Map<String, dynamic>> rows,
+  ) {
+    final groups = <String, Map<String, dynamic>>{};
+    final order = <String>[];
+    for (var i = 0; i < rows.length; i++) {
+      final row = Map<String, dynamic>.from(rows[i]);
+      final stageId = (row['stage_id'] ?? row['stageId'] ?? row['workplaceId'])
+              ?.toString()
+              .trim() ??
+          '';
+      if (stageId.isEmpty) continue;
+      final explicitGroup = (row['stage_group_key'] ?? row['stageGroupKey'])
+              ?.toString()
+              .trim() ??
+          '';
+      final groupKey = explicitGroup.isEmpty ? stageId : explicitGroup;
+      final group = groups.putIfAbsent(groupKey, () {
+        order.add(groupKey);
+        return <String, dynamic>{
+          ...row,
+          'stage_group_key': groupKey,
+          'workplaceIds': <String>[],
+        };
+      });
+      final ids = (group['workplaceIds'] as List).cast<String>();
+      if (!ids.contains(stageId)) ids.add(stageId);
+      group['stage_id'] ??= stageId;
+      group['stageId'] ??= stageId;
+      group['stage_name'] = _stageName(group, row);
+      group['status'] = _strongerStatus(group['status'], row['status']);
+      group['step_no'] = _minInt(
+        group['step_no'] ?? group['order'],
+        row['step_no'] ?? row['order'] ?? row['seq'],
+        i + 1,
+      );
+      group['order'] = group['step_no'];
+      if (row['plan_id'] != null) group['plan_id'] ??= row['plan_id'];
+    }
+    return order.map((key) => groups[key]!).toList(growable: false)
+      ..sort(
+        (a, b) => _readInt(a['step_no']).compareTo(_readInt(b['step_no'])),
+      );
+  }
+
+  String _stageName(Map<String, dynamic> current, Map<String, dynamic> next) {
+    for (final row in [current, next]) {
+      for (final key in const [
+        'stage_name',
+        'stageName',
+        'name',
+        'workplaceName',
+      ]) {
+        final value = row[key]?.toString().trim();
+        if (value != null && value.isNotEmpty) return value;
+      }
+    }
+    return 'Этап';
+  }
+
+  int _readInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value?.toString() ?? '') ?? 0;
+  }
+
+  int _minInt(dynamic a, dynamic b, int fallback) {
+    final ai = _readInt(a);
+    final bi = _readInt(b);
+    if (ai <= 0 && bi <= 0) return fallback;
+    if (ai <= 0) return bi;
+    if (bi <= 0) return ai;
+    return ai < bi ? ai : bi;
+  }
+
+  String _strongerStatus(dynamic a, dynamic b) {
+    int rank(dynamic status) {
+      switch ((status ?? '').toString().toLowerCase().replaceAll('-', '_')) {
+        case 'completed':
+        case 'complete':
+        case 'done':
+          return 5;
+        case 'inprogress':
+        case 'in_progress':
+        case 'started':
+          return 4;
+        case 'paused':
+        case 'problem':
+          return 3;
+        case 'ready':
+        case 'available':
+          return 2;
+        default:
+          return 1;
+      }
+    }
+
+    return rank(b) > rank(a)
+        ? (b ?? 'waiting').toString()
+        : (a ?? 'waiting').toString();
   }
 
   void _resubscribe() {
@@ -66,7 +192,9 @@ class _ProductionStagesWidgetState extends State<ProductionStagesWidget> {
           schema: 'public',
           table: 'prod_plan_stages',
           filter: PostgresChangeFilter.equals('plan_id', _planId!),
-          callback: (payload) { _load(); },
+          callback: (payload) {
+            _load();
+          },
         )
         .subscribe();
 
@@ -77,7 +205,9 @@ class _ProductionStagesWidgetState extends State<ProductionStagesWidget> {
           schema: 'public',
           table: 'prod_plans',
           filter: PostgresChangeFilter.equals('id', _planId!),
-          callback: (payload) { _load(); },
+          callback: (payload) {
+            _load();
+          },
         )
         .subscribe();
   }
@@ -115,7 +245,10 @@ class _ProductionStagesWidgetState extends State<ProductionStagesWidget> {
     } else if (_rows.isEmpty) {
       body = Padding(
         padding: widget.padding,
-        child: Text('План этапов отсутствует', style: theme.textTheme.bodyMedium),
+        child: Text(
+          'План этапов отсутствует',
+          style: theme.textTheme.bodyMedium,
+        ),
       );
     } else {
       body = Padding(
@@ -142,16 +275,24 @@ class _StageChip extends StatelessWidget {
   const _StageChip({required this.row});
 
   Color _statusColor(BuildContext context, String? status) {
-    switch (status) {
-      case 'inProgress':
+    switch ((status ?? '').toLowerCase().replaceAll('-', '_')) {
+      case 'inprogress':
+      case 'in_progress':
+      case 'started':
         return Colors.blueGrey.shade400;
       case 'paused':
         return const Color(0xFFCCB389); // warm sand
       case 'problem':
         return const Color(0xFFD9A1A3); // soft red
       case 'completed':
+      case 'complete':
+      case 'done':
         return const Color(0xFFA9C4AE); // soft green
       case 'waiting':
+      case 'pending':
+      case 'planned':
+      case 'new':
+      case 'todo':
       default:
         return Colors.grey.shade300;
     }
@@ -160,9 +301,14 @@ class _StageChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final name = row['stage_name'] as String? ?? 'Этап';
-    final no = row['step_no'] as int?;
-    final status = row['status'] as String? ?? 'waiting';
+    final name = row['stage_name']?.toString() ?? 'Этап';
+    final rawNo = row['step_no'];
+    final no = rawNo is int
+        ? rawNo
+        : rawNo is num
+            ? rawNo.toInt()
+            : int.tryParse(rawNo?.toString() ?? '');
+    final status = row['status']?.toString() ?? 'waiting';
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -800,7 +800,9 @@ class TaskProvider with ChangeNotifier {
       ];
       final rows = await _supabase
           .from('v_order_plan_stages')
-          .select('stage_id, stage_name, step_no, order_id, order_code')
+          .select(
+            'stage_id, stage_group_key, stage_name, step_no, order_id, order_code',
+          )
           .or(filters.join(','))
           .order('step_no', ascending: true);
       final seq = await fromRows(rows);
@@ -818,7 +820,9 @@ class TaskProvider with ChangeNotifier {
       ];
       final rows = await _supabase
           .from('production.v_plan_with_stages')
-          .select('stage_id, stage_name, step_no, order_id, order_code')
+          .select(
+            'stage_id, stage_group_key, stage_name, step_no, order_id, order_code',
+          )
           .or(filters.join(','))
           .order('step_no', ascending: true);
       final seq = await fromRows(rows);

--- a/supabase/migrations/20260508_sync_order_plan_stage_groups.sql
+++ b/supabase/migrations/20260508_sync_order_plan_stage_groups.sql
@@ -1,0 +1,150 @@
+alter table if exists public.tasks
+  add column if not exists stage_group_key text;
+
+update public.tasks
+set stage_group_key = stage_id
+where coalesce(stage_group_key, '') = ''
+  and coalesce(stage_id, '') <> '';
+
+create index if not exists tasks_order_stage_group_idx
+  on public.tasks(order_id, stage_group_key);
+
+alter table if exists public.prod_plan_stages
+  add column if not exists stage_id text;
+
+alter table if exists public.prod_plan_stages
+  add column if not exists stage_group_key text;
+
+alter table if exists public.prod_plan_stages
+  add column if not exists step_no integer;
+
+update public.prod_plan_stages
+set stage_group_key = stage_id
+where coalesce(stage_group_key, '') = ''
+  and coalesce(stage_id, '') <> '';
+
+update public.prod_plan_stages
+set step_no = seq
+where step_no is null
+  and seq is not null;
+
+create index if not exists prod_plan_stages_plan_group_step_idx
+  on public.prod_plan_stages(plan_id, stage_group_key, step_no);
+
+do $$
+declare
+  stage_name_expr text := 'pps.stage_id';
+  order_code_expr text := 'null::text';
+  workplace_join text := '';
+  started_expr text := 'null::text as started_at';
+  finished_expr text := 'null::text as finished_at';
+  completed_expr text := 'null::text as completed_at';
+  executor_expr text := 'null::text as executor_id';
+  assigned_expr text := 'null::text as assigned_employee_id';
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'orders'
+      and column_name = 'assignment_id'
+  ) then
+    order_code_expr := 'o.assignment_id';
+  end if;
+
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'public' and table_name = 'workplaces'
+  ) then
+    workplace_join := ' left join public.workplaces w on w.id = pps.stage_id ';
+    stage_name_expr := 'coalesce(pps.stage_id, '''')';
+    if exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'workplaces'
+        and column_name = 'title'
+    ) then
+      stage_name_expr := 'coalesce(w.title, ' || stage_name_expr || ')';
+    end if;
+    if exists (
+      select 1 from information_schema.columns
+      where table_schema = 'public' and table_name = 'workplaces'
+        and column_name = 'name'
+    ) then
+      stage_name_expr := 'coalesce(w.name, ' || stage_name_expr || ')';
+    end if;
+  end if;
+
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'prod_plan_stages'
+      and column_name = 'stage_name'
+  ) then
+    stage_name_expr := 'coalesce(pps.stage_name, ' || stage_name_expr || ')';
+  end if;
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'prod_plan_stages'
+      and column_name = 'name'
+  ) then
+    stage_name_expr := 'coalesce(pps.name, ' || stage_name_expr || ')';
+  end if;
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'prod_plan_stages'
+      and column_name = 'started_at'
+  ) then
+    started_expr := 'pps.started_at';
+  end if;
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'prod_plan_stages'
+      and column_name = 'finished_at'
+  ) then
+    finished_expr := 'pps.finished_at';
+  end if;
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'prod_plan_stages'
+      and column_name = 'completed_at'
+  ) then
+    completed_expr := 'pps.completed_at';
+  end if;
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'prod_plan_stages'
+      and column_name = 'executor_id'
+  ) then
+    executor_expr := 'pps.executor_id';
+  end if;
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'prod_plan_stages'
+      and column_name = 'assigned_employee_id'
+  ) then
+    assigned_expr := 'pps.assigned_employee_id';
+  end if;
+
+  execute 'drop view if exists public.v_order_plan_stages';
+
+  execute 'create view public.v_order_plan_stages as
+    select
+      pp.order_id,
+      ' || order_code_expr || ' as order_code,
+      pp.id as plan_id,
+      pps.id as plan_stage_id,
+      pps.stage_id,
+      coalesce(pps.stage_group_key, pps.stage_id) as stage_group_key,
+      ' || stage_name_expr || ' as stage_name,
+      coalesce(pps.step_no, pps.seq) as step_no,
+      pps.seq,
+      pps.status,
+      ' || started_expr || ',
+      ' || finished_expr || ',
+      ' || completed_expr || ',
+      ' || executor_expr || ',
+      ' || assigned_expr || '
+    from public.prod_plans pp
+    join public.prod_plan_stages pps on pps.plan_id = pp.id
+    left join public.orders o on o.id = pp.order_id'
+    || workplace_join;
+end $$;
+
+notify pgrst, 'reload schema';

--- a/test/order_queue_sync_service_test.dart
+++ b/test/order_queue_sync_service_test.dart
@@ -145,6 +145,28 @@ void main() {
     expect(entries.map((entry) => entry.step), [1, 2]);
   });
 
+  test('OrderQueueMapper keeps separate normalized rows in the same group', () {
+    final entries = OrderQueueMapper.toSyncEntries(const [
+      {
+        'stage_id': 'die-cut-a1',
+        'stage_group_key': 'die_cut',
+        'step_no': 5,
+      },
+      {
+        'stage_id': 'die-cut-a2',
+        'stage_group_key': 'die_cut',
+        'step_no': 5,
+      },
+    ]);
+
+    expect(entries.map((entry) => entry.stageId), [
+      'die-cut-a1',
+      'die-cut-a2',
+    ]);
+    expect(entries.map((entry) => entry.stageGroupKey).toSet(), {'die_cut'});
+    expect(entries.map((entry) => entry.step), [5, 5]);
+  });
+
   test('physical seq stays unique for parallel stages on the same logical step', () {
     const firstAlternative = OrderQueueSyncEntry(
       stageId: 'die-cut-a1',


### PR DESCRIPTION
### Motivation
- Restore a single source of truth for order stage queues so the order form, normalized plan rows (`prod_plan_stages`), tasks and the production UI all see the same queue and group stages consistently.
- Prevent data loss, duplicates and accidental overwrites when editing or launching orders by protecting started/completed stages and removing only pending duplicates.

### Description
- Preserve all normalized plan rows when mapping saved queues: `OrderQueueMapper.toSyncEntries` no longer collapses rows that share a `stage_group_key` so grouped stages keep every workplace member (e.g. Высечка A1/A2). (modified `lib/modules/orders/order_queue_service.dart`)
- During sync, remove only pending duplicate rows from `prod_plan_stages` and `tasks` and keep protected statuses intact, and use the cleaned set for diffing; added helpers `_deleteDuplicatePendingPlanStages` and `_deleteDuplicatePendingTasks`. (modified `lib/modules/orders/order_queue_sync_service.dart`)
- Make production UI use the same source of truth as TaskProvider/OrderQueueService: `ProductionStagesWidget` now reads `v_order_plan_stages` with fallback to `OrderQueueService.loadSavedQueue`, groups physical rows into logical stages by `stage_group_key`, aggregates `workplaceIds`, step/order and group status and displays consistent grouped stages. (modified `lib/modules/production/production_stages_widget.dart`)
- Ensure workspace fallback reads include `stage_group_key` so TaskProvider and ProductionDetails use the same grouping, and add a Supabase migration that populates/indices `stage_group_key`, `stage_id`, `step_no`, and (re)creates `v_order_plan_stages` to support the new behavior. (modified `lib/modules/tasks/task_provider.dart`, `lib/modules/production/production_details_screen.dart`, added `supabase/migrations/20260508_sync_order_plan_stage_groups.sql`)
- Add a regression unit test that keeps separate normalized rows in the same `stage_group_key` and preserves steps/member rows. (modified `test/order_queue_sync_service_test.dart`)

### Testing
- Ran repository checks including `git diff --check` and inspected diffs; changes committed successfully.
- Added a regression unit test (`OrderQueueMapper` grouping) but full `flutter test` could not be executed in this environment because `flutter` is not installed, so tests were not run here.
- Attempted `flutter analyze` but it could not run in the container for the same reason, so static analysis was not executed here.
- Verified via code inspection that `OrderQueueService.loadSavedQueue` priority and `OrderQueueSyncService.diff` protection remain unchanged and that widget/provider fallbacks now request `stage_group_key` to keep ordering/grouping consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcda59d58832fbbd42fd7ca27fd57)