### PR TITLE
Показ формы (детали и фото) и исправление логики наладки/старта/завершения этапа

### DIFF
--- a/lib/modules/orders/order_details_card.dart
+++ b/lib/modules/orders/order_details_card.dart
@@ -14,6 +14,7 @@ class OrderDetailsCard extends StatelessWidget {
     required this.files,
     required this.stageTemplateName,
     this.formImageUrl,
+    this.formDetails,
     this.extraSections = const <Widget>[],
   });
 
@@ -22,6 +23,7 @@ class OrderDetailsCard extends StatelessWidget {
   final List<Map<String, dynamic>> files;
   final String? stageTemplateName;
   final String? formImageUrl;
+  final Map<String, dynamic>? formDetails;
   final List<Widget> extraSections;
 
   String _fmtDate(DateTime? d) =>
@@ -123,6 +125,44 @@ class OrderDetailsCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+
+  String _formDetailValue(String key) {
+    final value = formDetails?[key];
+    if (value == null) return '';
+    if (value is List) {
+      return value
+          .map((e) => e?.toString().trim() ?? '')
+          .where((e) => e.isNotEmpty)
+          .join(', ');
+    }
+    return value.toString().trim();
+  }
+
+  List<Widget> _formDetailWidgets({bool compact = false}) {
+    final details = <String, String>{
+      'Название': _formDetailValue('title'),
+      'Код': _formDetailValue('code'),
+      'Серия': _formDetailValue('series'),
+      'Номер': _formDetailValue('number'),
+      'Размер': _formDetailValue('size'),
+      'Тип продукта': _formDetailValue('product_type'),
+      'Цвета': _formDetailValue('colors'),
+      'Доп. информация': _formDetailValue('description'),
+    };
+    return details.entries
+        .where((entry) => entry.value.isNotEmpty)
+        .map((entry) => Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                '${entry.key}: ${entry.value}',
+                style: compact
+                    ? const TextStyle(fontSize: 14 * _compactTextScale)
+                    : null,
+              ),
+            ))
+        .toList();
   }
 
   Widget _buildDimensionsValue({bool compact = false}) {
@@ -445,6 +485,7 @@ class OrderDetailsCard extends StatelessWidget {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(_formDisplayText(o)),
+                              ..._formDetailWidgets(compact: true),
                               if (formImageUrl != null &&
                                   formImageUrl!.trim().isNotEmpty)
                                 Padding(

--- a/lib/modules/orders/view_order_screen.dart
+++ b/lib/modules/orders/view_order_screen.dart
@@ -23,6 +23,7 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
   List<Map<String, dynamic>> _paints = const [];
   String? _stageTemplateName;
   String? _formImageUrl;
+  Map<String, dynamic>? _formDetails;
 
   String? _buildFormImageUrl(String? rawUrl, {String? updatedAt}) {
     final trimmed = rawUrl?.trim();
@@ -70,7 +71,7 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
       if (formCode != null && formCode.isNotEmpty) {
         final res = await Supabase.instance.client
             .from('forms')
-            .select('image_url, updated_at')
+            .select()
             .eq('code', formCode)
             .maybeSingle();
         if (res != null && res is Map) {
@@ -83,7 +84,7 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
           formNo != null) {
         final res = await Supabase.instance.client
             .from('forms')
-            .select('image_url, updated_at')
+            .select()
             .eq('series', formSeries)
             .eq('number', formNo)
             .maybeSingle();
@@ -110,6 +111,7 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
         _paints = paints;
         _files = files;
         _formImageUrl = formImageUrl;
+        _formDetails = form;
         _stageTemplateName = stageTemplateName;
       });
     } catch (_) {
@@ -182,6 +184,7 @@ class _ViewOrderDialogState extends State<ViewOrderDialog> {
                         files: _files,
                         stageTemplateName: _stageTemplateName,
                         formImageUrl: _formImageUrl,
+                        formDetails: _formDetails,
                       ),
                     ),
                   ),

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -118,6 +118,8 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
   List<Map<String, dynamic>> _files = const [];
   List<Map<String, dynamic>> _paints = const [];
   String? _stageTemplateName;
+  String? _formImageUrl;
+  Map<String, dynamic>? _formDetails;
 
   List<String> _decodeStringList(dynamic raw) {
     if (raw == null) return const [];
@@ -319,12 +321,62 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
     super.dispose();
   }
 
+
+  String? _buildFormImageUrl(String? rawUrl, {String? updatedAt}) {
+    final trimmed = rawUrl?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+
+    String resolvedUrl = trimmed;
+    if (!(trimmed.startsWith('http://') || trimmed.startsWith('https://'))) {
+      resolvedUrl = Supabase.instance.client.storage.from('tmc').getPublicUrl(trimmed);
+    }
+
+    final dt = DateTime.tryParse(updatedAt ?? '');
+    if (dt == null) return resolvedUrl;
+
+    final uri = Uri.tryParse(resolvedUrl);
+    if (uri == null) return resolvedUrl;
+
+    final query = Map<String, String>.from(uri.queryParameters);
+    query['v'] = dt.millisecondsSinceEpoch.toString();
+    return uri.replace(queryParameters: query).toString();
+  }
+
+  Future<Map<String, dynamic>?> _loadFormDetails() async {
+    final formCode = widget.order.formCode?.trim();
+    final formSeries = widget.order.formSeries?.trim();
+    final formNo = widget.order.newFormNo;
+    if (formCode != null && formCode.isNotEmpty) {
+      final res = await Supabase.instance.client
+          .from('forms')
+          .select()
+          .eq('code', formCode)
+          .maybeSingle();
+      if (res != null && res is Map) return Map<String, dynamic>.from(res);
+    }
+    if (formSeries != null && formSeries.isNotEmpty && formNo != null) {
+      final res = await Supabase.instance.client
+          .from('forms')
+          .select()
+          .eq('series', formSeries)
+          .eq('number', formNo)
+          .maybeSingle();
+      if (res != null && res is Map) return Map<String, dynamic>.from(res);
+    }
+    return null;
+  }
+
   Future<void> _loadOrderDetails() async {
     setState(() => _loadingFiles = true);
     try {
       final repo = OrdersRepository();
       final paints = await repo.getPaints(widget.order.id);
       final files = await storage.listOrderFiles(widget.order.id);
+      final formDetails = await _loadFormDetails();
+      final formImageUrl = _buildFormImageUrl(
+        formDetails?['image_url']?.toString(),
+        updatedAt: formDetails?['updated_at']?.toString(),
+      );
       String? stageTemplateName;
       final tplId = widget.order.stageTemplateId;
       if (tplId != null && tplId.isNotEmpty) {
@@ -341,6 +393,8 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
         _paints = paints;
         _files = files;
         _stageTemplateName = stageTemplateName;
+        _formImageUrl = formImageUrl;
+        _formDetails = formDetails;
       });
     } catch (_) {
       // ignore errors in read-only view
@@ -940,6 +994,8 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                             paints: _paints,
                             files: _files,
                             stageTemplateName: _stageTemplateName,
+                            formImageUrl: _formImageUrl,
+                            formDetails: _formDetails,
                           ),
                         ),
                       ),

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -3210,6 +3210,7 @@ class _TasksScreenState extends State<TasksScreen>
           final resolvedFormImageUrl =
               (data != null && data.isNotEmpty ? data[0] as String? : null) ??
                   cachedFormImageUrl;
+          final resolvedFormDetails = _formImageCache[order.id]?.details;
           final resolvedPaints =
               (data != null && data.length > 1
                       ? data[1] as List<Map<String, dynamic>>
@@ -3229,6 +3230,7 @@ class _TasksScreenState extends State<TasksScreen>
                 files: resolvedFiles,
                 stageTemplateName: templateName,
                 formImageUrl: resolvedFormImageUrl,
+                formDetails: resolvedFormDetails,
                 extraSections: [
                   _buildStageList(order, scale),
                 ],
@@ -3507,6 +3509,7 @@ class _TasksScreenState extends State<TasksScreen>
 
   bool _canFinalizeTask(TaskModel task) {
     if (task.status == TaskStatus.completed) return false;
+    if (!_hasProductionStartedForStage(task)) return false;
     if (_anyUserActive(task)) return false;
     if (_isInkConfirmationStage(task)) {
       return true;
@@ -4352,9 +4355,11 @@ class _TasksScreenState extends State<TasksScreen>
                     // allow pausing also if user resumed
                     final bool canFinishRow = isMyRow &&
                         canFinish &&
+                        _hasProductionStartedForStage(task) &&
                         userParticipatedInStage &&
                         (stateRowUser != UserRunState.idle &&
-                            stateRowUser != UserRunState.finished);
+                            stateRowUser != UserRunState.finished) &&
+                        !isSetupActiveForRow;
                     final bool canProblemRow = isMyRow &&
                         canProblem &&
                         stateRowUser == UserRunState.active;
@@ -4487,9 +4492,6 @@ class _TasksScreenState extends State<TasksScreen>
                           return;
                         }
 
-                        final bool setupInProgressForCurrentUser =
-                            _isSetupInProgressForUser(task, widget.employeeId) &&
-                                !_hasProductionStartedForStage(task);
 
                         final startedAtTs =
                             task.startedAt ?? DateTime.now().millisecondsSinceEpoch;
@@ -4537,8 +4539,7 @@ class _TasksScreenState extends State<TasksScreen>
                         }
 
                         if (_hasMachineForStage(stage) &&
-                            !_isSetupCompletedForUser(task, widget.employeeId) &&
-                            !setupInProgressForCurrentUser) {
+                            !_isSetupCompletedForUser(task, widget.employeeId)) {
                           await _finishSetup(task, provider);
                         }
                         final isResumeAction = stateRowUser == UserRunState.paused ||
@@ -5261,9 +5262,10 @@ class _TasksScreenState extends State<TasksScreen>
                                   if (_hasMachineForStage(stage) && isMyRow) ...[
                                     ElevatedButton.icon(
                                       onPressed: (!shiftPaused &&
-                                              !_isSetupCompletedForStage(task) &&
-                                              !_hasPendingSetupForStage(task) &&
-                                              !_hasProductionStartedForStage(task))
+                                              _canStartOrResumeSetupForUser(
+                                                task,
+                                                widget.employeeId,
+                                              ))
                                           ? () => _startSetup(task, provider)
                                           : null,
                                       style: ElevatedButton.styleFrom(
@@ -5281,7 +5283,14 @@ class _TasksScreenState extends State<TasksScreen>
                                             : null,
                                       ),
                                       icon: const Icon(Icons.build),
-                                      label: const Text('Начать наладку'),
+                                      label: Text(
+                                        _hasUnfinishedSetupForUser(
+                                          task,
+                                          widget.employeeId,
+                                        )
+                                            ? 'Продолжить наладку'
+                                            : 'Начать наладку',
+                                      ),
                                     ),
                                     SizedBox(width: buttonSpacing),
                                   ],
@@ -5769,6 +5778,29 @@ class _TasksScreenState extends State<TasksScreen>
     return false;
   }
 
+  bool _hasUnfinishedSetupForUser(TaskModel task, String userId) {
+    var lastSetupStart = 0;
+    var lastSetupDone = 0;
+    for (final c in task.comments) {
+      if (c.userId != userId) continue;
+      if (c.type == 'setup_start' || c.type == 'setup_resume') {
+        if (c.timestamp > lastSetupStart) lastSetupStart = c.timestamp;
+      } else if (c.type == 'setup_done') {
+        if (c.timestamp > lastSetupDone) lastSetupDone = c.timestamp;
+      }
+    }
+    return lastSetupStart > 0 && lastSetupStart > lastSetupDone;
+  }
+
+  bool _canStartOrResumeSetupForUser(TaskModel task, String userId) {
+    if (_hasProductionStartedForStage(task) || _isSetupCompletedForStage(task)) {
+      return false;
+    }
+    final hasPendingSetup = _hasPendingSetupForStage(task);
+    if (!hasPendingSetup) return true;
+    return _hasUnfinishedSetupForUser(task, userId);
+  }
+
   bool _isSetupCompletedForStage(TaskModel task) {
     if (_hasPendingSetupForStage(task)) return false;
     return task.comments.any((c) => c.type == 'setup_done');
@@ -5786,7 +5818,11 @@ class _TasksScreenState extends State<TasksScreen>
       (t) => t.id == task.id,
       orElse: () => task,
     );
-    if (_hasPendingSetupForStage(latestTask) ||
+    final resumeOwnSetup = _hasUnfinishedSetupForUser(
+      latestTask,
+      widget.employeeId,
+    );
+    if ((_hasPendingSetupForStage(latestTask) && !resumeOwnSetup) ||
         _isSetupCompletedForStage(latestTask) ||
         _hasProductionStartedForStage(latestTask)) {
       if (!mounted) return;
@@ -5813,8 +5849,10 @@ class _TasksScreenState extends State<TasksScreen>
     }
     await provider.addCommentAutoUser(
       taskId: task.id,
-      type: 'setup_start',
-      text: 'Начал(а) настройку станка',
+      type: resumeOwnSetup ? 'setup_resume' : 'setup_start',
+      text: resumeOwnSetup
+          ? 'Продолжил(а) настройку станка'
+          : 'Начал(а) настройку станка',
       userIdOverride: widget.employeeId,
     );
     final participants = _participantsSnapshot(latestTask, widget.employeeId);
@@ -6047,7 +6085,7 @@ class _TasksScreenState extends State<TasksScreen>
       if (code != null && code.isNotEmpty) {
         final res = await client
             .from('forms')
-            .select('image_url, updated_at')
+            .select()
             .eq('code', code)
             .maybeSingle();
         if (res != null && res is Map) {
@@ -6062,7 +6100,7 @@ class _TasksScreenState extends State<TasksScreen>
           order.newFormNo != null) {
         final res = await client
             .from('forms')
-            .select('image_url, updated_at')
+            .select()
             .eq('series', order.formSeries!.trim())
             .eq('number', order.newFormNo!)
             .maybeSingle();
@@ -6074,11 +6112,19 @@ class _TasksScreenState extends State<TasksScreen>
         row?['image_url']?.toString(),
         updatedAt: row?['updated_at']?.toString(),
       );
-      _formImageCache[key] = _FormImageCacheEntry(url: url, fetchedAt: DateTime.now());
+      _formImageCache[key] = _FormImageCacheEntry(
+        url: url,
+        details: row,
+        fetchedAt: DateTime.now(),
+      );
       return url;
     } catch (e) {
       debugPrint('❌ load form image error: $e');
-      _formImageCache[key] = _FormImageCacheEntry(url: null, fetchedAt: DateTime.now());
+      _formImageCache[key] = _FormImageCacheEntry(
+        url: null,
+        details: null,
+        fetchedAt: DateTime.now(),
+      );
       return null;
     } finally {
       _formImagePending.remove(key);
@@ -6147,10 +6193,12 @@ class _TasksScreenState extends State<TasksScreen>
 
 class _FormImageCacheEntry {
   final String? url;
+  final Map<String, dynamic>? details;
   final DateTime fetchedAt;
 
   const _FormImageCacheEntry({
     required this.url,
+    required this.details,
     required this.fetchedAt,
   });
 }


### PR DESCRIPTION
### Motivation
- Исправить отображение информации о форме в деталях заказа и деталях задания, включая фото и дополнительные поля формы. 
- Обеспечить корректную передачу данных формы между созданием/редактированием заказа, модулем управления заданиями и рабочим пространством сотрудника без изменения существующей структуры данных в БД. 
- Упорядочить поведение кнопок «Наладка», «Начать», «Пауза», «Проблема» и «Завершить» так, чтобы наладка не считалась производством и чтобы можно было возобновлять свою наладку после паузы/проблемы. 

### Description
- Передача и рендер дополнительных полей формы: добавлен параметр `formDetails` в `OrderDetailsCard` и выводятся поля (title, code, series, number, size, product_type, colors, description) рядом с информацией о форме и фото (file: `lib/modules/orders/order_details_card.dart`).
- Подгрузка полной строки формы из таблицы `forms` в диалогах/панелях: смена селекта на полную строку (`.select()`) и сохранение результата `form` (file: `lib/modules/orders/view_order_screen.dart`, `lib/modules/production/production_details_screen.dart`, `lib/modules/tasks/tasks_screen.dart`).
- Загрузка и кеширование метаданных формы вместе с URL фото в рабочем пространстве (`_formImageCache` расширен для хранения `details`) и передача этих данных в `OrderDetailsCard` из списка задач и деталей производства (file: `lib/modules/tasks/tasks_screen.dart`, `lib/modules/production/production_details_screen.dart`).
- Логика наладки/возобновления: добавлены `_hasUnfinishedSetupForUser` и `_canStartOrResumeSetupForUser` для проверки возможности возобновления собственной незавершённой наладки; при возобновлении добавляется комментарий типа `setup_resume` (file: `lib/modules/tasks/tasks_screen.dart`).
- Поведение кнопок и завершения этапа: перед запуском производства `_finishSetup` вызывается при необходимости; кнопка «Завершить»/финализация этапа теперь запрещены, если производство реально не стартовало (`_hasProductionStartedForStage` используется в проверках `_canFinalizeTask` и в доступности кнопки завершения строки) (file: `lib/modules/tasks/tasks_screen.dart`).
- Небольшие защитные правки: обработка отсутствия image_url не ломает UI, корректный fallback для показа изображений (использование `storage.getPublicUrl` и параметра версии `v` по `updated_at`).

### Testing
- Выполнен `git diff --check` для проверки смешанных пробелов/конфликтов и ошибок диффа — проблем не обнаружено (успешно).
- Попытка запустить `flutter analyze` завершилась ошибкой окружения: Flutter SDK не установлен в текущем CI/контейнере, поэтому статический анализ не выполнен (неуспешно из-за окружения).
- Локальные интеграционные/юнит-тесты проекта не запускались в этом окружении; изменения ограничены добавлением выборок полей и логики поверх существующих флагов, без добавления новых полей в модели БД, чтобы не сломать совместимость с существующими заказами.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031ee7bc24832fb88e00b23b1f614e)