### PR TITLE
Fix handle workplace routing and correct manual handle UUID

### DIFF
--- a/lib/modules/orders/order_stage_filter.dart
+++ b/lib/modules/orders/order_stage_filter.dart
@@ -2,7 +2,7 @@ enum OrderHandleType { none, flat, twisted, dieCut }
 
 const String flatHandleStageId = '6ffdf2d9-3f57-45ca-9fad-dd700ac5c320';
 const String twistedHandleStageId = 'c51ebb2e-dac8-4068-9e4c-ce0d8b975626';
-const String manualHandleStageId = 'c25acbfa-390a-4e87-84aa-536055e013f4';
+const String manualHandleStageId = 'c25ac6fa-390a-4e87-84aa-536055e013f4';
 const String dieCutHandleStageId = '4925309c-a2c6-4f5f-9f5e-7dd5ff38827d';
 const String cuttingStageId = 'c828062f-a6a6-4fe5-b01b-c51e36fe5fba';
 const String kCardboardCuttingStageId =

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -480,6 +480,7 @@ class _OrderStageQueueBuilder {
     if (_isSheetProduct(productTypeId)) {
       _add(_stage(kSheetCutStageId, 'Листорезка'));
       if (draft.hasTrimming) _add(_stage(kCuttingStageId, 'Резка'));
+      _appendHandleStage();
       return;
     }
     if (_isVTypeProduct(productTypeId)) {
@@ -491,6 +492,7 @@ class _OrderStageQueueBuilder {
         fallbackSelectedId: kFriStageId,
       ));
       if (draft.hasTrimming) _add(_stage(kCuttingStageId, 'Резка'));
+      _appendHandleStage();
       return;
     }
     if (_isTwoSheetPackageProduct(productTypeId)) {

--- a/test/order_stage_filter_test.dart
+++ b/test/order_stage_filter_test.dart
@@ -4,6 +4,10 @@ import 'package:sheet_clone/modules/orders/order_stage_filter.dart';
 Map<String, dynamic> _stage(String id) => {'stageId': id, 'stageName': id};
 
 void main() {
+  test('manual handle stage id matches production workplace id', () {
+    expect(manualHandleStageId, 'c25ac6fa-390a-4e87-84aa-536055e013f4');
+  });
+
   final baseStages = [
     _stage(flatHandleStageId),
     _stage(twistedHandleStageId),

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -1248,6 +1248,31 @@ void main() {
       );
     });
 
+    test('Листы: adds flat handle as one multi-workplace stage', () {
+      final result = buildOrderStages(
+        const OrderStageQueueDraft(
+          productTypeId: kSheetProductTypeId,
+          orderWidthB: 600,
+          materialWidth: 600,
+          hasPaint: false,
+          hasTrimming: false,
+          hasCardboard: false,
+          handleType: OrderHandleType.flat,
+        ),
+      );
+
+      expectBuiltStages(
+        result,
+        [kSheetCutStageId, kFlatHandleGroupStageId, kPackagingStageId],
+        workplaceIdsByStageKey: const {
+          kFlatHandleGroupStageId: [
+            kFlatHandleStageId,
+            kManualHandleStageId,
+          ],
+        },
+      );
+    });
+
     test('В-образные UUID products default to Фри and disable cardboard', () {
       for (final productTypeId in kVTypeProducts) {
         final result = buildOrderStages(
@@ -1327,6 +1352,40 @@ void main() {
         [kVMainSwitchStageKey, kCuttingStageId, kPackagingStageId],
         workplaceIdsByStageKey: const {
           kVMainSwitchStageKey: [kFriStageId, kWindowStageId],
+        },
+        selectedWorkplaceIdsByStageKey: const {
+          kVMainSwitchStageKey: kFriStageId,
+        },
+      );
+    });
+
+    test('В-образный: adds twisted handle as one multi-workplace stage', () {
+      final result = buildOrderStages(
+        const OrderStageQueueDraft(
+          productTypeId: kVTypeProductAltId,
+          orderWidthB: 600,
+          materialWidth: 600,
+          hasPaint: false,
+          hasTrimming: true,
+          hasCardboard: false,
+          handleType: OrderHandleType.twisted,
+        ),
+      );
+
+      expectBuiltStages(
+        result,
+        [
+          kVMainSwitchStageKey,
+          kCuttingStageId,
+          kTwistedHandleGroupStageId,
+          kPackagingStageId,
+        ],
+        workplaceIdsByStageKey: const {
+          kVMainSwitchStageKey: [kFriStageId, kWindowStageId],
+          kTwistedHandleGroupStageId: [
+            kTwistedHandleStageId,
+            kManualHandleStageId,
+          ],
         },
         selectedWorkplaceIdsByStageKey: const {
           kVMainSwitchStageKey: kFriStageId,


### PR DESCRIPTION
### Motivation
- Fix incorrect manual handle workplace UUID and ensure handle stages are added for sheet and V-type products so manual handle workplace appears as the second workplace in a single stage when flat/twisted handles are selected.

### Description
- Corrected `manualHandleStageId` constant value in `lib/modules/orders/order_stage_filter.dart` to the production workplace UUID `c25ac6fa-390a-4e87-84aa-536055e013f4`.
- Added calls to `_appendHandleStage()` for sheet and V-type product branches in `lib/modules/orders/stage_queue_builder.dart` so flat/twisted handle selection produces a single multi-workplace handle stage that includes the manual handle workplace.
- Added unit tests: `test/order_stage_filter_test.dart` now contains a test asserting the manual handle ID matches the production UUID, and `test/stage_queue_builder_test.dart` includes tests that cover sheet flat-handle and V-type twisted-handle routing producing one multi-workplace handle stage with the manual workplace.

### Testing
- `flutter test test/stage_queue_builder_test.dart test/order_stage_filter_test.dart` was attempted and failed because the Flutter SDK is not installed in the execution environment.
- `dart format --output=none --set-exit-if-changed lib/modules/orders/order_stage_filter.dart lib/modules/orders/stage_queue_builder.dart test/order_stage_filter_test.dart test/stage_queue_builder_test.dart` was attempted and failed because the Dart SDK is not installed in the execution environment.
- The change set includes added regression tests; please run the above `flutter test` and `dart format` commands in a local or CI environment with Flutter/Dart SDKs to validate all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0170cc35b0832f8a65b03663eb2348)