### PR TITLE
Task comment attachments — Supabase migration, attachment service, provider and UI

### DIFF
--- a/lib/modules/tasks/task_model.dart
+++ b/lib/modules/tasks/task_model.dart
@@ -224,6 +224,106 @@ class TaskComment {
       };
 }
 
+
+class TaskCommentAttachment {
+  final String id;
+  final String taskId;
+  final String orderId;
+  final String stageId;
+  final String commentId;
+  final String userId;
+  final String fileType;
+  final String fileName;
+  final String storagePath;
+  final String? fileUrl;
+  final String mimeType;
+  final int sizeBytes;
+  final DateTime createdAt;
+
+  const TaskCommentAttachment({
+    required this.id,
+    required this.taskId,
+    required this.orderId,
+    required this.stageId,
+    required this.commentId,
+    required this.userId,
+    required this.fileType,
+    required this.fileName,
+    required this.storagePath,
+    this.fileUrl,
+    required this.mimeType,
+    required this.sizeBytes,
+    required this.createdAt,
+  });
+
+  factory TaskCommentAttachment.fromMap(Map<String, dynamic> map) {
+    int parseSize(dynamic value) {
+      if (value is int) return value;
+      if (value is num) return value.toInt();
+      if (value is String) return int.tryParse(value) ?? 0;
+      return 0;
+    }
+
+    DateTime parseCreatedAt(dynamic value) {
+      if (value is DateTime) return value;
+      if (value is String) {
+        return DateTime.tryParse(value) ?? DateTime.now();
+      }
+      return DateTime.now();
+    }
+
+    return TaskCommentAttachment(
+      id: (map['id'] ?? '').toString(),
+      taskId: (map['task_id'] ?? map['taskId'] ?? '').toString(),
+      orderId: (map['order_id'] ?? map['orderId'] ?? '').toString(),
+      stageId: (map['stage_id'] ?? map['stageId'] ?? '').toString(),
+      commentId: (map['comment_id'] ?? map['commentId'] ?? '').toString(),
+      userId: (map['user_id'] ?? map['userId'] ?? '').toString(),
+      fileType: (map['file_type'] ?? map['fileType'] ?? 'file').toString(),
+      fileName: (map['file_name'] ?? map['fileName'] ?? 'attachment').toString(),
+      storagePath: (map['storage_path'] ?? map['storagePath'] ?? '').toString(),
+      fileUrl: (map['file_url'] ?? map['fileUrl'])?.toString(),
+      mimeType: (map['mime_type'] ?? map['mimeType'] ?? 'application/octet-stream').toString(),
+      sizeBytes: parseSize(map['size_bytes'] ?? map['sizeBytes']),
+      createdAt: parseCreatedAt(map['created_at'] ?? map['createdAt']),
+    );
+  }
+
+  TaskCommentAttachment copyWith({String? fileUrl}) {
+    return TaskCommentAttachment(
+      id: id,
+      taskId: taskId,
+      orderId: orderId,
+      stageId: stageId,
+      commentId: commentId,
+      userId: userId,
+      fileType: fileType,
+      fileName: fileName,
+      storagePath: storagePath,
+      fileUrl: fileUrl ?? this.fileUrl,
+      mimeType: mimeType,
+      sizeBytes: sizeBytes,
+      createdAt: createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'task_id': taskId,
+        'order_id': orderId,
+        'stage_id': stageId,
+        'comment_id': commentId,
+        'user_id': userId,
+        'file_type': fileType,
+        'file_name': fileName,
+        'storage_path': storagePath,
+        'file_url': fileUrl,
+        'mime_type': mimeType,
+        'size_bytes': sizeBytes,
+        'created_at': createdAt.toUtc().toIso8601String(),
+      };
+}
+
 /// Модель задачи, назначенной на рабочее место и конкретный этап заказа.
 ///
 /// Каждая задача содержит ссылку на заказ, идентификатор этапа, список

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -3,6 +3,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'dart:async';
 
 import '../../services/app_auth.dart';
+import '../../services/attachment_service.dart';
 
 import '../orders/order_model.dart';
 import '../orders/order_queue_service.dart';
@@ -193,12 +194,15 @@ class _StageSequenceData {
 
 class TaskProvider with ChangeNotifier {
   final SupabaseClient _supabase = Supabase.instance.client;
+  late final AttachmentService _attachmentService = AttachmentService(supabase: _supabase);
 
   final List<TaskModel> _tasks = [];
   final Map<String, String> _workplaceAliasToId = <String, String>{};
   final Map<String, List<String>> _orderStageSequences = {};
   final Map<String, Map<String, String>> _orderStageNames = {};
   final Map<String, Map<String, String>> _orderStageGroupMaps = {};
+  final Map<String, List<TaskCommentAttachment>> _attachmentsByComment = {};
+  final Set<String> _loadingAttachmentKeys = <String>{};
   final Set<String> _loadedStageSequenceOrderIds = <String>{};
   RealtimeChannel? _tasksChannel;
   final List<RealtimeChannel> _stageSyncChannels = <RealtimeChannel>[];
@@ -208,6 +212,8 @@ class TaskProvider with ChangeNotifier {
   }
 
   List<TaskModel> get tasks => List.unmodifiable(_tasks);
+  List<TaskCommentAttachment> attachmentsForComment(String commentId) =>
+      List.unmodifiable(_attachmentsByComment[commentId] ?? const <TaskCommentAttachment>[]);
   List<String>? stageSequenceForOrder(String orderId) {
     final seq = _orderStageSequences[orderId];
     return seq == null ? null : List.unmodifiable(normalizeStageSequence(seq));
@@ -1337,6 +1343,167 @@ class TaskProvider with ChangeNotifier {
     return message.contains(columnName.toLowerCase()) &&
         (error.code == '42703' || error.code == 'PGRST204');
   }
+
+
+  Future<void> createCommentWithAttachments({
+    required String taskId,
+    required String type,
+    required String text,
+    required String userId,
+    List<AttachmentDraft> attachments = const <AttachmentDraft>[],
+  }) async {
+    final task = _tasks.cast<TaskModel?>().firstWhere(
+          (item) => item?.id == taskId,
+          orElse: () => null,
+        );
+    if (task == null) {
+      await addComment(
+        taskId: taskId,
+        type: type,
+        text: text,
+        userId: userId,
+      );
+      return;
+    }
+
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final commentId = '$timestamp';
+    final uploaded = <TaskCommentAttachment>[];
+    try {
+      for (final draft in attachments) {
+        uploaded.add(await _attachmentService.uploadTaskCommentAttachment(
+          draft: draft,
+          taskId: task.id,
+          orderId: task.orderId,
+          stageId: task.stageId,
+          commentId: commentId,
+          userId: userId,
+        ));
+      }
+      await _insertCommentWithId(
+        taskId: taskId,
+        id: commentId,
+        type: type,
+        text: text,
+        userId: userId,
+        timestamp: timestamp,
+      );
+      if (uploaded.isNotEmpty) {
+        _attachmentsByComment[commentId] = uploaded;
+        notifyListeners();
+      }
+    } catch (e, st) {
+      for (final attachment in uploaded) {
+        await _attachmentService.removeAttachment(attachment);
+      }
+      debugPrint('❌ createCommentWithAttachments error: $e\n$st');
+      rethrow;
+    }
+  }
+
+  Future<void> _insertCommentWithId({
+    required String taskId,
+    required String id,
+    required String type,
+    required String text,
+    required String userId,
+    required int timestamp,
+  }) async {
+    final row = await _supabase
+        .from('tasks')
+        .select('comments')
+        .eq('id', taskId)
+        .single();
+    final comments = _normalizeComments(row['comments']);
+    comments.add({
+      'id': id,
+      'type': type,
+      'text': text,
+      'userId': userId,
+      'timestamp': timestamp,
+    });
+    comments.sort((a, b) =>
+        _parseCommentTimestamp(a['timestamp'])
+            .compareTo(_parseCommentTimestamp(b['timestamp'])));
+    await _supabase.from('tasks').update({'comments': comments}).eq('id', taskId);
+
+    final idx = _tasks.indexWhere((t) => t.id == taskId);
+    if (idx != -1) {
+      final current = _tasks[idx];
+      final updatedComments = List<TaskComment>.from(current.comments)
+        ..add(TaskComment(
+          id: id,
+          type: type,
+          text: text,
+          userId: userId,
+          timestamp: timestamp,
+        ))
+        ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+      _tasks[idx] = current.copyWith(comments: updatedComments);
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadAttachmentsForComments(Iterable<String> commentIds) async {
+    final ids = commentIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    final missing = ids
+        .where((id) => !_attachmentsByComment.containsKey(id))
+        .toList(growable: false);
+    if (missing.isEmpty) return;
+    final key = 'comments:${missing.join(',')}';
+    if (_loadingAttachmentKeys.contains(key)) return;
+    _loadingAttachmentKeys.add(key);
+    try {
+      final loaded = await _attachmentService.loadTaskCommentAttachments(
+        commentIds: missing,
+      );
+      for (final id in missing) {
+        _attachmentsByComment[id] = loaded
+            .where((attachment) => attachment.commentId == id)
+            .toList(growable: false);
+      }
+      notifyListeners();
+    } catch (e, st) {
+      debugPrint('❌ loadAttachmentsForComments error: $e\n$st');
+    } finally {
+      _loadingAttachmentKeys.remove(key);
+    }
+  }
+
+  Future<void> loadAttachmentsForOrder(String orderId, {String? stageId}) async {
+    final key = 'order:$orderId:${stageId ?? ''}';
+    if (_loadingAttachmentKeys.contains(key)) return;
+    _loadingAttachmentKeys.add(key);
+    try {
+      final loaded = await _attachmentService.loadTaskCommentAttachments(
+        orderId: orderId,
+        stageId: stageId,
+      );
+      for (final attachment in loaded) {
+        final list = _attachmentsByComment.putIfAbsent(
+          attachment.commentId,
+          () => <TaskCommentAttachment>[],
+        );
+        final index = list.indexWhere((item) => item.id == attachment.id);
+        if (index == -1) {
+          list.add(attachment);
+        } else {
+          list[index] = attachment;
+        }
+      }
+      notifyListeners();
+    } catch (e, st) {
+      debugPrint('❌ loadAttachmentsForOrder error: $e\n$st');
+    } finally {
+      _loadingAttachmentKeys.remove(key);
+    }
+  }
+
+  Future<void> removeStorageObject(String storagePath) =>
+      _attachmentService.removeStorageObject(storagePath);
 
   Future<void> addComment(
       {required String taskId,

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1,7 +1,16 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math' as math;
+import 'dart:typed_data';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mime/mime.dart';
+import 'package:open_filex/open_filex.dart';
+import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../orders/order_model.dart';
@@ -27,6 +36,7 @@ import 'task_visibility.dart';
 import 'stage_sequence_utils.dart' as stage_sequence;
 import '../common/pdf_view_screen.dart';
 import '../../services/storage_service.dart';
+import '../../services/attachment_service.dart';
 // Additional helpers for time formatting and aggregated timers
 const String kCardboardCuttingStageId =
     stage_sequence.kCardboardCuttingStageId;
@@ -689,6 +699,13 @@ class _TaskSelectionState extends ChangeNotifier {
 
 final Map<String, _TaskSelectionState> _selectionCache = {};
 
+class _CommentDraft {
+  final String text;
+  final List<AttachmentDraft> attachments;
+
+  const _CommentDraft({required this.text, this.attachments = const []});
+}
+
 class _InkUsageDialogResult {
   final List<Map<String, dynamic>> paints;
   final bool openPaperEditor;
@@ -710,6 +727,7 @@ class _TasksScreenState extends State<TasksScreen>
 
   final TextEditingController _chatController = TextEditingController();
   final ScrollController _commentsScrollController = ScrollController();
+  final List<AttachmentDraft> _pendingCommentAttachments = <AttachmentDraft>[];
   late final _TaskSelectionState _selection;
   bool _selectionUpdateScheduled = false;
   String? _lastQueueSyncGroupId;
@@ -3029,12 +3047,234 @@ class _TasksScreenState extends State<TasksScreen>
     );
   }
 
+
+  List<int>? _mimeHeader(Uint8List bytes) {
+    if (bytes.isEmpty) return null;
+    return bytes.length > 16 ? bytes.sublist(0, 16) : bytes;
+  }
+
+  Future<Uint8List> _readPickedFileBytes(PlatformFile file) async {
+    if (file.bytes != null) return file.bytes!;
+    if (file.readStream != null) {
+      final builder = BytesBuilder(copy: false);
+      await for (final chunk in file.readStream!) {
+        builder.add(chunk);
+      }
+      return builder.takeBytes();
+    }
+    final path = file.path;
+    if (path == null) throw Exception('Не удалось прочитать файл');
+    return File(path).readAsBytes();
+  }
+
+  bool get _shouldUseFilePickerForMedia =>
+      kIsWeb ||
+      defaultTargetPlatform == TargetPlatform.windows ||
+      defaultTargetPlatform == TargetPlatform.macOS ||
+      defaultTargetPlatform == TargetPlatform.linux;
+
+  Future<void> _pickCommentAttachment({
+    required String source,
+    required void Function(void Function()) updateDialogState,
+  }) async {
+    try {
+      AttachmentDraft? draft;
+      if (_shouldUseFilePickerForMedia && source != 'file') {
+        await _pickCommentAttachment(
+          source: 'file',
+          updateDialogState: updateDialogState,
+        );
+        return;
+      }
+      if (source == 'camera') {
+        final image = await ImagePicker().pickImage(
+          source: ImageSource.camera,
+          imageQuality: 85,
+        );
+        if (image == null) return;
+        final bytes = await image.readAsBytes();
+        draft = AttachmentDraft(
+          bytes: bytes,
+          fileName: image.name.isNotEmpty ? image.name : p.basename(image.path),
+          mimeType: lookupMimeType(image.path, headerBytes: _mimeHeader(bytes)) ?? 'image/jpeg',
+        );
+      } else if (source == 'photo') {
+        final image = await ImagePicker().pickImage(
+          source: ImageSource.gallery,
+          imageQuality: 85,
+        );
+        if (image == null) return;
+        final bytes = await image.readAsBytes();
+        draft = AttachmentDraft(
+          bytes: bytes,
+          fileName: image.name.isNotEmpty ? image.name : p.basename(image.path),
+          mimeType: lookupMimeType(image.path, headerBytes: _mimeHeader(bytes)) ?? 'image/jpeg',
+        );
+      } else if (source == 'video') {
+        final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
+        if (video == null) return;
+        final bytes = await video.readAsBytes();
+        draft = AttachmentDraft(
+          bytes: bytes,
+          fileName: video.name.isNotEmpty ? video.name : p.basename(video.path),
+          mimeType: lookupMimeType(video.path, headerBytes: _mimeHeader(bytes)) ?? 'video/mp4',
+        );
+      } else {
+        final result = await FilePicker.platform.pickFiles(withReadStream: true);
+        if (result == null || result.files.isEmpty) return;
+        final file = result.files.first;
+        final bytes = await _readPickedFileBytes(file);
+        draft = AttachmentDraft(
+          bytes: bytes,
+          fileName: file.name,
+          mimeType: lookupMimeType(file.path ?? file.name, headerBytes: _mimeHeader(bytes)) ??
+              'application/octet-stream',
+        );
+      }
+      updateDialogState(() => _pendingCommentAttachments.add(draft!));
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Не удалось добавить вложение: $error')),
+      );
+    }
+  }
+
+  Widget _attachmentActionButton({
+    required IconData icon,
+    required String tooltip,
+    required VoidCallback? onPressed,
+    required double scale,
+  }) {
+    return IconButton(
+      visualDensity: VisualDensity.compact,
+      tooltip: tooltip,
+      onPressed: onPressed,
+      icon: Icon(icon, size: scale * 18),
+    );
+  }
+
+  Widget _pendingAttachmentsPreview(
+    double scale, {
+    required void Function(void Function()) updateDialogState,
+  }) {
+    if (_pendingCommentAttachments.isEmpty) return const SizedBox.shrink();
+    return Wrap(
+      spacing: scale * 6,
+      runSpacing: scale * 6,
+      children: [
+        for (var i = 0; i < _pendingCommentAttachments.length; i++)
+          Chip(
+            avatar: Icon(
+              _iconForAttachmentType(_fileTypeFromMime(_pendingCommentAttachments[i].mimeType)),
+              size: scale * 16,
+            ),
+            label: Text(
+              _pendingCommentAttachments[i].fileName,
+              overflow: TextOverflow.ellipsis,
+            ),
+            onDeleted: () => updateDialogState(
+              () => _pendingCommentAttachments.removeAt(i),
+            ),
+          ),
+      ],
+    );
+  }
+
+  String _fileTypeFromMime(String mimeType) {
+    final value = mimeType.toLowerCase();
+    if (value.startsWith('image/')) return 'image';
+    if (value.startsWith('video/')) return 'video';
+    if (value.startsWith('audio/')) return 'audio';
+    return 'file';
+  }
+
+  IconData _iconForAttachmentType(String fileType) {
+    switch (fileType) {
+      case 'image':
+        return Icons.image_outlined;
+      case 'video':
+        return Icons.videocam_outlined;
+      case 'audio':
+        return Icons.audiotrack_outlined;
+      default:
+        return Icons.insert_drive_file_outlined;
+    }
+  }
+
+  Future<void> _openAttachment(TaskCommentAttachment attachment) async {
+    final url = (attachment.fileUrl ?? '').trim();
+    if (url.isEmpty) return;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    if (!kIsWeb && uri.scheme == 'file') {
+      await OpenFilex.open(uri.toFilePath());
+      return;
+    }
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Widget _attachmentTile(TaskCommentAttachment attachment, double scale) {
+    final isImage = attachment.fileType == 'image' &&
+        (attachment.fileUrl ?? '').trim().isNotEmpty;
+    return InkWell(
+      onTap: () => _openAttachment(attachment),
+      child: Container(
+        width: scale * 112,
+        padding: EdgeInsets.all(scale * 6),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF3F4F6),
+          borderRadius: BorderRadius.circular(scale * 10),
+          border: Border.all(color: const Color(0xFFE5E7EB)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isImage)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(scale * 8),
+                child: Image.network(
+                  attachment.fileUrl!,
+                  width: double.infinity,
+                  height: scale * 68,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) => Icon(
+                    _iconForAttachmentType(attachment.fileType),
+                    size: scale * 34,
+                  ),
+                ),
+              )
+            else
+              Icon(
+                _iconForAttachmentType(attachment.fileType),
+                size: scale * 34,
+                color: const Color(0xFF374151),
+              ),
+            SizedBox(height: scale * 4),
+            Text(
+              attachment.fileName,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(fontSize: scale * 10.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildCommentsPanel(TaskModel task, double scale) {
     final isAssignee = task.assignees.contains(widget.employeeId) ||
         task.assignees.isEmpty;
     final personnel = context.watch<PersonnelProvider>();
     final taskProvider = context.watch<TaskProvider>();
     final aggregated = _collectOrderComments(taskProvider, task);
+    Future.microtask(
+      () => taskProvider.loadAttachmentsForComments(
+        aggregated.map((entry) => entry.comment.id),
+      ),
+    );
     _maybeAutoScrollComments(task.id, aggregated);
 
     Widget commentList() {
@@ -3130,6 +3370,24 @@ class _TasksScreenState extends State<TasksScreen>
                               _describeComment(entry.comment),
                               style: TextStyle(fontSize: scale * 12.5),
                             ),
+                            Builder(builder: (_) {
+                              final attachments = taskProvider
+                                  .attachmentsForComment(entry.comment.id);
+                              if (attachments.isEmpty) {
+                                return const SizedBox.shrink();
+                              }
+                              return Padding(
+                                padding: EdgeInsets.only(top: scale * 6),
+                                child: Wrap(
+                                  spacing: scale * 6,
+                                  runSpacing: scale * 6,
+                                  children: [
+                                    for (final attachment in attachments)
+                                      _attachmentTile(attachment, scale),
+                                  ],
+                                ),
+                              );
+                            }),
                           ],
                         );
                       },
@@ -3160,6 +3418,10 @@ class _TasksScreenState extends State<TasksScreen>
             ),
           ),
           SizedBox(height: scale * 6),
+          if (_pendingCommentAttachments.isNotEmpty) ...[
+            _pendingAttachmentsPreview(scale, updateDialogState: setState),
+            SizedBox(height: scale * 6),
+          ],
           Row(
             children: [
               Expanded(
@@ -3193,18 +3455,69 @@ class _TasksScreenState extends State<TasksScreen>
                   ),
                 ),
               ),
-              SizedBox(width: scale * 8),
+              SizedBox(width: scale * 4),
+              _attachmentActionButton(
+                icon: Icons.photo_outlined,
+                tooltip: 'Фото',
+                scale: scale,
+                onPressed: isAssignee
+                    ? () => _pickCommentAttachment(
+                          source: 'photo',
+                          updateDialogState: setState,
+                        )
+                    : null,
+              ),
+              _attachmentActionButton(
+                icon: Icons.videocam_outlined,
+                tooltip: 'Видео',
+                scale: scale,
+                onPressed: isAssignee
+                    ? () => _pickCommentAttachment(
+                          source: 'video',
+                          updateDialogState: setState,
+                        )
+                    : null,
+              ),
+              _attachmentActionButton(
+                icon: Icons.photo_camera_outlined,
+                tooltip: _shouldUseFilePickerForMedia ? 'Файл' : 'Камера',
+                scale: scale,
+                onPressed: isAssignee
+                    ? () => _pickCommentAttachment(
+                          source: 'camera',
+                          updateDialogState: setState,
+                        )
+                    : null,
+              ),
+              _attachmentActionButton(
+                icon: Icons.attach_file,
+                tooltip: 'Файл',
+                scale: scale,
+                onPressed: isAssignee
+                    ? () => _pickCommentAttachment(
+                          source: 'file',
+                          updateDialogState: setState,
+                        )
+                    : null,
+              ),
+              SizedBox(width: scale * 4),
               InkResponse(
                 onTap: isAssignee
                     ? () async {
                         final txt = _chatController.text.trim();
-                        if (txt.isEmpty) return;
-                        await context.read<TaskProvider>().addCommentAutoUser(
-                            taskId: task.id,
-                            type: 'msg',
-                            text: txt,
-                            userIdOverride: widget.employeeId);
+                        final attachments = List<AttachmentDraft>.from(
+                          _pendingCommentAttachments,
+                        );
+                        if (txt.isEmpty && attachments.isEmpty) return;
+                        await context.read<TaskProvider>().createCommentWithAttachments(
+                              taskId: task.id,
+                              type: 'msg',
+                              text: txt.isEmpty ? 'Вложение' : txt,
+                              userId: widget.employeeId,
+                              attachments: attachments,
+                            );
                         _chatController.clear();
+                        setState(() => _pendingCommentAttachments.clear());
                       }
                     : null,
                 child: Container(
@@ -4847,13 +5160,19 @@ class _TasksScreenState extends State<TasksScreen>
                     }
 
                     Future<void> onProblem() async {
-                      final comment = await _askComment('Причина проблемы');
-                      if (comment == null) return;
-                      await context.read<TaskProvider>().addCommentAutoUser(
-                          taskId: task.id,
-                          type: 'problem',
-                          text: comment,
-                          userIdOverride: widget.employeeId);
+                      final problemDraft = await _askCommentDraft(
+                        'Причина проблемы',
+                        allowAttachments: true,
+                      );
+                      if (problemDraft == null) return;
+                      final comment = problemDraft.text;
+                      await context.read<TaskProvider>().createCommentWithAttachments(
+                            taskId: task.id,
+                            type: 'problem',
+                            text: comment,
+                            userId: widget.employeeId,
+                            attachments: problemDraft.attachments,
+                          );
                       await recordTimeEventForUser(TaskTimeType.problem,
                           note: comment);
                       await context
@@ -5772,31 +6091,112 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   Future<String?> _askComment(String title) async {
+    final draft = await _askCommentDraft(title, allowAttachments: false);
+    return draft?.text;
+  }
+
+  Future<_CommentDraft?> _askCommentDraft(
+    String title, {
+    bool allowAttachments = false,
+  }) async {
     final controller = TextEditingController();
-    return showDialog<String?>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(title),
-        content: TextField(
-          controller: controller,
-          decoration: const InputDecoration(hintText: 'Укажите причину'),
-          maxLines: 3,
+    final previousPending = List<AttachmentDraft>.from(_pendingCommentAttachments);
+    _pendingCommentAttachments.clear();
+    try {
+      return showDialog<_CommentDraft?>(
+        context: context,
+        builder: (ctx) => StatefulBuilder(
+          builder: (ctx, setDialogState) => AlertDialog(
+            title: Text(title),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextField(
+                    controller: controller,
+                    decoration: const InputDecoration(hintText: 'Укажите причину'),
+                    maxLines: 3,
+                  ),
+                  if (allowAttachments) ...[
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 4,
+                      children: [
+                        _attachmentActionButton(
+                          icon: Icons.photo_outlined,
+                          tooltip: 'Фото',
+                          scale: 1,
+                          onPressed: () => _pickCommentAttachment(
+                            source: 'photo',
+                            updateDialogState: setDialogState,
+                          ),
+                        ),
+                        _attachmentActionButton(
+                          icon: Icons.videocam_outlined,
+                          tooltip: 'Видео',
+                          scale: 1,
+                          onPressed: () => _pickCommentAttachment(
+                            source: 'video',
+                            updateDialogState: setDialogState,
+                          ),
+                        ),
+                        _attachmentActionButton(
+                          icon: Icons.photo_camera_outlined,
+                          tooltip: _shouldUseFilePickerForMedia ? 'Файл' : 'Камера',
+                          scale: 1,
+                          onPressed: () => _pickCommentAttachment(
+                            source: 'camera',
+                            updateDialogState: setDialogState,
+                          ),
+                        ),
+                        _attachmentActionButton(
+                          icon: Icons.attach_file,
+                          tooltip: 'Файл',
+                          scale: 1,
+                          onPressed: () => _pickCommentAttachment(
+                            source: 'file',
+                            updateDialogState: setDialogState,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    _pendingAttachmentsPreview(1, updateDialogState: setDialogState),
+                  ],
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(null),
+                child: const Text('Отмена'),
+              ),
+              TextButton(
+                onPressed: () {
+                  final text = controller.text.trim();
+                  final attachments = List<AttachmentDraft>.from(_pendingCommentAttachments);
+                  if (text.isEmpty && attachments.isEmpty) {
+                    Navigator.of(ctx).pop(null);
+                    return;
+                  }
+                  Navigator.of(ctx).pop(_CommentDraft(
+                    text: text.isEmpty ? 'Вложение' : text,
+                    attachments: attachments,
+                  ));
+                },
+                child: const Text('Сохранить'),
+              ),
+            ],
+          ),
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(null),
-            child: const Text('Отмена'),
-          ),
-          TextButton(
-            onPressed: () {
-              final text = controller.text.trim();
-              Navigator.of(ctx).pop(text.isEmpty ? null : text);
-            },
-            child: const Text('Сохранить'),
-          ),
-        ],
-      ),
-    );
+      );
+    } finally {
+      _pendingCommentAttachments
+        ..clear()
+        ..addAll(previousPending);
+      controller.dispose();
+    }
   }
 
   bool _hasMachineForStage(WorkplaceModel stage) {
@@ -6117,8 +6517,12 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   Future<void> _handleProblem(TaskModel task, TaskProvider provider) async {
-    final comment = await _askComment('Причина проблемы');
-    if (comment == null) return;
+    final problemDraft = await _askCommentDraft(
+      'Причина проблемы',
+      allowAttachments: true,
+    );
+    if (problemDraft == null) return;
+    final comment = problemDraft.text;
     final seconds = _elapsed(task).inSeconds;
 
     await provider.updateStatus(
@@ -6128,11 +6532,13 @@ class _TasksScreenState extends State<TasksScreen>
       startedAt: null,
     );
 
-    await provider.addCommentAutoUser(
-        taskId: task.id,
-        type: 'problem',
-        text: comment,
-        userIdOverride: widget.employeeId);
+    await provider.createCommentWithAttachments(
+      taskId: task.id,
+      type: 'problem',
+      text: comment,
+      userId: widget.employeeId,
+      attachments: problemDraft.attachments,
+    );
     await provider.recordTimeEvent(
       task: task,
       type: TaskTimeType.problem,

--- a/lib/services/attachment_service.dart
+++ b/lib/services/attachment_service.dart
@@ -1,0 +1,191 @@
+import 'dart:typed_data';
+
+import 'package:mime/mime.dart';
+import 'package:path/path.dart' as p;
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import '../modules/tasks/task_model.dart';
+
+const String kTaskCommentAttachmentsBucket = 'task-comment-attachments';
+const String kTaskCommentAttachmentsTable = 'task_comment_attachments';
+
+class AttachmentDraft {
+  final Uint8List bytes;
+  final String fileName;
+  final String mimeType;
+
+  const AttachmentDraft({
+    required this.bytes,
+    required this.fileName,
+    required this.mimeType,
+  });
+
+  int get sizeBytes => bytes.lengthInBytes;
+}
+
+class AttachmentService {
+  AttachmentService({SupabaseClient? supabase})
+      : _supabase = supabase ?? Supabase.instance.client;
+
+  final SupabaseClient _supabase;
+  final Uuid _uuid = const Uuid();
+
+  String detectFileType(String mimeType, {String? fileName}) {
+    final normalized = mimeType.toLowerCase().trim();
+    if (normalized.startsWith('image/')) return 'image';
+    if (normalized.startsWith('video/')) return 'video';
+    if (normalized.startsWith('audio/')) return 'audio';
+    final ext = p.extension(fileName ?? '').toLowerCase();
+    if (ext == '.jpg' || ext == '.jpeg' || ext == '.png' || ext == '.webp') {
+      return 'image';
+    }
+    if (ext == '.mp4' || ext == '.mov' || ext == '.webm') return 'video';
+    return 'file';
+  }
+
+  String detectMimeType(String fileName, {List<int>? headerBytes}) {
+    return lookupMimeType(fileName, headerBytes: headerBytes) ??
+        'application/octet-stream';
+  }
+
+  Future<TaskCommentAttachment> uploadTaskCommentAttachment({
+    required AttachmentDraft draft,
+    required String taskId,
+    required String orderId,
+    required String stageId,
+    required String commentId,
+    required String userId,
+    Duration signedUrlTtl = const Duration(hours: 12),
+  }) async {
+    final attachmentId = _uuid.v4();
+    final safeName = _sanitizeFileName(draft.fileName);
+    final ext = p.extension(safeName);
+    final storagePath = [
+      orderId,
+      taskId,
+      commentId,
+      ext.isEmpty ? attachmentId : '$attachmentId$ext',
+    ].join('/');
+
+    final storage = _supabase.storage.from(kTaskCommentAttachmentsBucket);
+    await storage.uploadBinary(
+      storagePath,
+      draft.bytes,
+      fileOptions: FileOptions(contentType: draft.mimeType, upsert: false),
+    );
+
+    try {
+      final now = DateTime.now().toUtc();
+      final row = await _supabase
+          .from(kTaskCommentAttachmentsTable)
+          .insert({
+            'id': attachmentId,
+            'task_id': taskId,
+            'order_id': orderId,
+            'stage_id': stageId,
+            'comment_id': commentId,
+            'user_id': userId,
+            'file_type': detectFileType(draft.mimeType, fileName: safeName),
+            'file_name': safeName,
+            'storage_path': storagePath,
+            'file_url': null,
+            'mime_type': draft.mimeType,
+            'size_bytes': draft.sizeBytes,
+            'created_at': now.toIso8601String(),
+          })
+          .select()
+          .single();
+      return _withSignedUrl(
+        TaskCommentAttachment.fromMap(Map<String, dynamic>.from(row)),
+        signedUrlTtl,
+      );
+    } catch (_) {
+      await removeStorageObject(storagePath);
+      rethrow;
+    }
+  }
+
+  Future<List<TaskCommentAttachment>> loadTaskCommentAttachments({
+    String? taskId,
+    String? orderId,
+    String? stageId,
+    Iterable<String>? commentIds,
+    Duration signedUrlTtl = const Duration(hours: 12),
+  }) async {
+    dynamic query = _supabase.from(kTaskCommentAttachmentsTable).select();
+    if (taskId != null && taskId.trim().isNotEmpty) {
+      query = query.eq('task_id', taskId.trim());
+    }
+    if (orderId != null && orderId.trim().isNotEmpty) {
+      query = query.eq('order_id', orderId.trim());
+    }
+    if (stageId != null && stageId.trim().isNotEmpty) {
+      query = query.eq('stage_id', stageId.trim());
+    }
+    final ids = (commentIds ?? const <String>[])
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toList(growable: false);
+    if (ids.isNotEmpty) {
+      query = query.inFilter('comment_id', ids);
+    }
+    final rows = await query.order('created_at');
+    final attachments = <TaskCommentAttachment>[];
+    if (rows is List) {
+      for (final raw in rows) {
+        final map = Map<String, dynamic>.from(raw as Map);
+        attachments.add(await _withSignedUrl(
+          TaskCommentAttachment.fromMap(map),
+          signedUrlTtl,
+        ));
+      }
+    }
+    return attachments;
+  }
+
+  Future<String> getUrl(
+    TaskCommentAttachment attachment, {
+    Duration signedUrlTtl = const Duration(hours: 12),
+  }) async {
+    if ((attachment.fileUrl ?? '').trim().isNotEmpty) {
+      return attachment.fileUrl!.trim();
+    }
+    return _supabase.storage
+        .from(kTaskCommentAttachmentsBucket)
+        .createSignedUrl(attachment.storagePath, signedUrlTtl.inSeconds);
+  }
+
+  Future<void> removeAttachment(TaskCommentAttachment attachment) async {
+    await removeStorageObject(attachment.storagePath);
+    await _supabase
+        .from(kTaskCommentAttachmentsTable)
+        .delete()
+        .eq('id', attachment.id);
+  }
+
+  Future<void> removeStorageObject(String storagePath) async {
+    try {
+      await _supabase
+          .storage
+          .from(kTaskCommentAttachmentsBucket)
+          .remove([storagePath]);
+    } catch (_) {
+      // Best-effort rollback cleanup. The original DB/storage error is more important.
+    }
+  }
+
+  Future<TaskCommentAttachment> _withSignedUrl(
+    TaskCommentAttachment attachment,
+    Duration signedUrlTtl,
+  ) async {
+    final url = await getUrl(attachment, signedUrlTtl: signedUrlTtl);
+    return attachment.copyWith(fileUrl: url);
+  }
+
+  String _sanitizeFileName(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return 'attachment';
+    return trimmed.replaceAll(RegExp(r'[\\/]+'), '_');
+  }
+}

--- a/supabase/migrations/20260514_create_task_comment_attachments.sql
+++ b/supabase/migrations/20260514_create_task_comment_attachments.sql
@@ -1,0 +1,166 @@
+-- Вложения к комментариям задач и приватный Storage bucket.
+
+create table if not exists public.task_comment_attachments (
+  id uuid primary key default gen_random_uuid(),
+  task_id text not null,
+  order_id text not null,
+  stage_id text not null,
+  comment_id text not null,
+  user_id text,
+  file_type text not null default 'file'
+    check (file_type in ('image', 'video', 'audio', 'file')),
+  file_name text not null,
+  storage_path text not null unique,
+  file_url text,
+  mime_type text not null default 'application/octet-stream',
+  size_bytes bigint not null default 0 check (size_bytes >= 0),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists task_comment_attachments_task_id_idx
+  on public.task_comment_attachments(task_id);
+
+create index if not exists task_comment_attachments_order_id_idx
+  on public.task_comment_attachments(order_id);
+
+create index if not exists task_comment_attachments_comment_id_idx
+  on public.task_comment_attachments(comment_id);
+
+create index if not exists task_comment_attachments_order_stage_idx
+  on public.task_comment_attachments(order_id, stage_id);
+
+alter table public.task_comment_attachments enable row level security;
+alter table public.task_comment_attachments replica identity full;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'task_comment_attachments'
+      and policyname = 'task_comment_attachments_select'
+  ) then
+    create policy task_comment_attachments_select
+      on public.task_comment_attachments
+      for select
+      to authenticated, anon
+      using (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'task_comment_attachments'
+      and policyname = 'task_comment_attachments_insert'
+  ) then
+    create policy task_comment_attachments_insert
+      on public.task_comment_attachments
+      for insert
+      to authenticated, anon
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'task_comment_attachments'
+      and policyname = 'task_comment_attachments_update'
+  ) then
+    create policy task_comment_attachments_update
+      on public.task_comment_attachments
+      for update
+      to authenticated, anon
+      using (true)
+      with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'task_comment_attachments'
+      and policyname = 'task_comment_attachments_delete'
+  ) then
+    create policy task_comment_attachments_delete
+      on public.task_comment_attachments
+      for delete
+      to authenticated, anon
+      using (true);
+  end if;
+end $$;
+
+insert into storage.buckets (id, name, public)
+values ('task-comment-attachments', 'task-comment-attachments', false)
+on conflict (id) do update
+set name = excluded.name,
+    public = excluded.public;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'task_comment_attachments_storage_select'
+  ) then
+    create policy task_comment_attachments_storage_select
+      on storage.objects
+      for select
+      to authenticated, anon
+      using (bucket_id = 'task-comment-attachments');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'task_comment_attachments_storage_insert'
+  ) then
+    create policy task_comment_attachments_storage_insert
+      on storage.objects
+      for insert
+      to authenticated, anon
+      with check (bucket_id = 'task-comment-attachments');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'task_comment_attachments_storage_update'
+  ) then
+    create policy task_comment_attachments_storage_update
+      on storage.objects
+      for update
+      to authenticated, anon
+      using (bucket_id = 'task-comment-attachments')
+      with check (bucket_id = 'task-comment-attachments');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'task_comment_attachments_storage_delete'
+  ) then
+    create policy task_comment_attachments_storage_delete
+      on storage.objects
+      for delete
+      to authenticated, anon
+      using (bucket_id = 'task-comment-attachments');
+  end if;
+end $$;
+
+do $$
+begin
+  if exists (
+    select 1 from pg_publication
+    where pubname = 'supabase_realtime'
+  ) and not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'task_comment_attachments'
+  ) then
+    alter publication supabase_realtime add table public.task_comment_attachments;
+  end if;
+end $$;


### PR DESCRIPTION
### Motivation
- Добавить поддержку вложений к комментариям задач (фото/видео/файлы) с хранением объектов в Supabase Storage и metadata в базе для удобного отображения и безопасного доступа. 
- Убрать дублирование логики загрузки (есть похожая реализация в чате) и обеспечить атомарность: загрузка файлов в Storage + запись metadata в БД с rollback при ошибке.

### Description
- Добавлена миграция `supabase/migrations/20260514_create_task_comment_attachments.sql` которая создаёт таблицу `task_comment_attachments` с полями `id, task_id, order_id, stage_id, comment_id, user_id, file_type, file_name, storage_path, file_url, mime_type, size_bytes, created_at`, индексы по `task_id`, `order_id`, `comment_id`, RLS-политики и приватный bucket `task-comment-attachments` с политиками для `storage.objects`.
- Новый сервис `lib/services/attachment_service.dart` реализует загрузку бинарных данных в Storage (`uploadTaskCommentAttachment`), запись metadata в таблицу, получение signed URL (`getUrl`), определение типа/мimetype, и удаление объектов при rollback (`removeStorageObject` / `removeAttachment`).
- Модель `TaskCommentAttachment` добавлена в `lib/modules/tasks/task_model.dart` с парсингом/сериализацией и `copyWith`.
- Провайдер задач `lib/modules/tasks/task_provider.dart` расширен: подключён `AttachmentService`, добавлено кеширование вложений по комментариям, методы `createCommentWithAttachments`, `_insertCommentWithId`, `loadAttachmentsForComments`, `loadAttachmentsForOrder` и `removeStorageObject` для безопасной последовательности загрузки файлов и создания комментария.
- UI: `lib/modules/tasks/tasks_screen.dart` обновлён — в панели комментариев добавлены кнопки фото/видео/камера/файл (с desktop/web fallback на FilePicker), предпросмотр отложенных вложений перед отправкой, отправка комментария вместе с вложениями, отображение плиток миниатюр/иконок вложений под каждым комментарием и открытие/скачивание вложений через `url_launcher`/`open_filex`; та же логика включена в диалог «Проблема» (позволяет прикреплять фото/видео/файлы).
- Изменения охватывают основные файлы: `lib/services/attachment_service.dart`, `lib/modules/tasks/task_model.dart`, `lib/modules/tasks/task_provider.dart`, `lib/modules/tasks/tasks_screen.dart`, и новую миграцию в `supabase/migrations`.

### Testing
- Запущена проверка изменений `git diff --check`, она прошла без конфликтов/ошибок.
- Форматирование/статический анализ (`dart format` / `flutter analyze`) не были выполнены в CI-контейнере, так как `dart`/`flutter` не установлены в окружении (`command not found`).
- Локальных unit/widget тестов на изменённый код не запускал(а) из-за отсутствия Flutter SDK в контейнере; рекомендую запустить `dart format` и `flutter analyze` и прогнать тесты приложения в вашей CI перед развёртыванием миграции и обновлением production Supabase instance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06165f63a0832fac7c774a7410650e)