### PR TITLE
Prevent shipping when actual qty < tirage and handle missing tasks.completed_at

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -984,8 +984,14 @@ class OrdersProvider with ChangeNotifier {
     final double actualQty =
         orderData.actualQty ?? orderData.product.quantity.toDouble();
     final double safeActual = actualQty < 0 ? 0 : actualQty;
-    double writeoffQty = writeoffOverride ??
-        (safeActual < plannedQty ? safeActual : plannedQty.toDouble());
+    if (safeActual < plannedQty) {
+      throw Exception(
+        'Нельзя отгрузить заказ: фактическое количество '
+        '(${_formatQty(safeActual)}) меньше тиража '
+        '(${_formatQty(plannedQty)}).',
+      );
+    }
+    double writeoffQty = writeoffOverride ?? plannedQty.toDouble();
     if (writeoffQty.isNaN || writeoffQty.isInfinite) {
       writeoffQty = 0;
     }
@@ -1990,11 +1996,8 @@ class OrdersProvider with ChangeNotifier {
 
   Future<double?> _loadLatestProductionActualQty(String orderId) async {
     try {
-      final rows = await _supabase
-          .from('tasks')
-          .select('stage_id, comments, completed_at, finished_at')
-          .eq('order_id', orderId);
-      if (rows is! List || rows.isEmpty) {
+      final rows = await _loadProductionTaskQuantityRows(orderId);
+      if (rows.isEmpty) {
         return null;
       }
 
@@ -2036,6 +2039,41 @@ class OrdersProvider with ChangeNotifier {
       debugPrint('⚠️ shipOrder: unable to load production actual_qty: $e\n$st');
       return null;
     }
+  }
+
+  Future<List<Map<String, dynamic>>> _loadProductionTaskQuantityRows(
+    String orderId,
+  ) async {
+    const columnSets = <String>[
+      'stage_id, comments, completed_at, finished_at',
+      'stage_id, comments, finished_at',
+      'stage_id, comments',
+    ];
+
+    Object? lastMissingColumnError;
+    for (final columns in columnSets) {
+      try {
+        final rows = await _supabase
+            .from('tasks')
+            .select(columns)
+            .eq('order_id', orderId);
+        if (rows is! List) {
+          return const <Map<String, dynamic>>[];
+        }
+        return rows
+            .whereType<Map>()
+            .map((row) => Map<String, dynamic>.from(row))
+            .toList(growable: false);
+      } catch (error) {
+        final canRetry = _isMissingColumnError(error, 'completed_at') ||
+            _isMissingColumnError(error, 'finished_at');
+        if (!canRetry) rethrow;
+        lastMissingColumnError = error;
+      }
+    }
+
+    if (lastMissingColumnError != null) throw lastMissingColumnError;
+    return const <Map<String, dynamic>>[];
   }
 
   List<Map<String, dynamic>> _normalizeTaskComments(dynamic value) {

--- a/lib/modules/orders/orders_screen.dart
+++ b/lib/modules/orders/orders_screen.dart
@@ -477,6 +477,18 @@ class _OrdersScreenState extends State<OrdersScreen> {
     final double plannedQty = order.product.quantity.toDouble();
     final double actualQty = order.actualQty ?? plannedQty;
     final double safeActual = actualQty < 0 ? 0 : actualQty;
+    if (safeActual < plannedQty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Нельзя отгрузить заказ: факт '
+            '${_formatQuantity(safeActual)} меньше тиража '
+            '${_formatQuantity(plannedQty)}.',
+          ),
+        ),
+      );
+      return;
+    }
     double? warehouseExtraQty;
     String? warehouseExtraSize;
     try {


### PR DESCRIPTION
### Motivation
- Fix a runtime `PostgrestException` caused by selecting a missing `tasks.completed_at` column when loading production actual quantities. 
- Enforce the business rule that an order must not be shipped if the actual produced quantity is less than the planned tirage. 

### Description
- Replace the direct `tasks` select with a resilient loader `Future<List<Map<String, dynamic>>> _loadProductionTaskQuantityRows(String orderId)` that retries compatible column sets (`'stage_id, comments, completed_at, finished_at'`, `'stage_id, comments, finished_at'`, `'stage_id, comments'`) to avoid schema-dependent `PostgrestException` errors in `_loadLatestProductionActualQty` (file `lib/modules/orders/orders_provider.dart`).
- Update `_loadLatestProductionActualQty` to use the resilient loader and preserve existing aggregation logic for computing the latest stage total (file `lib/modules/orders/orders_provider.dart`).
- Add a validation in `shipOrder` to throw a clear `Exception` when `actual_qty < planned tirage`, and make `writeoffQty` default to the planned tirage when permitted (file `lib/modules/orders/orders_provider.dart`).
- Add a quick UI guard in `_confirmShipment` to show a `SnackBar` and abort opening the shipment dialog when the currently loaded order already has `actual_qty < planned tirage` (file `lib/modules/orders/orders_screen.dart`).

### Testing
- Ran `git diff --check` to ensure there are no trivial diff issues (succeeded). 
- Attempted to run `flutter test`, but the Flutter SDK is not available in the environment so automated tests were not executed. 
- Attempted to run `dart analyze`, but the Dart SDK is not available in the environment so static analysis was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d6854908832fa93e1a8c572e9375)