### PR TITLE
Исправление завершения этапа и очистки `startedAt`

### DIFF
--- a/lib/modules/tasks/task_model.dart
+++ b/lib/modules/tasks/task_model.dart
@@ -387,6 +387,7 @@ class TaskModel {
     TaskStatus? status,
     int? spentSeconds,
     int? startedAt,
+    bool clearStartedAt = false,
     String? stageGroupKey,
     String? capturedByWorkplaceId,
     String? capturedByUserId,
@@ -404,7 +405,7 @@ class TaskModel {
       capturedAt: capturedAt ?? this.capturedAt,
       status: status ?? this.status,
       spentSeconds: spentSeconds ?? this.spentSeconds,
-      startedAt: startedAt ?? this.startedAt,
+      startedAt: clearStartedAt ? null : (startedAt ?? this.startedAt),
       assignees: assignees ?? this.assignees,
       comments: comments ?? this.comments,
     );

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -1045,15 +1045,21 @@ class TaskProvider with ChangeNotifier {
     TaskStatus status, {
     int? spentSeconds,
     int? startedAt,
+    bool clearStartedAt = false,
   }) async {
     final index = _tasks.indexWhere((t) => t.id == id);
     if (index == -1) return false;
 
     final current = _tasks[index];
+    final shouldClearStartedAt =
+        clearStartedAt || (status != TaskStatus.inProgress && startedAt == null);
+    final effectiveStartedAt =
+        shouldClearStartedAt ? null : (startedAt ?? current.startedAt);
     final updated = current.copyWith(
       status: status,
       spentSeconds: spentSeconds ?? current.spentSeconds,
-      startedAt: startedAt ?? current.startedAt,
+      startedAt: effectiveStartedAt,
+      clearStartedAt: shouldClearStartedAt,
       comments: current.comments,
       assignees: current.assignees,
     );
@@ -1061,7 +1067,7 @@ class TaskProvider with ChangeNotifier {
     final updates = <String, dynamic>{
       'status': status.name,
       'spent_seconds': updated.spentSeconds,
-      'started_at': updated.startedAt,
+      'started_at': effectiveStartedAt,
     };
     final bool becameInProgress =
         current.status != TaskStatus.inProgress && status == TaskStatus.inProgress;
@@ -1209,10 +1215,13 @@ class TaskProvider with ChangeNotifier {
         : task.stageId.trim();
     if (task.orderId.trim().isEmpty || groupKey.isEmpty) return;
 
+    final shouldClearStartedAt =
+        status != TaskStatus.inProgress && startedAt == null;
     final taskUpdates = <String, dynamic>{
       'status': status.name,
       if (spentSeconds != null) 'spent_seconds': spentSeconds,
-      if (startedAt != null) 'started_at': startedAt,
+      if (shouldClearStartedAt) 'started_at': null,
+      if (!shouldClearStartedAt && startedAt != null) 'started_at': startedAt,
       if (completedAt != null) 'completed_at': completedAt,
     };
     final startedIso = startedAt == null
@@ -1246,7 +1255,10 @@ class TaskProvider with ChangeNotifier {
           _tasks[i] = local.copyWith(
             status: status,
             spentSeconds: spentSeconds ?? local.spentSeconds,
-            startedAt: startedAt ?? local.startedAt,
+            startedAt: shouldClearStartedAt
+                ? null
+                : (startedAt ?? local.startedAt),
+            clearStartedAt: shouldClearStartedAt,
           );
         }
       }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4780,25 +4780,28 @@ class _TasksScreenState extends State<TasksScreen>
                         (t) => t.id == task.id,
                         orElse: () => task,
                       );
-                      if (!_anyUserActive(latestTask)) {
+                      final shouldCloseStage =
+                          jointGroup != null || (jointGroup == null && separateAllDone);
+                      // Если все исполнители уже отметились как завершившие этап,
+                      // не оставляем этап в работе из-за устаревшего открытого
+                      // time_event: пользователь видит "Завершил(а) этап", значит
+                      // статус этапа должен перейти в финальное состояние.
+                      final canApplyFinish =
+                          !_anyUserActive(latestTask) || shouldCloseStage;
+                      if (canApplyFinish) {
                         final _secs = _elapsed(latestTask).inSeconds;
-                        // Для режима "Отдельный исполнитель" финальное закрытие
-                        // этапа выполняется только через отдельную кнопку
-                        // "Завершить задание" (ниже в карточке этапа).
-                        final shouldCloseStage =
-                            jointGroup != null || (jointGroup == null && separateAllDone);
                         if (_isInkConfirmationStage(task)) {
                           await _finalizeTask(task, initialQtyInput: qtyInput);
                           return;
                         }
-                        final nextStatus =
-                            shouldCloseStage && !_isInkConfirmationStage(task)
-                                ? TaskStatus.completed
-                                : TaskStatus.paused;
+                        final nextStatus = shouldCloseStage
+                            ? TaskStatus.completed
+                            : TaskStatus.paused;
                         await taskProvider.updateStatus(
                             task.id, nextStatus,
                             spentSeconds: _secs,
-                            startedAt: null);
+                            startedAt: null,
+                            clearStartedAt: true);
                         if (context.mounted &&
                             separateAllDone &&
                             jointGroup == null &&

--- a/test/task_model_started_at_test.dart
+++ b/test/task_model_started_at_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/tasks/task_model.dart';
+
+void main() {
+  test('copyWith can clear startedAt when stage is finished or paused', () {
+    final task = TaskModel(
+      id: 'task-1',
+      orderId: 'order-1',
+      stageId: 'stage-1',
+      status: TaskStatus.inProgress,
+      startedAt: 1710000000000,
+    );
+
+    final updated = task.copyWith(
+      status: TaskStatus.completed,
+      clearStartedAt: true,
+    );
+
+    expect(updated.status, TaskStatus.completed);
+    expect(updated.startedAt, isNull);
+  });
+}


### PR DESCRIPTION
### Motivation
- Исправить проблему когда участник пометил этап как завершённый, но этап оставался в состоянии выполнения из‑за открытого `time_event` и локального `startedAt` оставался установленным.
- Обеспечить корректную синхронизацию статуса группы этапов и явную возможность очистки времени начала этапа в модели задачи.

### Description
- Добавлена опция `clearStartedAt` в `TaskModel.copyWith` для явной очистки `startedAt` в локальной модели задачи (`lib/modules/tasks/task_model.dart`).
- Расширен `TaskProvider.updateStatus` добавлением параметра `clearStartedAt` и логики вычисления `effectiveStartedAt`, чтобы при переводе задачи из `inProgress` в другое состояние `started_at` сбрасывался в базе и локально (`lib/modules/tasks/task_provider.dart`).
- При синхронизации статуса группы этапов (`_syncStageGroupStatusToSharedSources`) учитывается необходимость очистки `started_at` для связанных задач группы (`lib/modules/tasks/task_provider.dart`).
- В UI логике завершения участия пользователя в строке этапа (`onFinish`) добавлена проверка, позволяющая закрывать этап как завершённый, если все исполнители отметились как `user_done`, даже при наличии устаревшего открытого `time_event`, и при этом вызывается `updateStatus` с `clearStartedAt: true` (`lib/modules/tasks/tasks_screen.dart`).
- Добавлен регрессионный тест `test/task_model_started_at_test.dart`, проверяющий, что `copyWith` может очистить `startedAt`.

### Testing
- Запущена проверка изменений с `git diff --check`, ошибок не обнаружено (успешно).
- Добавлен unit‑test `test/task_model_started_at_test.dart`, но запуск `flutter test` в CI/контейнере не выполнился из‑за отсутствия установленного `flutter` (ошибка: `flutter: command not found`).
- Форматирование/локальные интеграционные тесты не выполнялись в этом окружении по той же причине отсутствия SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0197622b44832facc4e97dbbe9203e)