### PR TITLE
Исправить блокировку кнопки «Начать» после наладки

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4305,8 +4305,7 @@ class _TasksScreenState extends State<TasksScreen>
                     final UserRunState stateRowUser =
                         _userRunState(task, currentRowUserId);
                     final bool isSetupActiveForRow =
-                        _openEventForUser(task, currentRowUserId)?.type ==
-                            TaskTimeType.setup;
+                        _isSetupInProgressForUser(task, currentRowUserId);
                     final bool isSetupStartPending =
                         _startingSetupTaskIds.contains(task.id);
                     // Disable buttons for other users' rows
@@ -4331,12 +4330,14 @@ class _TasksScreenState extends State<TasksScreen>
                             stateRowUser == UserRunState.idle;
                     final bool hasOpenStartIntentForRowUser =
                         _hasOpenStartIntentForUser(task, currentRowUserId);
+                    final bool startIntentBlocksRow =
+                        hasOpenStartIntentForRowUser && !isSetupActiveForRow;
                     final bool canStartButtonRow = isMyRow &&
                         canStart &&
                         !_startingTaskIds.contains(task.id) &&
                         !requiresSetupBeforeStart &&
                         !blockedByShiftResumeLock &&
-                        !hasOpenStartIntentForRowUser &&
+                        !startIntentBlocksRow &&
                         // Для отдельных исполнителей разрешаем возобновлять этап
                         // после личного завершения (до финальной кнопки
                         // "Завершить задание").
@@ -5747,7 +5748,6 @@ class _TasksScreenState extends State<TasksScreen>
             c.userId == userId &&
             (c.type == 'start' ||
                 c.type == 'resume' ||
-                c.type == 'setup_resume' ||
                 c.type == 'pause' ||
                 c.type == 'problem' ||
                 c.type == 'user_done'))
@@ -5755,9 +5755,7 @@ class _TasksScreenState extends State<TasksScreen>
       ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
     if (events.isEmpty) return false;
     final lastType = events.last.type;
-    return lastType == 'start' ||
-        lastType == 'resume' ||
-        lastType == 'setup_resume';
+    return lastType == 'start' || lastType == 'resume';
   }
 
   bool _hasPendingSetupForStage(TaskModel task) {


### PR DESCRIPTION
### Motivation
- После восстановления/возобновления наладки по комментариям кнопка `▶ Начать` оставалась заблокированной, потому что код проверял только открытый таймер и считал `setup_resume` как «открытый intent старта», мешая перейти из наладки в производство.

### Description
- Заменил проверку активной наладки с `_openEventForUser(...).type == TaskTimeType.setup` на `_isSetupInProgressForUser(...)` в `lib/modules/tasks/tasks_screen.dart` чтобы учитывать восстановлённое состояние наладки.
- Ввел флаг `startIntentBlocksRow` и изменил условие, чтобы «открытый intent старта» блокировал кнопку только если пользователь не находится в активной наладке.
- Убрал `setup_resume` из списка типов, которые считаются «открытым intent старта» в `_hasOpenStartIntentForUser`, чтобы возобновление наладки не мешало нажатию `Start`.

### Testing
- Выполнена проверка синтаксических/статических проблем через `git diff --check`, ошибок не обнаружено.
- Попытка запустить `dart format lib/modules/tasks/tasks_screen.dart` не выполнена, так как `dart` отсутствует в окружении.  
- Автоматических юнит-тестов в рамках этого изменения не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0416dd9870832f9cdd5adf44cbd7fd)