### PR TITLE
Разрешить переключение ожидающего автоматического этапа

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -1326,6 +1326,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             : null);
     if (effectiveCurrent == selectedStageId) return;
 
+    final wasBuilt = _queueBuildStatus == QueueBuildStatus.built;
     setState(() {
       if (stageKey == kVMainSwitchStageKey) {
         _selectedVStage = selectedStageId;
@@ -1344,8 +1345,18 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       );
       _stagePreviewStages = queue;
       _syncSwitchableStageSelectionFields(queue);
-      _queueBuildStatus = QueueBuildStatus.outdated;
-      _isStageQueueBuilt = false;
+      if (wasBuilt) {
+        // Переключение альтернативного рабочего места уже перестраивает
+        // фактическую очередь здесь. Поэтому запущенный/собранный заказ можно
+        // сохранить сразу: сервис синхронизации ниже обновит только ожидающий
+        // этап и заблокирует сохранение, если выбранный автомат уже начат.
+        _queueBuildStatus = QueueBuildStatus.built;
+        _queueSignature = _currentQueueSignature();
+        _isStageQueueBuilt = true;
+      } else {
+        _queueBuildStatus = QueueBuildStatus.outdated;
+        _isStageQueueBuilt = false;
+      }
     });
   }
 

--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -603,6 +603,7 @@ class OrderQueueSyncService {
     final updates = {
       'stage_id': next.stageId,
       'stage_group_key': next.stageGroupKey,
+      'name': next.displayName,
       'seq': physicalSeq,
       'status': 'waiting',
     };

--- a/test/order_queue_sync_service_test.dart
+++ b/test/order_queue_sync_service_test.dart
@@ -200,4 +200,86 @@ void main() {
     expect(physicalSeq.values.toSet(), hasLength(4));
   });
 
+  test(
+    'diff allows switching a pending automatic stage after protected base stages',
+    () {
+      const protectedFlexo = OrderQueueSyncEntry(
+        stageId: 'flexo',
+        stageGroupKey: 'flexo',
+        step: 1,
+        status: 'in_progress',
+        row: {'name': 'Флексопечать'},
+      );
+      const pendingAutoBig = OrderQueueSyncEntry(
+        stageId: 'auto-big',
+        stageGroupKey: 'p_main_switch',
+        step: 2,
+        status: 'waiting',
+        row: {'name': 'Автомат большой'},
+      );
+      const nextFlexo = OrderQueueSyncEntry(
+        stageId: 'flexo',
+        stageGroupKey: 'flexo',
+        step: 1,
+      );
+      const nextAutoSmall = OrderQueueSyncEntry(
+        stageId: 'auto-small',
+        stageGroupKey: 'p_main_switch',
+        step: 2,
+        row: {'stageName': 'Автомат маленький'},
+      );
+
+      final operations = OrderQueueSyncService.diff(
+        currentStages: const [protectedFlexo, pendingAutoBig],
+        currentTasks: const [protectedFlexo, pendingAutoBig],
+        nextQueue: const [nextFlexo, nextAutoSmall],
+      );
+
+      expect(
+        operations.where((op) => op.type == OrderQueueSyncOperationType.block),
+        isEmpty,
+      );
+      expect(
+        operations.any((op) =>
+            op.type == OrderQueueSyncOperationType.cancelOrDeletePending &&
+            op.current?.stageId == 'auto-big'),
+        isTrue,
+      );
+      expect(
+        operations.any((op) =>
+            op.type == OrderQueueSyncOperationType.insert &&
+            op.next?.stageId == 'auto-small'),
+        isTrue,
+      );
+    },
+  );
+
+  test('diff blocks switching an automatic stage that has already started', () {
+    const startedAutoBig = OrderQueueSyncEntry(
+      stageId: 'auto-big',
+      stageGroupKey: 'p_main_switch',
+      step: 2,
+      status: 'started',
+      row: {'name': 'Автомат большой'},
+    );
+    const nextAutoSmall = OrderQueueSyncEntry(
+      stageId: 'auto-small',
+      stageGroupKey: 'p_main_switch',
+      step: 2,
+      row: {'stageName': 'Автомат маленький'},
+    );
+
+    final operations = OrderQueueSyncService.diff(
+      currentStages: const [startedAutoBig],
+      currentTasks: const [startedAutoBig],
+      nextQueue: const [nextAutoSmall],
+    );
+
+    final blocked = operations.where(
+      (op) => op.type == OrderQueueSyncOperationType.block,
+    );
+    expect(blocked, isNotEmpty);
+    expect(blocked.first.reason, contains('Автомат большой'));
+  });
+
 }


### PR DESCRIPTION
### Motivation
- Обеспечить возможность смены между «Автомат большой» и «Автомат маленький» в редакторе заказа даже когда предыдущие базовые этапы (например, Флексопечать / Бобинорезка) уже начаты, но сам автомат остаётся в состоянии ожидания, и чтобы изменение тут же отражалось в очереди и управлении заданиями.

### Description
- В `EditOrderScreen._selectSwitchablePreviewStage` сохраняется признак, что очередь была `built`, и при переключении альтернативного рабочего места очередь пересобирается «in-place», при этом при сохранении сохраняется подпись очереди через `_queueSignature` и состояние остаётся `built` для корректной синхронизации запущенных заказов.
- В `OrderQueueSyncService._updatePendingPlanStage` при обновлении отложенного (pending) этапа теперь записывается также поле `name` с `next.displayName`, чтобы отображаемое имя этапа обновлялось в `prod_plan_stages` и было видно в модулях управления заданиями и рабочем пространстве.
- Добавлены тесты в `test/order_queue_sync_service_test.dart`, которые покрывают сценарии: переключение ожидающего автоматического этапа разрешено при наличии защищённого ранее начатого этапа, и переключение блокируется, если сам автомат уже стартовал.

### Testing
- Выполнена проверка изменений кодовой базы через `git diff --check`, ошибок не обнаружено.
- Добавлены автоматические тесты в `test/order_queue_sync_service_test.dart`, но запуск `flutter test` не произведён в этой среде из-за отсутствия Flutter SDK (`flutter: command not found`).
- Изменены файлы: `lib/modules/orders/edit_order_screen.dart`, `lib/modules/orders/order_queue_sync_service.dart`, `test/order_queue_sync_service_test.dart`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b40e0c5c832f93a7526bab4daf11)