### PR TITLE
Hide unlaunched order tasks from workspace

### DIFF
--- a/lib/modules/tasks/task_visibility.dart
+++ b/lib/modules/tasks/task_visibility.dart
@@ -1,0 +1,13 @@
+import '../orders/order_model.dart';
+
+/// Returns whether a task may be displayed in an employee workspace.
+///
+/// Task rows can already exist for orders that were saved/prepared but not yet
+/// launched into production. The workspace should only expose tasks once the
+/// order is considered launched. If the order is not available locally yet, the
+/// caller may keep the task visible to avoid hiding data during provider loading.
+bool isTaskOrderLaunchedForWorkspace(OrderModel? order) {
+  if (order == null) return true;
+  return order.assignmentCreated ||
+      order.statusEnum == OrderStatus.in_production;
+}

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -23,6 +23,7 @@ import '../warehouse/warehouse_provider.dart';
 import 'task_model.dart';
 import 'task_completion_rules.dart';
 import 'task_provider.dart';
+import 'task_visibility.dart';
 import 'stage_sequence_utils.dart' as stage_sequence;
 import '../common/pdf_view_screen.dart';
 import '../../services/storage_service.dart';
@@ -2210,7 +2211,12 @@ class _TasksScreenState extends State<TasksScreen>
         : '';
     final stageTasksAll = _selectedWorkplaceId == null
         ? const <TaskModel>[]
-        : taskProvider.tasks.where((t) => t.stageId == _selectedWorkplaceId).toList();
+        : taskProvider.tasks
+            .where((t) => t.stageId == _selectedWorkplaceId)
+            .where((task) => isTaskOrderLaunchedForWorkspace(
+                  findOrder(task.orderId),
+                ))
+            .toList();
     final stageQueueIds = stageTasksAll
         .map((task) => _queueOrderIdForTask(task, ordersProvider))
         .where((id) => id.isNotEmpty)
@@ -4086,6 +4092,18 @@ class _TasksScreenState extends State<TasksScreen>
     if (_selectedWorkplaceId == null) return const <TaskModel>[];
 
     final ordersProvider = context.read<OrdersProvider>();
+    OrderModel? findTaskOrder(String id) {
+      for (final order in ordersProvider.orders) {
+        if (order.id == id) return order;
+      }
+      for (final order in ordersProvider.orders) {
+        if (order.assignmentId != null && order.assignmentId == id) {
+          return order;
+        }
+      }
+      return null;
+    }
+
     final templateProvider = context.read<TemplateProvider>();
     final stageGroupByOrder = <String, Map<String, String>>{};
     for (final order in ordersProvider.orders) {
@@ -4102,8 +4120,9 @@ class _TasksScreenState extends State<TasksScreen>
     String taskGroupKey(TaskModel task) {
       final lookup = stageGroupByOrder[task.orderId];
       final persistedGroup = task.stageGroupKey.trim();
-      final groupKey =
-          persistedGroup.isNotEmpty ? persistedGroup : (lookup?[task.stageId] ?? task.stageId);
+      final groupKey = persistedGroup.isNotEmpty
+          ? persistedGroup
+          : (lookup?[task.stageId] ?? task.stageId);
       return '${task.orderId}::$groupKey';
     }
 
@@ -4115,6 +4134,9 @@ class _TasksScreenState extends State<TasksScreen>
 
     return taskProvider.tasks
         .where((t) => t.stageId == _selectedWorkplaceId)
+        .where((task) => isTaskOrderLaunchedForWorkspace(
+              findTaskOrder(task.orderId),
+            ))
         .where((t) => !_isEffectivelyCompleted(t))
         .where((task) {
           final groupKey = taskGroupKey(task);

--- a/test/task_visibility_test.dart
+++ b/test/task_visibility_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/order_model.dart';
+import 'package:sheet_clone/modules/orders/product_model.dart';
+import 'package:sheet_clone/modules/tasks/task_visibility.dart';
+
+void main() {
+  OrderModel order({
+    required OrderStatus status,
+    required bool assignmentCreated,
+  }) {
+    return OrderModel(
+      id: 'order-1',
+      manager: 'manager',
+      customer: 'customer',
+      orderDate: DateTime(2026, 5, 11),
+      dueDate: null,
+      product: ProductModel(
+        id: 'product-1',
+        type: 'Пакет',
+        quantity: 100,
+        width: 10,
+        height: 20,
+        depth: 5,
+      ),
+      status: status.name,
+      assignmentCreated: assignmentCreated,
+    );
+  }
+
+  test('hides tasks for saved orders that are not launched yet', () {
+    expect(
+      isTaskOrderLaunchedForWorkspace(
+        order(
+          status: OrderStatus.ready_to_start,
+          assignmentCreated: false,
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      isTaskOrderLaunchedForWorkspace(
+        order(
+          status: OrderStatus.waiting_materials,
+          assignmentCreated: false,
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      isTaskOrderLaunchedForWorkspace(
+        order(
+          status: OrderStatus.draft,
+          assignmentCreated: false,
+        ),
+      ),
+      isFalse,
+    );
+  });
+
+  test('shows tasks once the order is launched', () {
+    expect(
+      isTaskOrderLaunchedForWorkspace(
+        order(
+          status: OrderStatus.in_production,
+          assignmentCreated: true,
+        ),
+      ),
+      isTrue,
+    );
+  });
+
+  test('keeps tasks visible while order data is not loaded locally', () {
+    expect(isTaskOrderLaunchedForWorkspace(null), isTrue);
+  });
+}


### PR DESCRIPTION
### Motivation
- Tasks created for orders that are saved/prepared but not launched should not appear in employee workspaces to avoid showing non-actionable rows.

### Description
- Add helper `isTaskOrderLaunchedForWorkspace(OrderModel? order)` in `lib/modules/tasks/task_visibility.dart` that returns true only when `order.assignmentCreated` or `order.statusEnum == OrderStatus.in_production`, and returns true for `null` to avoid hiding tasks while orders are not loaded locally.
- Apply the visibility filter to the workspace queue/queue-sync source by filtering `taskProvider.tasks` with `isTaskOrderLaunchedForWorkspace(findOrder(task.orderId))` in `lib/modules/tasks/tasks_screen.dart` where `stageTasksAll` is built.
- Apply the same filter to the per-workplace task list in `TasksScreen._tasksForWorkplace` using a local `findTaskOrder` (search by `order.id` and fallback to `order.assignmentId`).
- Add unit tests exercising saved/unlaunched states, launched state and the `null` (order not loaded) case in `test/task_visibility_test.dart`.

### Testing
- Created `test/task_visibility_test.dart` covering `draft`, `waiting_materials`, `ready_to_start`, `in_production` and `null` order cases (tests added but not executed in CI here).
- Ran `git diff --check` and staged changes; no diff-check issues were reported.
- Attempted to run `flutter test test/task_visibility_test.dart` but the Flutter/Dart SDK is not available in this environment so the unit test was not executed (automated test run failed due to missing `flutter` command).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01863bd6e4832f962a19f1527544d9)