### PR TITLE
Keep saved production queue visible while editing

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -847,6 +847,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (widget.order != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _loadRuntimeEditLocks();
+        _scheduleStagePreviewUpdate(immediate: true);
       });
     }
   }
@@ -995,7 +996,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   String _resolveStageName(Map<String, dynamic> stage) {
     final baseName = (() {
       final dynamic raw = stage['stageName'] ??
+          stage['stage_name'] ??
           stage['workplaceName'] ??
+          stage['workplace_name'] ??
           stage['title'] ??
           stage['name'];
       if (raw is String && raw.trim().isNotEmpty) {
@@ -1007,7 +1010,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     final altNames = <String>[];
     final rawAlt = stage['alternativeStageNames'];
     if (rawAlt is List) {
-      altNames.addAll(rawAlt.whereType<String>().map((e) => e.trim()).where((e) => e.isNotEmpty));
+      altNames.addAll(
+        rawAlt
+            .whereType<String>()
+            .map((e) => e.trim())
+            .where((e) => e.isNotEmpty),
+      );
     }
 
     final ordered = <String>[];
@@ -1624,7 +1632,6 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         .toList();
   }
 
-
   List<Map<String, dynamic>> _selectedTemplateStageMaps() {
     final templateId = _stageTemplateId;
     if (templateId == null || templateId.isEmpty) {
@@ -1637,6 +1644,65 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         : _templateStageMaps(template);
   }
 
+  List<Map<String, dynamic>> _normalizeSavedPreviewStages(
+    List<Map<String, dynamic>> rows,
+  ) {
+    return rows.map((source) {
+      final row = Map<String, dynamic>.from(source);
+      final stageName = (row['stageName'] ??
+              row['stage_name'] ??
+              row['workplaceName'] ??
+              row['workplace_name'] ??
+              row['name'] ??
+              row['title'] ??
+              '')
+          .toString()
+          .trim();
+      if (stageName.isNotEmpty) {
+        row['stageName'] ??= stageName;
+        row['workplaceName'] ??= stageName;
+      }
+      final stageId = (row['stageId'] ??
+              row['stage_id'] ??
+              row['stageid'] ??
+              row['workplaceId'] ??
+              row['workplace_id'] ??
+              row['id'] ??
+              '')
+          .toString()
+          .trim();
+      if (stageId.isNotEmpty) {
+        row['stageId'] ??= stageId;
+        row['workplaceId'] ??= stageId;
+        row['id'] ??= stageId;
+      }
+      return row;
+    }).toList(growable: false);
+  }
+
+  bool _shouldKeepSavedStagePreview(SavedOrderQueue saved) {
+    if (widget.order == null || saved.rows.isEmpty) return false;
+    if (_stageOrderManuallyChanged) return false;
+    if (QueueBuildStatus.normalize(_queueBuildStatus) !=
+        QueueBuildStatus.built) {
+      return false;
+    }
+    return _sameQueueSignature(_queueSignature, _currentQueueSignature()) ||
+        widget.order!.assignmentCreated;
+  }
+
+  List<Map<String, dynamic>> _currentBuiltStageMapsForSave() {
+    if (_stagePreviewStages.isNotEmpty) {
+      return _stagePreviewStages
+          .map((stage) => Map<String, dynamic>.from(stage))
+          .toList(growable: false);
+    }
+    return _buildStageQueueFromCurrentDraft(
+      existingStages: _stagePreviewStages,
+      templateStages: _selectedTemplateStageMaps(),
+    );
+  }
+
   Future<void> _rebuildStagePreview() async {
     final templateStages = _selectedTemplateStageMaps();
 
@@ -1646,7 +1712,18 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     if (widget.order != null) {
       try {
         final saved = await _orderQueueService.loadSavedQueue(widget.order!.id);
-        existingStages = saved.rows;
+        existingStages = _normalizeSavedPreviewStages(saved.rows);
+        if (_shouldKeepSavedStagePreview(saved)) {
+          if (!mounted) return;
+          setState(() {
+            _stagePreviewStages = existingStages;
+            _stagePreviewLoading = false;
+            _stagePreviewError = null;
+            _stagePreviewInitialized = true;
+            _isStageQueueBuilt = true;
+          });
+          return;
+        }
       } catch (_) {
         existingStages = <Map<String, dynamic>>[];
       }
@@ -2728,10 +2805,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
     final bool willSaveBuiltStageQueue =
         nextQueueBuildStatus == QueueBuildStatus.built;
     final stageMaps = willSaveBuiltStageQueue
-        ? _buildStageQueueFromCurrentDraft(
-            existingStages: _stagePreviewStages,
-            templateStages: _selectedTemplateStageMaps(),
-          )
+        ? _currentBuiltStageMapsForSave()
         : <Map<String, dynamic>>[];
     final bool hasEffectiveStageQueue =
         willSaveBuiltStageQueue && stageMaps.isNotEmpty;

--- a/test/order_queue_service_load_test.dart
+++ b/test/order_queue_service_load_test.dart
@@ -49,6 +49,10 @@ void main() {
         saved.rows.map((row) => row['stage_id']),
         ['new-print', 'new-pack'],
       );
+      expect(
+        saved.rows.map((row) => row['stage_name']),
+        ['Печать', 'Упаковка'],
+      );
     },
   );
 


### PR DESCRIPTION
### Motivation
- При редактировании уже сохранённого/запущенного заказа нужно показывать сохранённую очередь этапов и не пересобирать её автоматически, чтобы сотрудник видел и мог редактировать ту же очередь, которую сохранили/запустили.

### Description
- При открытии экрана редактирования существующего заказа запускается загрузка предпросмотра очереди (`_scheduleStagePreviewUpdate(immediate: true)`) чтобы подтянуть сохранённую очередь сразу (файл: `lib/modules/orders/edit_order_screen.dart`).
- Добавлена нормализация загруженных из БД строк очереди в формат предпросмотра (`_normalizeSavedPreviewStages`) и обработка snake_case-полей для корректного отображения названий и идентификаторов этапов. (файл: `lib/modules/orders/edit_order_screen.dart`).
- Экран теперь сохраняет и повторно использует отображаемую (built) сохранённую очередь, если очередь актуальна или заказ уже запущен (`_shouldKeepSavedStagePreview` и `_currentBuiltStageMapsForSave`), вместо того чтобы каждый раз перестраивать очередь авто‑логикой (файл: `lib/modules/orders/edit_order_screen.dart`).
- Тест обновлён, чтобы проверять, что при загрузке нормализованных строк сохраняются названия этапов (`test/order_queue_service_load_test.dart`).

### Testing
- Выполнена проверка `git diff --check` без ошибок (успех).
- Попытка запустить `flutter test test/order_queue_service_load_test.dart` не удалась из-за отсутствия `flutter` в окружении (не выполнено).
- Коммит с изменениями создан в репозитории (сообщение: "Keep saved production queue on edit").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c045fcd8832fb4aa6d54522f766d)