### PR TITLE
Обновлять список заданий в рабочем пространстве после запуска заказа

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -672,6 +672,8 @@ class _TasksScreenState extends State<TasksScreen>
   bool _selectionUpdateScheduled = false;
   String? _lastQueueSyncGroupId;
   String? _lastQueueSyncIdsSignature;
+  String? _lastLaunchedOrderIdsSignature;
+  bool _taskRefreshAfterLaunchScheduled = false;
   final Set<String> _startingTaskIds = <String>{};
   String? get _selectedWorkplaceId => _selection.workplaceId;
   set _selectedWorkplaceId(String? value) {
@@ -778,6 +780,38 @@ class _TasksScreenState extends State<TasksScreen>
         duration: const Duration(milliseconds: 220),
         curve: Curves.easeOut,
       );
+    });
+  }
+
+  void _scheduleTaskRefreshForLaunchedOrders({
+    required Iterable<OrderModel> orders,
+    required TaskProvider taskProvider,
+  }) {
+    final launchedOrderIds = orders
+        .where((order) =>
+            order.assignmentCreated ||
+            order.statusEnum == OrderStatus.in_production)
+        .map((order) => order.id.trim())
+        .where((id) => id.isNotEmpty)
+        .toList()
+      ..sort();
+    final signature = launchedOrderIds.join('|');
+    if (_lastLaunchedOrderIdsSignature == signature) return;
+
+    _lastLaunchedOrderIdsSignature = signature;
+    if (signature.isEmpty || _taskRefreshAfterLaunchScheduled) return;
+
+    _taskRefreshAfterLaunchScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) {
+        _taskRefreshAfterLaunchScheduled = false;
+        return;
+      }
+      try {
+        await taskProvider.refresh();
+      } finally {
+        _taskRefreshAfterLaunchScheduled = false;
+      }
     });
   }
 
@@ -2007,7 +2041,12 @@ class _TasksScreenState extends State<TasksScreen>
     final templateProvider = context.watch<TemplateProvider>();
     final queue = context.watch<ProductionQueueProvider>();
 
-    final orderIds = ordersProvider.orders.map((o) => o.id).toList(growable: false);
+    final orderIds =
+        ordersProvider.orders.map((o) => o.id).toList(growable: false);
+    _scheduleTaskRefreshForLaunchedOrders(
+      orders: ordersProvider.orders,
+      taskProvider: taskProvider,
+    );
 
     final media = MediaQuery.of(context);
     final bool isTablet =


### PR DESCRIPTION
### Motivation
- После запуска заказа создаются задачи в таблице `tasks`, но при пропущенных realtime-сообщениях они не всегда появляются в рабочем пространстве исполнителя, поэтому нужно принудительно подгружать список задач для только что запущенных заказов. 

### Description
- В `lib/modules/tasks/tasks_screen.dart` добавлены поля `_lastLaunchedOrderIdsSignature` и `_taskRefreshAfterLaunchScheduled` для отслеживания уже обработанных подписок и предотвращения лишних обновлений. 
- Добавлен метод `_scheduleTaskRefreshForLaunchedOrders(...)`, который собирает сигнатуру запущенных/в производстве заказов и в post-frame вызывает `TaskProvider.refresh()` при изменении сигнатуры. 
- В `build()` экрана задач вызов `_scheduleTaskRefreshForLaunchedOrders(...)` интегрирован сразу после получения `OrdersProvider` и `TaskProvider`, чтобы обеспечить обновление списка заданий при появлении новых production-задач. 

### Testing
- Выполнена проверка стиля/конфликта с `git diff --check`, которая не выявила проблем. 
- Попытка запустить `flutter test test/order_queue_sync_service_test.dart` не была выполнена в CI окружении, потому что `flutter` не установлен (`flutter: command not found`). 
- Попытка применить `dart format lib/modules/tasks/tasks_screen.dart` не выполнена из-за отсутствия `dart` в окружении (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0174a832cc832f84495508e7cd2417)