### PR TITLE
Add Supabase migration for chat messages and chat storage bucket

### DIFF
--- a/supabase/migrations/20260514_create_chat_messages.sql
+++ b/supabase/migrations/20260514_create_chat_messages.sql
@@ -1,0 +1,165 @@
+-- Таблица сообщений чата и bucket для вложений.
+
+create table if not exists public.chat_messages (
+  id text primary key,
+  room_id text not null,
+  sender_id text,
+  sender_name text,
+  kind text not null default 'text',
+  body text,
+  file_url text,
+  file_mime text,
+  duration_ms int,
+  width int,
+  height int,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists chat_messages_room_created_at_idx
+  on public.chat_messages(room_id, created_at);
+
+alter table public.chat_messages enable row level security;
+alter table public.chat_messages replica identity full;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'chat_messages'
+      and policyname = 'chat_messages_select'
+  ) then
+    create policy chat_messages_select
+      on public.chat_messages
+      for select
+      to authenticated, anon
+      using (true);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'chat_messages'
+      and policyname = 'chat_messages_insert'
+  ) then
+    create policy chat_messages_insert
+      on public.chat_messages
+      for insert
+      to authenticated, anon
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'chat_messages'
+      and policyname = 'chat_messages_update'
+  ) then
+    create policy chat_messages_update
+      on public.chat_messages
+      for update
+      to authenticated, anon
+      using (true)
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'chat_messages'
+      and policyname = 'chat_messages_delete'
+  ) then
+    create policy chat_messages_delete
+      on public.chat_messages
+      for delete
+      to authenticated, anon
+      using (true);
+  end if;
+end $$;
+
+insert into storage.buckets (id, name, public)
+values ('chat', 'chat', true)
+on conflict (id) do update
+set name = excluded.name,
+    public = excluded.public;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'chat_storage_select'
+  ) then
+    create policy chat_storage_select
+      on storage.objects
+      for select
+      to authenticated
+      using (bucket_id = 'chat');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'chat_storage_insert'
+  ) then
+    create policy chat_storage_insert
+      on storage.objects
+      for insert
+      to authenticated
+      with check (bucket_id = 'chat');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'chat_storage_update'
+  ) then
+    create policy chat_storage_update
+      on storage.objects
+      for update
+      to authenticated
+      using (bucket_id = 'chat')
+      with check (bucket_id = 'chat');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'chat_storage_delete'
+  ) then
+    create policy chat_storage_delete
+      on storage.objects
+      for delete
+      to authenticated
+      using (bucket_id = 'chat');
+  end if;
+end $$;
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_publication
+    where pubname = 'supabase_realtime'
+  ) and not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'chat_messages'
+  ) then
+    alter publication supabase_realtime add table public.chat_messages;
+  end if;
+end $$;


### PR DESCRIPTION
### Motivation
- Добавить в БД таблицу для сообщений чата, соответствующую модели `ChatMessage`, чтобы провайдер чата мог работать с реальным хранилищем данных и realtime-оповещениями.
- Обеспечить индексирование по `(room_id, created_at)` для эффективной выборки истории и корректную работу realtime через `replica identity full`.
- Создать storage bucket для вложений `chat` и настроить политики доступа, соответствующие модели доступа проекта.

### Description
- Добавлен миграционный файл `supabase/migrations/20260514_create_chat_messages.sql`, создающий таблицу `public.chat_messages` с колонками из `ChatMessage` (`id`, `room_id`, `sender_id`, `sender_name`, `kind`, `body`, `file_url`, `file_mime`, `duration_ms`, `width`, `height`, `created_at`).
- Добавлен индекс `chat_messages_room_created_at_idx` по `(room_id, created_at)`, включён `replica identity full` и добавлены idempotent RLS-политики `select/insert/update/delete` для ролей `authenticated` и `anon`.
- В миграции добавлен upsert для storage bucket `chat` (`insert into storage.buckets ... on conflict do update`) и созданы политики на `storage.objects` для чтения/вставки/обновления/удаления объектов bucket `chat` для авторизованных пользователей.
- Добавлено условное добавление `public.chat_messages` в публикацию `supabase_realtime`, если публикация существует, чтобы включить realtime-репликацию.
- Проверено, что `lib/modules/chat/chat_provider.dart` использует `public.chat_messages` и storage bucket `chat`, поэтому провайдер не обращается к несуществующей схеме.

### Testing
- Запущена проверка индексации и staged diff: `git diff --cached --check`, которая прошла успешно.
- Поиском `rg -n "schema:|from\('chat_messages'\)|storage\.from\('chat'\)" lib/modules/chat/chat_provider.dart` подтверждена корректная ссылка провайдера на `chat_messages` и на bucket `chat`.
- Просмотр содержимого миграции `nl -ba supabase/migrations/20260514_create_chat_messages.sql` подтвердил наличие всех заявленных DDL и политик.
- Все автоматизированные проверки, выполненные в процессе (см. команды выше), завершились успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06147a20b4832f8846970201c67531)