### PR TITLE
Add _isMissingColumnError helper to OrdersProvider

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -2076,6 +2076,25 @@ class OrdersProvider with ChangeNotifier {
     return const <Map<String, dynamic>>[];
   }
 
+  bool _isMissingColumnError(Object error, String columnName) {
+    if (error is! PostgrestException) return false;
+
+    final code = (error.code ?? '').trim();
+    final message = error.message.toLowerCase();
+    final details = (error.details ?? '').toString().toLowerCase();
+    final hint = (error.hint ?? '').toString().toLowerCase();
+    final normalizedColumn = columnName.toLowerCase();
+    final mentionsColumn = message.contains(normalizedColumn) ||
+        details.contains(normalizedColumn) ||
+        hint.contains(normalizedColumn);
+
+    return mentionsColumn &&
+        (code == '42703' ||
+            code == 'PGRST204' ||
+            message.contains('column') ||
+            message.contains('schema cache'));
+  }
+
   List<Map<String, dynamic>> _normalizeTaskComments(dynamic value) {
     if (value is List) {
       return value


### PR DESCRIPTION
### Motivation
- Fix a compilation/runtime error where `_isMissingColumnError` was referenced but not defined in `OrdersProvider`, preventing fallback SELECTs from retrying when optional timestamp columns are absent. 
- Ensure retry logic only triggers for genuine missing-column PostgREST errors and does not mask unrelated database failures.

### Description
- Add a private helper `bool _isMissingColumnError(Object error, String columnName)` to `OrdersProvider` that inspects `PostgrestException` fields (`code`, `message`, `details`, `hint`) and confirms the error mentions the requested column before classifying it as missing. 
- Normalize column and message text checks and include common PostgREST codes (`42703`, `PGRST204`) while also checking for generic "column" / "schema cache" phrases. 
- Remove a duplicate local variable declaration in `_taskProductionQuantity` (sanity fix surfaced while editing). 

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues and it completed successfully. 
- Executed a Python sanity script to assert the new helper is present and the duplicate `double total` declaration was removed, and the checks passed. 
- Attempted `flutter analyze` and `dart analyze` but they could not be executed in the environment because `flutter`/`dart` are not installed, so static analysis was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d87215a0832f82640f721dbab594)