### PR TITLE
Fix production visibility for parallel stage groups

### DIFF
--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -262,6 +262,17 @@ Map<String, _StageGroupInfo> _buildProductionStageGroupsForOrder({
     }
   }
 
+  final plannedIdsByGroup = <String, List<String>>{};
+  for (final id in sequence) {
+    final mappedGroupKey = stageGroupMap[id]?.trim();
+    final groupKey = mappedGroupKey != null && mappedGroupKey.isNotEmpty
+        ? mappedGroupKey
+        : id;
+    plannedIdsByGroup.putIfAbsent(groupKey, () => <String>[]);
+    final ids = plannedIdsByGroup[groupKey]!;
+    if (!ids.contains(id)) ids.add(id);
+  }
+
   final tasksByGroup = <String, List<TaskModel>>{};
   final firstTaskByStage = <String, TaskModel>{};
   for (final task in orderTasks) {
@@ -300,7 +311,7 @@ Map<String, _StageGroupInfo> _buildProductionStageGroupsForOrder({
     if (tasksByGroup.containsKey(groupKey)) {
       addTaskBackedGroup(groupKey, sequenceStageId: id);
     } else {
-      addGroup([id], explicitKey: groupKey);
+      addGroup(plannedIdsByGroup[groupKey] ?? [id], explicitKey: groupKey);
     }
   }
 
@@ -387,15 +398,15 @@ _OrderGroupingData _groupingForOrderData({
 
   void addVisibleForGroup(_StageGroupInfo group) {
     final groupTasks = tasksByGroup[group.key] ?? const <TaskModel>[];
-    final firstGroupWorkplace =
-        firstNonEmpty(group.stageIds.map((stageId) => stageId));
-    if (firstGroupWorkplace.isEmpty) return;
+    if (firstNonEmpty(group.stageIds.map((stageId) => stageId)).isEmpty) {
+      return;
+    }
 
     if (groupTasks.isEmpty) {
       // Saved queues may describe planned stages before task rows are created.
-      // Show the current/first workplace as a waiting destination so the order
-      // still appears in the left production menu.
-      visibleWorkplaceIds.add(firstGroupWorkplace);
+      // Show every workplace from a parallel stage group so the order is visible
+      // on all equivalent workstations, not only on the first one.
+      visibleWorkplaceIds.addAll(group.stageIds);
       return;
     }
 
@@ -421,9 +432,10 @@ _OrderGroupingData _groupingForOrderData({
       return;
     }
 
-    // For switchable groups with only waiting tasks, add the selected variant
-    // from the saved queue/group order instead of every alternative task row.
-    visibleWorkplaceIds.add(firstGroupWorkplace);
+    // Waiting parallel groups must be available on every equivalent
+    // workstation; switchable stages still contain only the selected workplace
+    // in the saved queue, so they remain visible on one selected tab.
+    visibleWorkplaceIds.addAll(group.stageIds);
   }
 
   for (final group in stageGroups.values) {
@@ -721,22 +733,24 @@ class _ProductionScreenState extends State<ProductionScreen>
       for (final group in grouping.stageGroups.values) {
         if (group.stageIds.isEmpty) continue;
 
-        final tabId = group.stageIds.first.trim();
-        if (tabId.isEmpty || !grouping.visibleWorkplaceIds.contains(tabId)) {
-          continue;
-        }
-
         final groupTasks =
             grouping.tasksByGroup[group.key] ?? const <TaskModel>[];
         if (_groupCompleted(groupTasks)) continue;
 
-        activeStageTabs.putIfAbsent(
-          tabId,
-          () => _ProductionTabInfo(
-            id: tabId,
-            label: workplaceNamesById[tabId] ?? group.label,
-          ),
-        );
+        for (final stageId in group.stageIds) {
+          final tabId = stageId.trim();
+          if (tabId.isEmpty || !grouping.visibleWorkplaceIds.contains(tabId)) {
+            continue;
+          }
+
+          activeStageTabs.putIfAbsent(
+            tabId,
+            () => _ProductionTabInfo(
+              id: tabId,
+              label: workplaceNamesById[tabId] ?? group.label,
+            ),
+          );
+        }
       }
     }
 

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -301,6 +301,148 @@ void main() {
     },
   );
 
+  test(
+    'production left menu shows every workplace in a parallel stage group',
+    () {
+      final order = OrderModel(
+        id: 'parallel-group-order',
+        manager: '',
+        customer: 'Parallel customer',
+        orderDate: DateTime(2026, 5, 8),
+        dueDate: null,
+        product: ProductModel(
+          id: 'product',
+          type: kTwoSheetPackageProductTypeId,
+          quantity: 1000,
+          width: 0,
+          height: 0,
+          depth: 0,
+        ),
+        status: OrderStatus.in_production.name,
+      );
+
+      const plannedSequence = [
+        kSheetCutStageId,
+        kDieCutA1WorkplaceId,
+        kDieCutA2WorkplaceId,
+        kPackagingStageId,
+      ];
+      const stageGroupMap = {
+        kDieCutA1WorkplaceId: kDieCutA1A2StageId,
+        kDieCutA2WorkplaceId: kDieCutA1A2StageId,
+      };
+      const stageNames = {
+        kSheetCutStageId: 'Листорезка',
+        kDieCutA1WorkplaceId: 'Высечка A1',
+        kDieCutA2WorkplaceId: 'Высечка A2',
+        kPackagingStageId: 'Упаковка',
+      };
+
+      TaskModel task(String stageId, {String? groupKey}) => TaskModel(
+            id: 'task-$stageId',
+            orderId: order.id,
+            stageId: stageId,
+            stageGroupKey: groupKey ?? stageId,
+          );
+
+      final visibleWorkplaces = productionVisibleWorkplaceIdsForTesting(
+        order: order,
+        orderTasks: [
+          task(kSheetCutStageId),
+          task(kDieCutA1WorkplaceId, groupKey: kDieCutA1A2StageId),
+          task(kDieCutA2WorkplaceId, groupKey: kDieCutA1A2StageId),
+          task(kPackagingStageId),
+        ],
+        plannedSequence: plannedSequence,
+        stageGroupMap: stageGroupMap,
+        stageNames: stageNames,
+      );
+      final labels = productionStageLabelsForTesting(
+        order: order,
+        orderTasks: [
+          task(kSheetCutStageId),
+          task(kDieCutA1WorkplaceId, groupKey: kDieCutA1A2StageId),
+          task(kDieCutA2WorkplaceId, groupKey: kDieCutA1A2StageId),
+          task(kPackagingStageId),
+        ],
+        plannedSequence: plannedSequence,
+        stageGroupMap: stageGroupMap,
+        stageNames: stageNames,
+      );
+
+      expect(visibleWorkplaces, containsAll([
+        kSheetCutStageId,
+        kDieCutA1WorkplaceId,
+        kDieCutA2WorkplaceId,
+        kPackagingStageId,
+      ]));
+      expect(labels, [
+        'Листорезка',
+        'Высечка A1 / Высечка A2',
+        'Упаковка',
+      ]);
+    },
+  );
+
+  test(
+    'production saved queue keeps parallel stage group together without task rows',
+    () {
+      final order = OrderModel(
+        id: 'parallel-group-without-tasks',
+        manager: '',
+        customer: 'Parallel plan customer',
+        orderDate: DateTime(2026, 5, 8),
+        dueDate: null,
+        product: ProductModel(
+          id: 'product',
+          type: kTwoSheetPackageProductTypeId,
+          quantity: 1000,
+          width: 0,
+          height: 0,
+          depth: 0,
+        ),
+        status: OrderStatus.in_production.name,
+      );
+
+      const plannedSequence = [
+        kDieCutA1WorkplaceId,
+        kDieCutA2WorkplaceId,
+        kScotchStageId,
+      ];
+      const stageGroupMap = {
+        kDieCutA1WorkplaceId: kDieCutA1A2StageId,
+        kDieCutA2WorkplaceId: kDieCutA1A2StageId,
+      };
+      const stageNames = {
+        kDieCutA1WorkplaceId: 'Высечка A1',
+        kDieCutA2WorkplaceId: 'Высечка A2',
+        kScotchStageId: 'Скотч',
+      };
+
+      final visibleWorkplaces = productionVisibleWorkplaceIdsForTesting(
+        order: order,
+        orderTasks: const [],
+        plannedSequence: plannedSequence,
+        stageGroupMap: stageGroupMap,
+        stageNames: stageNames,
+      );
+      final labels = productionStageLabelsForTesting(
+        order: order,
+        orderTasks: const [],
+        plannedSequence: plannedSequence,
+        stageGroupMap: stageGroupMap,
+        stageNames: stageNames,
+      );
+
+      expect(visibleWorkplaces, [
+        kDieCutA1WorkplaceId,
+        kDieCutA2WorkplaceId,
+        kScotchStageId,
+      ]);
+      expect(labels, ['Высечка A1 / Высечка A2', 'Скотч']);
+    },
+  );
+
   test('production All chips include planned stages without task rows', () {
     final order = OrderModel(
       id: 'order-with-plan-without-tasks',


### PR DESCRIPTION
### Motivation
- Parallel production stages that map to multiple workplaces were collapsed to a single workplace in the UI and left-menu, causing orders to be missing from some workplaces. 
- Waiting parallel stage groups should be visible on every equivalent workstation and remain grouped in the saved queue representation, while after capture they should be shown only on the capturing workplace.

### Description
- Keep planned workplace IDs together when reconstructing stage groups: build a `plannedIdsByGroup` map from the planned sequence and use it when creating a group that has no task rows so all parallel workplaces remain in the group. (modified `lib/modules/production/production_screen.dart`)
- Make waiting parallel groups visible on every workplace in the group by adding all `group.stageIds` to `visibleWorkplaceIds` when no tasks exist, and keep the captured/active logic intact for showing only the capturing workplace when a task is captured. (modified `lib/modules/production/production_screen.dart`)
- Create production tabs for every visible workplace in a parallel group instead of only the first workplace, so the left production menu shows all equivalent workstations. (modified `lib/modules/production/production_screen.dart`)
- Add regression tests that cover parallel groups with and without task rows and assert that the visible workplace list and displayed group labels are correct. (added tests to `test/stage_queue_builder_test.dart`)

### Testing
- Added unit tests in `test/stage_queue_builder_test.dart` to cover parallel-group visibility and saved-queue grouping; these tests are included but were not executed in this environment. 
- Ran quick repository checks: `git diff --check` completed successfully in the environment. 
- Attempt to run `dart format ... && flutter test ...` failed because `dart`/`flutter` are not available in the execution environment, so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016b130c3c832fb0efa8c165bb6eb1)