### PR TITLE
Require final confirmation for separate performers

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4701,17 +4701,15 @@ class _TasksScreenState extends State<TasksScreen>
                         (t) => t.id == task.id,
                         orElse: () => task,
                       );
-                      final shouldCloseStage =
-                          jointGroup != null || (jointGroup == null && separateAllDone);
-                      // Если все исполнители уже отметились как завершившие этап,
-                      // не оставляем этап в работе из-за устаревшего открытого
-                      // time_event: пользователь видит "Завершил(а) этап", значит
-                      // статус этапа должен перейти в финальное состояние.
-                      final canApplyFinish =
-                          !_anyUserActive(latestTask) || shouldCloseStage;
+                      // В режиме "отдельный исполнитель" кнопка в строке
+                      // фиксирует только личное завершение сотрудника. Сам этап
+                      // закрывается только отдельной кнопкой "Завершить задание"
+                      // после того, как все отдельные исполнители отметились.
+                      final shouldCloseStage = jointGroup != null;
+                      final canApplyFinish = !_anyUserActive(latestTask);
                       if (canApplyFinish) {
                         final _secs = _elapsed(latestTask).inSeconds;
-                        if (_isInkConfirmationStage(task)) {
+                        if (_isInkConfirmationStage(task) && shouldCloseStage) {
                           await _finalizeTask(task, initialQtyInput: qtyInput);
                           return;
                         }


### PR DESCRIPTION
### Motivation
- Fix the behavior for stages in "Отдельный исполнитель" mode so that a user pressing the per-row "Завершить" only marks their personal completion and does not close the stage until the separate "Завершить задание" button is pressed.
- Ensure ink/print confirmation stages are not finalized by a row-level finish in separate-performer mode to avoid premature finalization.

### Description
- Changed the finish logic in `lib/modules/tasks/tasks_screen.dart` to compute `shouldCloseStage` as `jointGroup != null` instead of `jointGroup != null || separateAllDone`, and to compute `canApplyFinish` only from `!_anyUserActive(latestTask)` so that per-row finish does not close the stage for separate execution mode.
- Guarded the ink-confirmation path so `_finalizeTask` is called only when `shouldCloseStage` is true, preventing row-level finalization of ink-confirm stages in separate mode.
- Adjusted comments and flow around the per-row `onFinish` handling so that, for separate execution, the row-level finish moves the task to a non-final state unless the whole stage should be closed.

### Testing
- Ran `git diff --check` which passed without issues.
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but it was not executed because the Dart SDK/`dart` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02cff2fa58832fb2b08a4aa1229a44)