### PR TITLE
Fix warehouse log paint lookups

### DIFF
--- a/lib/modules/warehouse/warehouse_logs_repository.dart
+++ b/lib/modules/warehouse/warehouse_logs_repository.dart
@@ -306,6 +306,16 @@ class WarehouseLogsRepository {
     String selectFields = '*',
     String? fallbackSelectFields,
   }) async {
+    final List<String> normalizedIds = ids
+        .map((dynamic id) => id?.toString().trim())
+        .whereType<String>()
+        .where((String id) => id.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (normalizedIds.isEmpty) {
+      return <Map<String, dynamic>>[];
+    }
+
     for (final String table in tables) {
       final List<String?> attemptedOrders = <String?>[
         orderBy,
@@ -331,14 +341,11 @@ class WarehouseLogsRepository {
           try {
             final PostgrestFilterBuilder<dynamic> baseQuery =
                 _client.from(table).select(select);
-            final PostgrestTransformBuilder<dynamic> query = ids.isEmpty
-                ? (order == null
-                    ? baseQuery
-                    : baseQuery.order(order, ascending: ascending))
-                : baseQuery
-                    .or(ids.map((dynamic e) => '$fk.eq.$e').join(','))
-                    .order(order ?? fk, ascending: ascending);
-            final dynamic data = await query;
+            final PostgrestFilterBuilder<dynamic> filteredQuery =
+                baseQuery.inFilter(fk, normalizedIds);
+            final dynamic data = order == null
+                ? await filteredQuery
+                : await filteredQuery.order(order, ascending: ascending);
             return (data as List).cast<Map<String, dynamic>>();
           } on PostgrestException catch (error) {
             final String code = (error.code?.toString() ?? '').toLowerCase();
@@ -362,7 +369,8 @@ class WarehouseLogsRepository {
             if (selectColumnMissing) {
               break;
             }
-            if (_isMissingRelationError(error, table)) {
+            if (_isMissingRelationError(error, table) ||
+                _isRecoverableSchemaProbeError(error)) {
               break;
             }
             debugPrint('WarehouseLogsRepository: $error for table $table');
@@ -375,6 +383,16 @@ class WarehouseLogsRepository {
       }
     }
     return <Map<String, dynamic>>[];
+  }
+
+  static bool _isRecoverableSchemaProbeError(PostgrestException error) {
+    final String code = (error.code?.toString() ?? '').toLowerCase();
+    final String message = (error.message?.toString() ?? '').toLowerCase();
+    final String details = (error.details?.toString() ?? '').toLowerCase();
+
+    return code == '400' &&
+        (message == 'bad request' || message.contains('bad request')) &&
+        (details.isEmpty || details == 'bad request');
   }
 
   static bool _isMissingRelationError(


### PR DESCRIPTION
### Motivation

- Avoid repeated `PostgrestException 400 Bad Request` errors when resolving warehouse log base rows (e.g. `paints`/`paint`) caused by malformed or empty ID filters.
- Prevent noisy logs and provide a stable fallback path when probing optional warehouse tables with different schemas.

### Description

- Normalize, trim and deduplicate `ids` into `normalizedIds` and return early if the list is empty to avoid issuing invalid queries.
- Replace manual `.or(id.eq...)` filter construction with the safer `.inFilter(fk, normalizedIds)` to generate valid PostgREST queries.
- Add `_isRecoverableSchemaProbeError` to treat generic `400 Bad Request` responses from optional schema probes as recoverable and avoid flooding logs.
- Adjust error handling so probing different tables breaks on missing-relation or recoverable probe errors while still logging unexpected failures.

### Testing

- Static repository checks were executed and completed successfully.
- Code formatting was attempted but could not be run in this environment due to the missing Dart toolchain (`dart` not found).
- No project unit tests were executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ce56bedc832f80b7f1f4b062f506)