### PR TITLE
Hide shipped orders from production jobs

### DIFF
--- a/lib/modules/production/production_order_visibility.dart
+++ b/lib/modules/production/production_order_visibility.dart
@@ -1,0 +1,13 @@
+import '../orders/order_model.dart';
+
+/// Returns whether an order should be shown in the production job management
+/// module's main datasets.
+///
+/// Production keeps active orders and finished-but-not-yet-shipped orders so
+/// they can be reviewed before shipment. Once shipment is registered, the order
+/// leaves the production lists entirely.
+bool isOrderVisibleInProductionJobs(OrderModel order) {
+  if (order.statusEnum == OrderStatus.in_production) return true;
+  if (order.statusEnum != OrderStatus.completed) return false;
+  return !order.isShipped;
+}

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -14,6 +14,7 @@ import '../production_planning/template_provider.dart';
 import '../production_planning/template_model.dart';
 import '../production_planning/planned_stage_model.dart';
 import 'production_details_screen.dart';
+import 'production_order_visibility.dart';
 
 const _completedLabel = 'Завершенные';
 const _completedTabId = '__completed__';
@@ -684,10 +685,9 @@ class _ProductionScreenState extends State<ProductionScreen>
     final queue = context.watch<ProductionQueueProvider>();
     final templateProvider = context.watch<TemplateProvider>();
 
-    final orders = ordersProvider.orders.where((order) {
-      return order.statusEnum == OrderStatus.in_production ||
-          order.statusEnum == OrderStatus.completed;
-    }).toList(growable: false);
+    final orders = ordersProvider.orders
+        .where(isOrderVisibleInProductionJobs)
+        .toList(growable: false);
     final tasks = taskProvider.tasks;
 
     final productTypeOptions = {

--- a/test/production_order_visibility_test.dart
+++ b/test/production_order_visibility_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/order_model.dart';
+import 'package:sheet_clone/modules/orders/product_model.dart';
+import 'package:sheet_clone/modules/production/production_order_visibility.dart';
+
+void main() {
+  ProductModel product() => ProductModel(
+        id: 'product-1',
+        type: 'П-пакет',
+        quantity: 100,
+        width: 10,
+        height: 20,
+        depth: 30,
+        parameters: '',
+      );
+
+  OrderModel order({required OrderStatus status, DateTime? shippedAt}) =>
+      OrderModel(
+        id: 'order-1',
+        manager: 'Manager',
+        customer: 'Customer',
+        orderDate: DateTime.utc(2026, 1, 1),
+        dueDate: null,
+        product: product(),
+        status: status.name,
+        shippedAt: shippedAt,
+      );
+
+  test('keeps active production orders in production jobs', () {
+    expect(
+      isOrderVisibleInProductionJobs(
+        order(status: OrderStatus.in_production),
+      ),
+      isTrue,
+    );
+  });
+
+  test('keeps completed orders until shipment is registered', () {
+    expect(
+      isOrderVisibleInProductionJobs(
+        order(status: OrderStatus.completed),
+      ),
+      isTrue,
+    );
+  });
+
+  test('hides completed orders after shipment is registered', () {
+    expect(
+      isOrderVisibleInProductionJobs(
+        order(
+          status: OrderStatus.completed,
+          shippedAt: DateTime.utc(2026, 5, 12),
+        ),
+      ),
+      isFalse,
+    );
+  });
+
+  test('does not show pre-production orders in production jobs', () {
+    expect(
+      isOrderVisibleInProductionJobs(order(status: OrderStatus.ready_to_start)),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
### Motivation
- Ensure that once an order is shipped it no longer appears in the main lists of the production job management module. 
- Keep completed-but-not-yet-shipped orders visible for review before shipment.

### Description
- Added `lib/modules/production/production_order_visibility.dart` with `isOrderVisibleInProductionJobs(OrderModel)` which encapsulates the visibility rule (show `in_production` orders and `completed` orders only if not shipped).
- Switched the production screen to use the new helper by replacing the inline filter with `.where(isOrderVisibleInProductionJobs)` in `lib/modules/production/production_screen.dart`.
- Added unit tests in `test/production_order_visibility_test.dart` covering active production, completed-unshipped, shipped, and pre-production cases.

### Testing
- Ran `git diff --check` to validate the diff and it passed.
- Attempted to run `dart format` on modified files but `dart` is not available in the environment so formatting could not be executed.
- Added `test/production_order_visibility_test.dart` but could not run `flutter test` in this environment because `flutter` is not installed; tests are present and should pass when run in a proper Flutter/Dart environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02daf79e0c832f8f516fd05c65ca80)