### PR TITLE
Prefill meter task quantity from paper length

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -31,6 +31,91 @@ import '../../services/storage_service.dart';
 const String kCardboardCuttingStageId =
     stage_sequence.kCardboardCuttingStageId;
 
+const Set<String> _meterUnitAliases = <String>{
+  'м',
+  'метр',
+  'метры',
+  'm',
+  'meter',
+  'meters',
+};
+
+String _normalizeTaskQuantityUnit(String? unit) =>
+    (unit ?? '').trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+
+bool isTaskMeterUnit(String? unit) =>
+    _meterUnitAliases.contains(_normalizeTaskQuantityUnit(unit));
+
+double? _taskPaperLengthNumber(dynamic value) {
+  if (value == null) return null;
+  if (value is num) return value.toDouble();
+  if (value is String) {
+    final normalized = value.trim().replaceAll(',', '.');
+    if (normalized.isEmpty) return null;
+    final parsed = double.tryParse(normalized);
+    if (parsed != null) return parsed;
+    return double.tryParse(normalized.replaceAll(RegExp(r'[^0-9.\-]'), ''));
+  }
+  return null;
+}
+
+double? _taskPaperLengthFromMap(Map<String, dynamic>? map) {
+  if (map == null) return null;
+  for (final key in const <String>['lengthL', 'length_l', 'length', 'L']) {
+    final parsed = _taskPaperLengthNumber(map[key]);
+    if (parsed != null && parsed > 0) return parsed;
+  }
+  final paper = map['paper'];
+  if (paper is Map) {
+    final parsed = _taskPaperLengthFromMap(Map<String, dynamic>.from(paper));
+    if (parsed != null && parsed > 0) return parsed;
+  }
+  return null;
+}
+
+double? _taskPaperLengthFromMaterial(MaterialModel material) {
+  final extraLength = _taskPaperLengthFromMap(material.extra);
+  if (extraLength != null && extraLength > 0) return extraLength;
+  if (material.quantity > 0) return material.quantity;
+  return null;
+}
+
+double taskPaperLengthTotalForOrder(OrderModel? order) {
+  if (order == null) return 0;
+
+  final materialTotal = order.paperMaterials.fold<double>(0, (sum, material) {
+    final length = _taskPaperLengthFromMaterial(material);
+    return length == null || length <= 0 ? sum : sum + length;
+  });
+  if (materialTotal > 0) return materialTotal;
+
+  final productMap = order.product.toMap();
+  final productLength = _taskPaperLengthFromMap(productMap);
+  if (productLength != null && productLength > 0) return productLength;
+
+  final directLength = order.product.length;
+  if (directLength != null && directLength > 0) return directLength;
+
+  return 0;
+}
+
+double? initialTaskMeterQuantityForOrder({
+  required String? unit,
+  required OrderModel? order,
+}) {
+  if (!isTaskMeterUnit(unit)) return null;
+  final total = taskPaperLengthTotalForOrder(order);
+  return total > 0 ? total : null;
+}
+
+String formatTaskInitialQuantity(double value) {
+  if (value % 1 == 0) return value.toStringAsFixed(0);
+  return value
+      .toStringAsFixed(2)
+      .replaceFirst(RegExp(r'0+$'), '')
+      .replaceFirst(RegExp(r'\.$'), '');
+}
+
 class TasksScreen extends StatefulWidget {
   final String employeeId;
   final bool showListOnly;
@@ -575,7 +660,7 @@ class _StageComment {
 }
 
 class _QuantityInput {
-  final int quantity;
+  final double quantity;
   final String displayText;
   final bool openPaperEditor;
   final int? packsCount;
@@ -906,6 +991,13 @@ class _TasksScreenState extends State<TasksScreen>
     } catch (_) {
       return null;
     }
+  }
+
+  double? _initialMeterQuantityForTask(TaskModel task, String? unit) {
+    return initialTaskMeterQuantityForOrder(
+      unit: unit,
+      order: _orderById(task.orderId),
+    );
   }
 
   String _queueOrderIdForTask(TaskModel task, OrdersProvider ordersProvider) {
@@ -3929,6 +4021,7 @@ class _TasksScreenState extends State<TasksScreen>
           context,
           unit: unitLabel,
           allowPaperEdit: true,
+          initialQuantity: _initialMeterQuantityForTask(task, unitLabel),
         );
         if (result == null) return;
         if (!result.openPaperEditor) {
@@ -4593,6 +4686,8 @@ class _TasksScreenState extends State<TasksScreen>
                           context,
                           unit: unitLabel,
                           allowPaperEdit: true,
+                          initialQuantity:
+                              _initialMeterQuantityForTask(task, unitLabel),
                         );
                         if (qtyInput == null) return;
                         if (!qtyInput.openPaperEditor) break;
@@ -4905,8 +5000,12 @@ class _TasksScreenState extends State<TasksScreen>
                       if (!confirmed) return;
 
                       final unitLabel = _workplaceUnit(personnel, task.stageId);
-                      final qtyInput =
-                          await _askQuantity(context, unit: unitLabel);
+                      final qtyInput = await _askQuantity(
+                        context,
+                        unit: unitLabel,
+                        initialQuantity:
+                            _initialMeterQuantityForTask(task, unitLabel),
+                      );
                       if (qtyInput == null) return;
 
                       await taskProvider.closeOpenTimeEvent(
@@ -4986,6 +5085,8 @@ class _TasksScreenState extends State<TasksScreen>
                             context,
                             unit: unitLabel,
                             allowPaperEdit: true,
+                            initialQuantity:
+                                _initialMeterQuantityForTask(task, unitLabel),
                           );
                           if (qtyInput == null) return;
                           if (!qtyInput.openPaperEditor) break;
@@ -6662,8 +6763,13 @@ Future<_QuantityInput?> _askQuantity(
   BuildContext context, {
   String? unit,
   bool allowPaperEdit = false,
+  double? initialQuantity,
 }) async {
-  final totalController = TextEditingController();
+  final totalController = TextEditingController(
+    text: initialQuantity != null && initialQuantity > 0
+        ? formatTaskInitialQuantity(initialQuantity)
+        : '',
+  );
   final unitLabel = (unit ?? '').trim();
   const paperEditValue = '__open_paper_edit__';
   final v = await showDialog<_QuantityInput?>(
@@ -6674,7 +6780,7 @@ Future<_QuantityInput?> _askQuantity(
         content: TextField(
           controller: totalController,
           autofocus: true,
-          keyboardType: TextInputType.number,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
           decoration: InputDecoration(
             hintText: unitLabel.isNotEmpty
                 ? 'Введите количество в $unitLabel'
@@ -6700,9 +6806,12 @@ Future<_QuantityInput?> _askQuantity(
           ElevatedButton(
             onPressed: () {
               final raw = totalController.text.trim();
-              final n = int.tryParse(raw);
+              final n = double.tryParse(raw.replaceAll(',', '.'));
               if (n == null) return;
-              final display = unitLabel.isNotEmpty ? '$n $unitLabel' : n.toString();
+              final displayQuantity = formatTaskInitialQuantity(n);
+              final display = unitLabel.isNotEmpty
+                  ? '$displayQuantity $unitLabel'
+                  : displayQuantity;
               Navigator.pop(
                 ctx,
                 _QuantityInput(quantity: n, displayText: display),
@@ -6714,6 +6823,7 @@ Future<_QuantityInput?> _askQuantity(
       );
     },
   );
+  totalController.dispose();
   if (v == null) return null;
   if (v.openPaperEditor || v.displayText == paperEditValue) {
     return const _QuantityInput(

--- a/test/tasks_paper_length_helper_test.dart
+++ b/test/tasks_paper_length_helper_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/material_model.dart';
+import 'package:sheet_clone/modules/orders/order_model.dart';
+import 'package:sheet_clone/modules/orders/product_model.dart';
+import 'package:sheet_clone/modules/tasks/tasks_screen.dart';
+
+void main() {
+  group('task paper length initial quantity helpers', () {
+    test('recognizes meter units with normalized case and spaces', () {
+      expect(isTaskMeterUnit(' м '), isTrue);
+      expect(isTaskMeterUnit('  M  '), isTrue);
+      expect(isTaskMeterUnit(' Meter '), isTrue);
+      expect(isTaskMeterUnit('meters'), isTrue);
+      expect(isTaskMeterUnit('шт'), isFalse);
+    });
+
+    test('uses one paper L=4500 from normalized materials', () {
+      final order = _orderWithMaterials([
+        const MaterialModel(name: 'Paper', quantity: 4500, unit: 'м'),
+      ]);
+
+      expect(
+        initialTaskMeterQuantityForOrder(unit: 'м', order: order),
+        4500,
+      );
+    });
+
+    test('sums two papers L=3000+2000 from normalized materials', () {
+      final order = _orderWithMaterials([
+        const MaterialModel(name: 'Paper 1', quantity: 3000, unit: 'м'),
+        const MaterialModel(name: 'Paper 2', quantity: 2000, unit: 'м'),
+      ]);
+
+      expect(
+        initialTaskMeterQuantityForOrder(unit: 'meters', order: order),
+        5000,
+      );
+    });
+
+    test('does not provide initial quantity for non-meter unit', () {
+      final order = _orderWithMaterials([
+        const MaterialModel(name: 'Paper', quantity: 4500, unit: 'м'),
+      ]);
+
+      expect(
+        initialTaskMeterQuantityForOrder(unit: 'шт', order: order),
+        isNull,
+      );
+    });
+
+    test('does not provide initial quantity when L is absent', () {
+      final order = _orderWithMaterials([
+        const MaterialModel(name: 'Paper', unit: 'м'),
+      ]);
+
+      expect(
+        initialTaskMeterQuantityForOrder(unit: 'м', order: order),
+        isNull,
+      );
+    });
+  });
+}
+
+OrderModel _orderWithMaterials(List<MaterialModel> materials) {
+  return OrderModel(
+    id: 'order-1',
+    manager: 'manager',
+    customer: 'customer',
+    orderDate: DateTime(2026),
+    dueDate: null,
+    product: ProductModel(
+      id: 'product-1',
+      type: 'product',
+      quantity: 1,
+      width: 0,
+      height: 0,
+      depth: 0,
+    ),
+    paperMaterials: materials,
+  );
+}


### PR DESCRIPTION
### Motivation
- Reduce manual entry for meter-based tasks by pre-filling the quantity dialog from order paper lengths while keeping the field editable.
- Support multiple normalized ways orders can carry length (`material_list` extras, `lengthL`/`length_l`/`length`/`L`, nested `paper` maps, and product `length`).

### Description
- Added meter unit recognition and normalization helpers: `_meterUnitAliases`, `_normalizeTaskQuantityUnit`, and `isTaskMeterUnit` and format helper `formatTaskInitialQuantity` in `lib/modules/tasks/tasks_screen.dart`.
- Implemented parsing helpers `_taskPaperLengthNumber`, `_taskPaperLengthFromMap`, `_taskPaperLengthFromMaterial`, and aggregation `taskPaperLengthTotalForOrder` plus public `initialTaskMeterQuantityForOrder` and a task-local `_initialMeterQuantityForTask` that use existing `OrderModel`/`MaterialModel` structures.
- Extended `_askQuantity` signature with `double? initialQuantity`, prefilled the `TextEditingController` when a positive initial value exists, switched parsing to `double`, kept the input editable, and preserved saving of the confirmed `qtyInput.displayText`.
- Updated call sites around task finish/helper removal/shift flows to pass `initialQuantity` only for meter units via `_initialMeterQuantityForTask`, and adjusted `_QuantityInput.quantity` to `double` to allow fractional meters.
- Added unit tests `test/tasks_paper_length_helper_test.dart` covering meter recognition, one-paper L=4500, two-papers L=3000+2000, non-meter unit, and missing L scenarios.

### Testing
- Ran `git diff --check` with no issues detected.
- Added unit tests at `test/tasks_paper_length_helper_test.dart` but `flutter test` could not be executed in the environment because `flutter` is not installed (test run failed with `flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0612b3434c832f8b3051af802b64c9)