### PR TITLE
Allow switching pending automatic stages after protected stages

### DIFF
--- a/lib/modules/orders/order_queue_sync_service.dart
+++ b/lib/modules/orders/order_queue_sync_service.dart
@@ -211,10 +211,28 @@ class OrderQueueSyncService {
       }
     }
 
+    bool hasEquivalentNextStage(OrderQueueSyncEntry current) {
+      return nextQueue.any(
+        (next) =>
+            current.sameQueueSlot(next) ||
+            (current.stageId == next.stageId && current.step == next.step),
+      );
+    }
+
+    bool hasProtectedPlanStageKeptForTask(OrderQueueSyncEntry task) {
+      return currentStages.any(
+        (stage) =>
+            isProtectedStatus(stage.status) &&
+            stage.stageId == task.stageId &&
+            hasEquivalentNextStage(stage),
+      );
+    }
+
     for (final task in currentTasks) {
       final next = nextByKey[task.identityKey];
       if (next != null && task.sameQueueSlot(next)) continue;
       if (isProtectedStatus(task.status)) {
+        if (hasProtectedPlanStageKeptForTask(task)) continue;
         operations.add(OrderQueueSyncOperation(
           type: OrderQueueSyncOperationType.block,
           current: task,

--- a/test/order_queue_sync_service_test.dart
+++ b/test/order_queue_sync_service_test.dart
@@ -69,6 +69,66 @@ void main() {
     );
   });
 
+  test(
+    'diff ignores legacy protected task group when its plan stage is unchanged',
+    () {
+      const protectedPlanStage = OrderQueueSyncEntry(
+        stageId: 'b92a89d1-8e95-4c6d-b990-e308486e4bf1',
+        stageGroupKey: 'bobbin',
+        step: 1,
+        status: 'completed',
+        row: {'name': 'Бобинорезка'},
+      );
+      const legacyProtectedTask = OrderQueueSyncEntry(
+        stageId: 'b92a89d1-8e95-4c6d-b990-e308486e4bf1',
+        stageGroupKey: 'b92a89d1-8e95-4c6d-b990-e308486e4bf1',
+        step: 1,
+        status: 'completed',
+      );
+      const pendingAutoBig = OrderQueueSyncEntry(
+        stageId: 'auto-big',
+        stageGroupKey: 'p_main_switch',
+        step: 2,
+        status: 'waiting',
+        row: {'name': 'Автомат большой'},
+      );
+      const nextProtectedPlanStage = OrderQueueSyncEntry(
+        stageId: 'b92a89d1-8e95-4c6d-b990-e308486e4bf1',
+        stageGroupKey: 'bobbin',
+        step: 1,
+      );
+      const nextAutoSmall = OrderQueueSyncEntry(
+        stageId: 'auto-small',
+        stageGroupKey: 'p_main_switch',
+        step: 2,
+        row: {'stageName': 'Автомат маленький'},
+      );
+
+      final operations = OrderQueueSyncService.diff(
+        currentStages: const [protectedPlanStage, pendingAutoBig],
+        currentTasks: const [legacyProtectedTask, pendingAutoBig],
+        nextQueue: const [nextProtectedPlanStage, nextAutoSmall],
+      );
+
+      expect(
+        operations.where((op) => op.type == OrderQueueSyncOperationType.block),
+        isEmpty,
+      );
+      expect(
+        operations.any((op) =>
+            op.type == OrderQueueSyncOperationType.cancelOrDeletePending &&
+            op.current?.stageId == 'auto-big'),
+        isTrue,
+      );
+      expect(
+        operations.any((op) =>
+            op.type == OrderQueueSyncOperationType.insert &&
+            op.next?.stageId == 'auto-small'),
+        isTrue,
+      );
+    },
+  );
+
   test('diff blocks moving a protected stage with a concrete message', () {
     const protectedStage = OrderQueueSyncEntry(
       stageId: 'print',


### PR DESCRIPTION
### Motivation
- Prevent legacy task rows with an old `stage_group_key` from blocking edits when the corresponding protected plan stage remains in place, which currently stops switching between "Автомат большой" and "Автомат маленький" for launched orders.
- Restore expected UX: allow swapping a pending automatic stage even if an earlier protected stage (Флексопечать/Бобинорезка) is started/completed, provided the plan stage itself is not moved.

### Description
- Adjusted `OrderQueueSyncService.diff` to detect when a protected plan stage with the same `stageId` is kept in the next queue and treat that as an equivalent protection so legacy protected tasks do not block the change (`hasEquivalentNextStage` and `hasProtectedPlanStageKeptForTask`).
- Skip blocking a protected task if a protected plan stage with the same `stageId` remains in the next queue, allowing pending automatic stages to be updated/cancelled and new ones inserted.
- Added a regression test `diff ignores legacy protected task group when its plan stage is unchanged` in `test/order_queue_sync_service_test.dart` covering a completed bobbin plan stage + legacy protected task + pending automatic stage swap.

### Testing
- Added unit test `test/order_queue_sync_service_test.dart` which asserts no blocking and correct cancel/insert operations for the legacy-group scenario (new test included in the commit).
- Ran `git diff --check` which reported no issues.
- Attempted `flutter test` and `dart format` but they were not executed in this environment because `flutter`/`dart` are not available, so full test run could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b7cdf68c832f9107968eb22fddb9)