### PR TITLE
Явная сборка очереди, обмен Флекс/Бобин и упрощённый селектор этапов

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1257,6 +1257,63 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     return options.isEmpty ? null : options.first;
   }
 
+  bool _isBobbinPreviewStage(Map<String, dynamic> stage) {
+    final id = _selectedSwitchableIdFromPreviewStage(stage)?.toLowerCase();
+    if (id == kBobbinStageId || kLegacyBobbinStageAliases.contains(id)) {
+      return true;
+    }
+    final name = _resolveStageName(stage).toLowerCase();
+    return name.contains('бобин') ||
+        name.contains('бабин') ||
+        name.contains('bobbin');
+  }
+
+  bool _isFlexPrintingPreviewStage(Map<String, dynamic> stage) {
+    final id = _selectedSwitchableIdFromPreviewStage(stage)?.toLowerCase();
+    if (id == kFlexPrintingStageId ||
+        kLegacyFlexPrintingStageAliases.contains(id)) {
+      return true;
+    }
+    final name = _resolveStageName(stage).toLowerCase();
+    return name.contains('флекс') || name.contains('flexo');
+  }
+
+  bool _canSwapBobbinFlexStage(int index) {
+    if (index < 0 || index >= _stagePreviewStages.length) return false;
+    final stage = _stagePreviewStages[index];
+    if (!_isBobbinPreviewStage(stage) && !_isFlexPrintingPreviewStage(stage)) {
+      return false;
+    }
+    return _stagePreviewStages.any(_isBobbinPreviewStage) &&
+        _stagePreviewStages.any(_isFlexPrintingPreviewStage);
+  }
+
+  void _swapBobbinFlexStages() {
+    final bobbinIndex = _stagePreviewStages.indexWhere(_isBobbinPreviewStage);
+    final flexIndex =
+        _stagePreviewStages.indexWhere(_isFlexPrintingPreviewStage);
+    if (bobbinIndex < 0 || flexIndex < 0 || bobbinIndex == flexIndex) return;
+
+    setState(() {
+      final updated = _stagePreviewStages
+          .map((stage) => Map<String, dynamic>.from(stage))
+          .toList(growable: true);
+      final tmp = updated[bobbinIndex];
+      updated[bobbinIndex] = updated[flexIndex];
+      updated[flexIndex] = tmp;
+      for (var i = 0; i < updated.length; i++) {
+        updated[i]['sortOrder'] = i + 1;
+        updated[i]['order'] = i + 1;
+      }
+      _stagePreviewStages = updated;
+      _stageOrderManuallyChanged = true;
+      if (_queueBuildStatus == QueueBuildStatus.built) {
+        _queueSignature = _currentQueueSignature();
+        _isStageQueueBuilt = true;
+      }
+    });
+  }
+
   void _selectSwitchablePreviewStage(String stageKey, String selectedStageId) {
     final current = stageKey == kVMainSwitchStageKey
         ? _selectedVStage
@@ -1356,21 +1413,17 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                 ),
               ),
               const SizedBox(width: 10),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  for (var i = 0; i < options.length; i++) ...[
-                    _SwitchableStageDot(
-                      label: options[i].label,
-                      selected: options[i].stageId == selected,
-                      onTap: () => _selectSwitchablePreviewStage(
-                        stageKey,
-                        options[i].stageId,
-                      ),
-                    ),
-                    if (i != options.length - 1) const SizedBox(width: 8),
-                  ],
-                ],
+              Icon(
+                Icons.touch_app_outlined,
+                size: 16,
+                color: colors.onSurfaceVariant,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                'нажмите на этап',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: colors.onSurfaceVariant,
+                ),
               ),
             ],
           ),
@@ -2727,19 +2780,22 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     // Запущенный заказ больше не снимается с производства только из-за
     // редактирования очереди. OrderQueueSyncService точечно обновляет pending
     // этапы/задачи и блокирует только изменение защищённых этапов.
-    // Перед сохранением всегда строим эффективную очередь из текущего черновика,
-    // даже если пользователь не нажимал «Собрать очередь» или шаблон не выбран.
-    final stageMaps = _buildStageQueueFromCurrentDraft(
-      templateStages: _selectedTemplateStageMaps(),
-    );
-    final bool hasEffectiveStageQueue = stageMaps.isNotEmpty;
-    final bool willSaveBuiltStageQueue = hasEffectiveStageQueue;
-    if (willSaveBuiltStageQueue) {
+    // Очередь сохраняем только после явного нажатия «Собрать очередь».
+    // Если очередь не собрана или устарела, заказ остаётся черновиком и не
+    // может быть запущен.
+    final bool willSaveBuiltStageQueue =
+        nextQueueBuildStatus == QueueBuildStatus.built;
+    final stageMaps = willSaveBuiltStageQueue
+        ? _buildStageQueueFromCurrentDraft(
+            existingStages: _stagePreviewStages,
+            templateStages: _selectedTemplateStageMaps(),
+          )
+        : <Map<String, dynamic>>[];
+    final bool hasEffectiveStageQueue =
+        willSaveBuiltStageQueue && stageMaps.isNotEmpty;
+    if (hasEffectiveStageQueue) {
       _syncSwitchableStageSelectionFields(stageMaps);
-      nextQueueBuildStatus = QueueBuildStatus.built;
     }
-    // Статус заказа рассчитываем от эффективной очереди текущего черновика,
-    // а не от того, нажимал ли пользователь кнопку «Собрать очередь».
     final bool hasQueueForStatus = hasEffectiveStageQueue;
     final bool hasEnoughMaterialsForQueue = hasEnoughPaperForLaunch();
     final bool canLaunchProductionNow =
@@ -3082,8 +3138,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       messenger.showSnackBar(
         const SnackBar(
           content: Text(
-            'Очередь изменилась и будет перестроена автоматически '
-            'при сохранении',
+            'Очередь изменилась. Нажмите «Собрать очередь» перед сохранением, '
+            'иначе заказ останется черновиком',
           ),
         ),
       );
@@ -5952,8 +6008,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         Padding(
           padding: const EdgeInsets.only(bottom: 8),
           child: Text(
-            'Очередь изменилась и будет перестроена автоматически '
-            'при сохранении',
+            'Очередь изменилась. Нажмите «Собрать очередь» перед сохранением, '
+            'иначе заказ останется черновиком',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: Theme.of(context).colorScheme.error,
                   fontWeight: FontWeight.w600,
@@ -6105,8 +6161,8 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if ((_stageTemplateId == null || _stageTemplateId!.isEmpty) &&
         _stagePreviewStages.isEmpty) {
       return Text(
-        'Очередь будет построена автоматически после выбора типа '
-        'продукта и параметров заказа',
+        'Выберите тип продукта и параметры заказа, затем нажмите '
+        '«Собрать очередь»',
         style: theme.textTheme.bodySmall,
       );
     }
@@ -6173,7 +6229,32 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(title, style: theme.textTheme.bodyMedium),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(title, style: theme.textTheme.bodyMedium),
+                      ),
+                      if (_canSwapBobbinFlexStage(i))
+                        Padding(
+                          padding: const EdgeInsets.only(left: 8),
+                          child: Tooltip(
+                            message:
+                                'Поменять местами Флексопечать и Бобинорезку',
+                            child: IconButton.filledTonal(
+                              visualDensity: VisualDensity.compact,
+                              constraints: const BoxConstraints.tightFor(
+                                width: 32,
+                                height: 32,
+                              ),
+                              padding: EdgeInsets.zero,
+                              icon: const Icon(Icons.swap_vert, size: 18),
+                              onPressed: _swapBobbinFlexStages,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
                   if (description.isNotEmpty)
                     Padding(
                       padding: const EdgeInsets.only(top: 4),

--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -231,9 +231,58 @@ List<Map<String, dynamic>> buildOrderStageQueue({
     selectedSwitchableStageId: selectedFromSource,
     selectedSwitchableStageIdsByStageKey: selectedByStageKey,
   );
-  return normalizeBuiltOrderStageQueue(
+  final built = normalizeBuiltOrderStageQueue(
     buildOrderStages(draft).map((stage) => stage.toMap()).toList(),
   );
+  return _preserveSwitchableBobbinFlexOrder(built, existingStages);
+}
+
+List<Map<String, dynamic>> _preserveSwitchableBobbinFlexOrder(
+  List<Map<String, dynamic>> built,
+  List<Map<String, dynamic>> existingStages,
+) {
+  if (built.length < 2 || existingStages.length < 2) return built;
+
+  final existingBobbinIndex = existingStages.indexWhere(
+    (stage) => _isBobbinStage(stage, _stageIdFromMap(stage)),
+  );
+  final existingFlexIndex = existingStages.indexWhere(
+    (stage) => _isFlexPrintingStage(stage, _stageIdFromMap(stage)),
+  );
+  if (existingBobbinIndex < 0 || existingFlexIndex < 0) return built;
+
+  final builtBobbinIndex = built.indexWhere(
+    (stage) => _isBobbinStage(stage, _stageIdFromMap(stage)),
+  );
+  final builtFlexIndex = built.indexWhere(
+    (stage) => _isFlexPrintingStage(stage, _stageIdFromMap(stage)),
+  );
+  if (builtBobbinIndex < 0 || builtFlexIndex < 0) return built;
+
+  final existingFlexBeforeBobbin = existingFlexIndex < existingBobbinIndex;
+  final builtFlexBeforeBobbin = builtFlexIndex < builtBobbinIndex;
+  if (existingFlexBeforeBobbin == builtFlexBeforeBobbin) return built;
+
+  final reordered = built
+      .map((stage) => Map<String, dynamic>.from(stage))
+      .toList(growable: true);
+  final flexStage = reordered.removeAt(builtFlexIndex);
+  final bobbinIndexAfterRemove = reordered.indexWhere(
+    (stage) => _isBobbinStage(stage, _stageIdFromMap(stage)),
+  );
+  if (bobbinIndexAfterRemove < 0) return built;
+  reordered.insert(
+    existingFlexBeforeBobbin
+        ? bobbinIndexAfterRemove
+        : bobbinIndexAfterRemove + 1,
+    flexStage,
+  );
+
+  for (var i = 0; i < reordered.length; i++) {
+    reordered[i]['sortOrder'] = i + 1;
+    reordered[i]['order'] = i + 1;
+  }
+  return reordered;
 }
 
 

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -221,18 +221,65 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
     return normalized.isEmpty ? planned.stageName : normalized.join(' / ');
   }
 
-  Future<void> _skipStageForTesting(List<TaskModel> stageTasks) async {
-    if (stageTasks.isEmpty) return;
+  String _stageGroupKeyForPlannedStage(
+    pcompat.PlannedStage planned,
+    List<String> stageIds,
+  ) {
+    for (final key in const <String>[
+      'stageGroupKey',
+      'stage_group_key',
+      'queueStageKey',
+      'queue_stage_key',
+      'groupKey',
+      'group_key',
+      'stageKey',
+      'stage_key',
+    ]) {
+      final value = planned.extra[key]?.toString().trim();
+      if (value != null && value.isNotEmpty) return value;
+    }
+    return stageIds.isNotEmpty ? stageIds.first : planned.stageId.trim();
+  }
+
+  Future<void> _skipStageForTesting(
+    pcompat.PlannedStage planned,
+    List<TaskModel> stageTasks,
+    List<String> stageIds,
+  ) async {
+    if (stageTasks.isEmpty && stageIds.isEmpty) return;
     final provider = context.read<TaskProvider>();
     // Тестовый режим: помечаем текущий этап завершённым и передаём заказ дальше.
-    for (final task in stageTasks) {
-      await provider.addComment(
-        taskId: task.id,
-        type: 'skip_stage_test',
-        text: 'Этап пропущен в тестовом режиме',
-        userId: 'system',
-      );
-      await provider.updateStatus(task.id, TaskStatus.completed);
+    if (stageTasks.isEmpty) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final stageId =
+          stageIds.isNotEmpty ? stageIds.first : planned.stageId.trim();
+      final stageGroupKey = _stageGroupKeyForPlannedStage(planned, stageIds);
+      await Supabase.instance.client.from('tasks').insert({
+        'order_id': widget.order.id,
+        'stage_id': stageId,
+        'stage_group_key': stageGroupKey,
+        'status': TaskStatus.completed.name,
+        'spent_seconds': 0,
+        'assignees': <String>[],
+        'comments': {
+          'skip_stage_test_$now': {
+            'type': 'skip_stage_test',
+            'text': 'Этап пропущен в тестовом режиме',
+            'userId': 'system',
+            'timestamp': now,
+          },
+        },
+      });
+    } else {
+      for (final task in stageTasks) {
+        await provider.addComment(
+          taskId: task.id,
+          type: 'skip_stage_test',
+          text: 'Этап пропущен в тестовом режиме',
+          userId: 'system',
+        );
+        await provider.updateStatus(task.id, TaskStatus.completed);
+      }
     }
     await provider.refresh();
     if (!mounted) return;
@@ -767,13 +814,16 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                                         color: Colors.black54,
                                       ),
                                     ),
-                                    if (stageTasks.isNotEmpty &&
-                                        stageStatus != TaskStatus.completed) ...[
+                                    if (stageStatus != TaskStatus.completed) ...[
                                       const SizedBox(height: 6),
                                       OutlinedButton.icon(
                                         onPressed: _loadingPlan
                                             ? null
-                                            : () => _skipStageForTesting(stageTasks),
+                                            : () => _skipStageForTesting(
+                                                  planned,
+                                                  stageTasks,
+                                                  stageIds,
+                                                ),
                                         icon: const Icon(Icons.skip_next, size: 16),
                                         label: const Text('Пропустить этап'),
                                       ),

--- a/test/stage_queue_builder_test.dart
+++ b/test/stage_queue_builder_test.dart
@@ -523,6 +523,25 @@ void main() {
     expect(kSheetProducts, {kSheetProductTypeId});
   });
 
+  test('preserves manually swapped flex printing before bobbin cutting', () {
+    final queue = buildOrderStageQueue(
+      productTypeId: kSheetProductTypeId,
+      hasCutting: false,
+      hasCardboard: false,
+      hasFlexPrinting: true,
+      requiresBobbinCutting: true,
+      existingStages: const [
+        {'stageId': kFlexPrintingStageId, 'stageName': 'Флексопечать'},
+        {'stageId': kBobbinStageId, 'stageName': 'Бобинорезка'},
+      ],
+    );
+
+    expect(queue[0]['stageId'], kFlexPrintingStageId);
+    expect(queue[1]['stageId'], kBobbinStageId);
+    expect(queue[0]['sortOrder'], 1);
+    expect(queue[1]['sortOrder'], 2);
+  });
+
   test('builds sheet queue from centralized draft rules', () {
     final result = buildOrderStages(
       const OrderStageQueueDraft(


### PR DESCRIPTION
### Motivation

- Пользовательская логика очереди должна позволять менять местами Флексопечать и Бобинорезку и при этом не терять ручные правки при пересборке/сохранении.  
- Интерфейс переключения альтернативных рабочих мест должен быть проще и интуитивнее (нажатие на карточку вместо маленьких кругов).  
- Очередь этапов не должна автоматически собираться/сохраняться без явного действия оператора, и пока очередь не собрана вручную — заказ нельзя запускать.

### Description

- Добавлена кнопка и логика ручного обмена позиций для пар «Флексопечать / Бобинорезка» в предпросмотре очереди, включая функции `_canSwapBobbinFlexStage`, `_swapBobbinFlexStages` и определения превью‑этапов; порядок пересчитывается и помечается как изменённый в UI (`lib/modules/orders/edit_order_screen.dart`).  
- В `stage_queue_builder.dart` добавлена функция `_preserveSwitchableBobbinFlexOrder`, которая при необходимости восстанавливает вручную переставленный порядок Флекс/Бобин при сборке очереди из драфта или шаблона.  
- Упрощён селектор переключаемых этапов: убраны круговые индикаторы, вместо них показана метка и подсказка, а переключение происходит по нажатию на карточку этапа (`_buildSwitchableStageSelector` и связанный UI в `edit_order_screen.dart`).  
- Изменено поведение сохранения очереди: фактическое сохранение/создание production задач происходит только если очередь в статусе `built` (то есть после явного нажатия `Собрать очередь`), и если очередь не собрана/устарела — заказ остаётся в черновике и не может быть запущен (`lib/modules/orders/edit_order_screen.dart`).  
- В `production_details_screen.dart` реализован пропуск этапа даже при отсутствии строк задач: теперь для таких этапов создаётся «заглушечная» завершённая задача с комментарием о пропуске, чтобы позволить переход к следующему этапу.  
- Добавлен unit‑test, проверяющий, что ручная перестановка Флекс/Бобин сохраняется (`test/stage_queue_builder_test.dart`).

### Testing

- Запущена проверка изменений через `git diff --check`, результат — без ошибок.  
- Добавлен тест `test/stage_queue_builder_test.dart` с новым кейсом на сохранение порядка Флекс/Бобин; тест в репозитории присутствует.  
- Попытки выполнить `dart format` и `flutter test` не были выполнены в CI‑контейнере, так как в среде отсутствуют `dart`/`flutter` (локально следует запустить `dart format` и `flutter test` чтобы подтвердить проход всех тестов).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018ddd2bf8832f8ef33a7b0999812f)