### PR TITLE
Add paint reservation workflow (DB, RPCs, UI)

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -2423,14 +2423,27 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       if (rows.isNotEmpty) {
         await _sb.from('order_paints').insert(rows);
       }
+      await OrdersRepository().syncPaintReservations(
+        orderId: orderId,
+        paints: rows,
+        actor: AuthHelper.currentUserName ?? '',
+      );
       // Сохраняем актуальные product.parameters даже когда красок нет:
       // в этом случае "Информация для красок" должна оставаться в заказе.
       await _sb.from('orders').update({
         'product': _product.toMap(),
       }).eq('id', orderId);
     } catch (e) {
-      // не блокируем сохранение заказа, просто сообщим в консоль
+      final message = e is PostgrestException && e.message.trim().isNotEmpty
+          ? e.message.trim()
+          : e.toString();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+      }
       debugPrint('❌ persist paints error: ' + e.toString());
+      rethrow;
     }
   }
 

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -8,6 +8,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'material_model.dart';
 import 'order_model.dart';
 import 'order_queue_service.dart';
+import 'orders_repository.dart';
 import 'product_model.dart';
 import '../../utils/auth_helper.dart';
 
@@ -874,6 +875,7 @@ class OrdersProvider with ChangeNotifier {
       await _cleanupProductionQueueState(relatedOrderIds);
       // Бизнес-правило: удаление заказа освобождает весь резерв бумаги.
       await _releasePaperReservations(orderId: id);
+      await _releasePaintReservations(orderId: id);
       await _supabase.from('order_paints').delete().eq('order_id', id);
       try {
         final plan = await _supabase
@@ -1532,6 +1534,23 @@ class OrdersProvider with ChangeNotifier {
     final after = await _loadOrderReservationMap(order.id);
     await _logReservationDiff(orderId: order.id, before: before, after: after);
     return null;
+  }
+
+  Future<void> _releasePaintReservations({required String orderId}) async {
+    try {
+      await OrdersRepository(supabaseClient: _supabase).releasePaintReservations(
+        orderId: orderId,
+        reason: 'order_deleted',
+        actor: AuthHelper.currentUserName ?? '',
+      );
+    } catch (_) {
+      try {
+        await _supabase
+            .from('order_paint_reservations')
+            .delete()
+            .eq('order_id', orderId);
+      } catch (_) {}
+    }
   }
 
   Future<void> _releasePaperReservations({required String orderId}) async {

--- a/lib/modules/orders/orders_repository.dart
+++ b/lib/modules/orders/orders_repository.dart
@@ -193,6 +193,12 @@ class OrdersRepository {
     }
     if (list.isNotEmpty) {
       await addPaints(orderId, list);
+      await syncPaintReservations(
+        orderId: orderId,
+        paints: list
+            .map((paint) => paint.toRow(orderId))
+            .toList(growable: false),
+      );
     }
 
     if (pdf != null) {
@@ -230,6 +236,114 @@ class OrdersRepository {
     final res = await _sb.from('order_paints').insert(rows).select('id');
     if (res is List) return res.length;
     return 0;
+  }
+
+  Future<void> syncPaintReservations({
+    required String orderId,
+    required List<Map<String, dynamic>> paints,
+    String? actor,
+  }) async {
+    await ensureSignedIn();
+    final rows = paints
+        .map((row) {
+          final qtyKg = (row['qty_kg'] is num)
+              ? (row['qty_kg'] as num).toDouble()
+              : double.tryParse(
+                  (row['qty_kg'] ?? '').toString().replaceAll(',', '.'),
+                );
+          final name =
+              (row['paint_name'] ?? row['name'] ?? '').toString().trim();
+          final paintId = (row['paint_id'] ?? row['material_id'] ?? '')
+              .toString()
+              .trim();
+          return <String, dynamic>{
+            if (paintId.isNotEmpty) 'paint_id': paintId,
+            if (name.isNotEmpty) 'paint_name': name,
+            'reserved_qty': (qtyKg ?? 0) * 1000,
+          };
+        })
+        .where((row) =>
+            (((row['paint_id'] ?? '') as String).isNotEmpty ||
+                ((row['paint_name'] ?? '') as String).isNotEmpty) &&
+            ((row['reserved_qty'] as num?)?.toDouble() ?? 0) > 0)
+        .toList(growable: false);
+
+    await _sb.rpc('sync_order_paint_reservations', params: {
+      'p_order_id': orderId,
+      'p_reservations': rows,
+      'p_actor': actor ?? '',
+    });
+  }
+
+  Future<void> releasePaintReservations({
+    required String orderId,
+    String reason = 'order_deleted',
+    String? actor,
+  }) async {
+    await ensureSignedIn();
+    await _sb.rpc('release_order_paint_reservations', params: {
+      'p_order_id': orderId,
+      'p_reason': reason,
+      'p_actor': actor ?? '',
+    });
+  }
+
+  Future<List<Map<String, dynamic>>> getPaintReservations(String orderId) async {
+    final rows = await _sb
+        .from('order_paint_reservations')
+        .select('paint_id, paint_name, reserved_qty, used_qty, released_qty')
+        .eq('order_id', orderId);
+    if (rows is List) {
+      return rows.cast<Map<String, dynamic>>();
+    }
+    return const [];
+  }
+
+  Future<void> completeFlexPrintingStage({
+    required String taskId,
+    required String orderId,
+    required String stageId,
+    required String employeeId,
+    required List<Map<String, dynamic>> paintUsages,
+    String? quantityDone,
+    String? comment,
+    String? actor,
+  }) async {
+    await ensureSignedIn();
+    final usages = paintUsages
+        .map((row) {
+          final qtyKg = (row['qty_kg'] is num)
+              ? (row['qty_kg'] as num).toDouble()
+              : double.tryParse(
+                  (row['qty_kg'] ?? '').toString().replaceAll(',', '.'),
+                );
+          final name =
+              (row['paint_name'] ?? row['name'] ?? '').toString().trim();
+          final paintId = (row['paint_id'] ?? row['material_id'] ?? '')
+              .toString()
+              .trim();
+          return <String, dynamic>{
+            if (paintId.isNotEmpty) 'paint_id': paintId,
+            if (name.isNotEmpty) 'paint_name': name,
+            'used_qty': (qtyKg ?? 0) * 1000,
+          };
+        })
+        .where((row) =>
+            (((row['paint_id'] ?? '') as String).isNotEmpty ||
+                ((row['paint_name'] ?? '') as String).isNotEmpty) &&
+            ((row['used_qty'] as num?)?.toDouble() ?? 0) >= 0)
+        .toList(growable: false);
+
+    await _sb.rpc('complete_flex_printing_stage', params: {
+      'p_task_id': taskId,
+      'p_order_id': orderId,
+      'p_stage_id': stageId,
+      'p_employee_id': employeeId,
+      'p_paint_usages': usages,
+      'p_quantity_done': quantityDone,
+      'p_comment': comment,
+      'p_actor': actor ?? '',
+    });
   }
 
   Future<List<Map<String, dynamic>>> getPaints(String orderId) async {

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -5,6 +5,7 @@ import 'package:uuid/uuid.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../services/storage_service.dart';
+import '../../utils/auth_helper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'dart:typed_data';
 import 'orders_provider.dart';
@@ -1236,6 +1237,11 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
       if (rows.isNotEmpty) {
         await _sb.from('order_paints').insert(rows);
       }
+      await OrdersRepository().syncPaintReservations(
+        orderId: orderId,
+        paints: rows,
+        actor: AuthHelper.currentUserName ?? '',
+      );
     } catch (e) {
       // не блокируем сохранение заказа, просто сообщим в консоль
       debugPrint('❌ persist paints error: ' + e.toString());

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4054,6 +4054,12 @@ class _TasksScreenState extends State<TasksScreen>
                                   .toString();
                           final orderedQty =
                               (row['qty_kg'] as num?)?.toDouble() ?? 0;
+                          final reservedQty =
+                              (row['reserved_qty'] as num?)?.toDouble() ?? 0;
+                          final usedQty =
+                              (row['used_qty'] as num?)?.toDouble() ?? 0;
+                          final releasedQty =
+                              (row['released_qty'] as num?)?.toDouble() ?? 0;
                           return Padding(
                             padding: const EdgeInsets.only(bottom: 8),
                             child: Row(
@@ -4062,7 +4068,9 @@ class _TasksScreenState extends State<TasksScreen>
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    'По заказу: ${(orderedQty * 1000).toStringAsFixed(0)} г',
+                                    'По заказу: ${(orderedQty * 1000).toStringAsFixed(0)} г\n'
+                                    'Резерв: ${reservedQty.toStringAsFixed(0)} г'
+                                    '${usedQty > 0 || releasedQty > 0 ? '\nИсп.: ${usedQty.toStringAsFixed(0)} г, освоб.: ${releasedQty.toStringAsFixed(0)} г' : ''}',
                                     textAlign: TextAlign.end,
                                   ),
                                 ),
@@ -4139,6 +4147,20 @@ class _TasksScreenState extends State<TasksScreen>
       return result;
     }
     return null;
+  }
+
+  String _humanizeRpcError(Object error) {
+    if (error is PostgrestException) {
+      final message = error.message.trim();
+      if (message.isNotEmpty) return message;
+      final details = (error.details ?? '').toString().trim();
+      if (details.isNotEmpty) return details;
+    }
+    final raw = error.toString();
+    final marker = RegExp(r'Недостаточно краски: [^\n}]+');
+    final match = marker.firstMatch(raw);
+    if (match != null) return match.group(0)!;
+    return raw;
   }
 
   Future<void> _validateInkAvailability(List<Map<String, dynamic>> paints) async {
@@ -4285,7 +4307,44 @@ class _TasksScreenState extends State<TasksScreen>
     if (_isInkConfirmationStage(task)) {
       List<Map<String, dynamic>> initialPaints = const <Map<String, dynamic>>[];
       try {
-        initialPaints = await OrdersRepository().getPaints(task.orderId);
+        final repo = OrdersRepository();
+        initialPaints = await repo.getPaints(task.orderId);
+        final reservations = await repo.getPaintReservations(task.orderId);
+        final reservationsByKey = <String, Map<String, dynamic>>{};
+        for (final reservation in reservations) {
+          final id = (reservation['paint_id'] ?? '').toString().trim();
+          final name = (reservation['paint_name'] ?? '')
+              .toString()
+              .trim()
+              .toLowerCase();
+          if (id.isNotEmpty) reservationsByKey['id:$id'] = reservation;
+          if (name.isNotEmpty) reservationsByKey['name:$name'] = reservation;
+        }
+        initialPaints = initialPaints.map((paint) {
+          final merged = Map<String, dynamic>.from(paint);
+          final id = (merged['paint_id'] ?? merged['material_id'] ?? '')
+              .toString()
+              .trim();
+          final name = (merged['paint_name'] ?? merged['name'] ?? '')
+              .toString()
+              .trim()
+              .toLowerCase();
+          final reservation =
+              (id.isNotEmpty ? reservationsByKey['id:$id'] : null) ??
+                  (name.isNotEmpty ? reservationsByKey['name:$name'] : null);
+          if (reservation != null) {
+            merged.addAll({
+              'paint_id': reservation['paint_id'],
+              'paint_name': reservation['paint_name'] ??
+                  merged['paint_name'] ??
+                  merged['name'],
+              'reserved_qty': reservation['reserved_qty'],
+              'used_qty': reservation['used_qty'],
+              'released_qty': reservation['released_qty'],
+            });
+          }
+          return merged;
+        }).toList(growable: false);
       } catch (e) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -4318,7 +4377,6 @@ class _TasksScreenState extends State<TasksScreen>
           continue;
         }
         mutablePaints = dialogResult.paints;
-        await _validateInkAvailability(mutablePaints);
         paints = mutablePaints;
         break;
       }
@@ -4357,6 +4415,37 @@ class _TasksScreenState extends State<TasksScreen>
     }
 
     final tp = context.read<TaskProvider>();
+    if (_isInkConfirmationStage(task)) {
+      final note = mounted ? await _askFinishNote() : null;
+      try {
+        await OrdersRepository().completeFlexPrintingStage(
+          taskId: task.id,
+          orderId: task.orderId,
+          stageId: task.stageId,
+          employeeId: widget.employeeId,
+          paintUsages: paints,
+          quantityDone: qtyInput?.displayText,
+          comment: note,
+        );
+        await tp.refresh();
+        if (mounted) {
+          setState(() {
+            _orderPaintsCache[task.orderId] = paints
+                .map((row) => Map<String, dynamic>.from(row))
+                .toList(growable: false);
+          });
+        }
+      } catch (e) {
+        if (mounted) {
+          final message = _humanizeRpcError(e);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(message)),
+          );
+        }
+      }
+      return;
+    }
+
     final wroteOff = await _writeoffInks(task, paints);
     if (!wroteOff) return;
 

--- a/supabase/migrations/20260514_add_order_paint_reservations.sql
+++ b/supabase/migrations/20260514_add_order_paint_reservations.sql
@@ -1,0 +1,488 @@
+-- Атомарные резервы и списание красок для заказов/флексопечати.
+
+alter table if exists public.paints
+  add column if not exists reserved_qty double precision not null default 0;
+
+create table if not exists public.order_paint_reservations (
+  id uuid primary key default gen_random_uuid(),
+  order_id text not null references public.orders(id) on delete cascade,
+  paint_id text references public.paints(id),
+  paint_name text,
+  reserved_qty double precision not null default 0,
+  used_qty double precision not null default 0,
+  released_qty double precision not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint order_paint_reservations_qty_nonnegative check (
+    reserved_qty >= 0 and used_qty >= 0 and released_qty >= 0
+  ),
+  constraint order_paint_reservations_has_paint check (
+    paint_id is not null or coalesce(trim(paint_name), '') <> ''
+  )
+);
+
+create unique index if not exists order_paint_reservations_order_paint_idx
+  on public.order_paint_reservations(order_id, paint_id)
+  where paint_id is not null;
+
+create unique index if not exists order_paint_reservations_order_paint_name_idx
+  on public.order_paint_reservations(order_id, lower(trim(paint_name)))
+  where paint_id is null and coalesce(trim(paint_name), '') <> '';
+
+create index if not exists order_paint_reservations_paint_idx
+  on public.order_paint_reservations(paint_id);
+
+create index if not exists order_paint_reservations_order_idx
+  on public.order_paint_reservations(order_id);
+
+alter table public.order_paint_reservations enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public' and tablename='order_paint_reservations' and policyname='order_paint_reservations_select'
+  ) then
+    create policy order_paint_reservations_select on public.order_paint_reservations
+      for select to authenticated, anon using (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public' and tablename='order_paint_reservations' and policyname='order_paint_reservations_write'
+  ) then
+    create policy order_paint_reservations_write on public.order_paint_reservations
+      for all to authenticated using (true) with check (true);
+  end if;
+end $$;
+
+create or replace function public.recalculate_paint_reserved_qty(p_paint_ids text[] default null)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_paint_ids is null then
+    update paints p
+       set reserved_qty = coalesce((
+             select sum(greatest(r.reserved_qty - r.used_qty - r.released_qty, 0))
+               from order_paint_reservations r
+              where r.paint_id = p.id
+           ), 0);
+  else
+    update paints p
+       set reserved_qty = coalesce((
+             select sum(greatest(r.reserved_qty - r.used_qty - r.released_qty, 0))
+               from order_paint_reservations r
+              where r.paint_id = p.id
+           ), 0)
+     where p.id = any(p_paint_ids);
+  end if;
+end;
+$$;
+
+create or replace function public.sync_order_paint_reservations(
+  p_order_id text,
+  p_reservations jsonb default '[]'::jsonb,
+  p_actor text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  rec record;
+  v_available double precision;
+  v_reserved_other double precision;
+  v_paint_name text;
+  v_touched text[] := array[]::text[];
+begin
+  if coalesce(trim(p_order_id), '') = '' then
+    raise exception 'order_id is required';
+  end if;
+
+  if p_reservations is null then
+    p_reservations := '[]'::jsonb;
+  end if;
+
+  for rec in
+    with requested as (
+      select
+        nullif(trim(coalesce(value->>'paint_id', value->>'material_id')), '') as paint_id,
+        nullif(trim(coalesce(value->>'paint_name', value->>'name')), '') as paint_name,
+        coalesce(
+          nullif(value->>'reserved_qty', '')::double precision,
+          nullif(value->>'qty', '')::double precision,
+          nullif(value->>'qty_g', '')::double precision,
+          nullif(value->>'qty_grams', '')::double precision,
+          nullif(value->>'qty_kg', '')::double precision * 1000,
+          0
+        ) as qty
+      from jsonb_array_elements(p_reservations)
+    ), resolved as (
+      select
+        coalesce(req.paint_id, p_by_name.id) as paint_id,
+        coalesce(req.paint_name, p_by_name.description) as paint_name,
+        req.qty
+      from requested req
+      left join lateral (
+        select p.id, p.description
+          from paints p
+         where req.paint_id is null
+           and req.paint_name is not null
+           and lower(trim(p.description)) = lower(trim(req.paint_name))
+         order by p.id
+         limit 1
+      ) p_by_name on true
+      where req.paint_id is not null or req.paint_name is not null
+    ), aggregated as (
+      select paint_id, max(paint_name) as paint_name, sum(qty) as qty
+      from resolved
+      group by paint_id
+    )
+    select a.paint_id, a.paint_name, a.qty, p.quantity as total_qty, p.description as stock_name
+    from aggregated a
+    left join paints p on p.id = a.paint_id
+    order by a.paint_id nulls last, a.paint_name
+    for update of p
+  loop
+    if rec.qty < 0 then
+      raise exception 'Нельзя зарезервировать отрицательное количество краски (%).', coalesce(rec.stock_name, rec.paint_name, rec.paint_id);
+    end if;
+
+    if rec.paint_id is null or rec.total_qty is null then
+      raise exception 'Краска % не найдена на складе.', coalesce(rec.paint_name, rec.paint_id);
+    end if;
+
+    select coalesce(sum(greatest(r.reserved_qty - r.used_qty - r.released_qty, 0)), 0)
+      into v_reserved_other
+      from order_paint_reservations r
+     where r.paint_id = rec.paint_id
+       and r.order_id <> p_order_id;
+
+    v_available := rec.total_qty - v_reserved_other;
+    if v_available < rec.qty then
+      v_paint_name := coalesce(rec.stock_name, rec.paint_name, rec.paint_id);
+      raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
+        v_paint_name, round(v_available::numeric, 2), round(rec.qty::numeric, 2);
+    end if;
+
+    v_touched := array_append(v_touched, rec.paint_id);
+  end loop;
+
+  v_touched := v_touched || array(
+    select distinct paint_id
+      from order_paint_reservations
+     where order_id = p_order_id and paint_id is not null
+  );
+
+  for rec in
+    with requested as (
+      select
+        nullif(trim(coalesce(value->>'paint_id', value->>'material_id')), '') as paint_id,
+        nullif(trim(coalesce(value->>'paint_name', value->>'name')), '') as paint_name,
+        coalesce(
+          nullif(value->>'reserved_qty', '')::double precision,
+          nullif(value->>'qty', '')::double precision,
+          nullif(value->>'qty_g', '')::double precision,
+          nullif(value->>'qty_grams', '')::double precision,
+          nullif(value->>'qty_kg', '')::double precision * 1000,
+          0
+        ) as qty
+      from jsonb_array_elements(p_reservations)
+    ), resolved as (
+      select coalesce(req.paint_id, p_by_name.id) as paint_id,
+             coalesce(req.paint_name, p_by_name.description) as paint_name,
+             req.qty
+      from requested req
+      left join lateral (
+        select p.id, p.description
+          from paints p
+         where req.paint_id is null
+           and req.paint_name is not null
+           and lower(trim(p.description)) = lower(trim(req.paint_name))
+         order by p.id
+         limit 1
+      ) p_by_name on true
+      where req.paint_id is not null or req.paint_name is not null
+    )
+    select paint_id, max(paint_name) as paint_name, sum(qty) as qty
+    from resolved
+    where paint_id is not null
+    group by paint_id
+  loop
+    if rec.qty <= 0 then
+      delete from order_paint_reservations
+       where order_id = p_order_id and paint_id = rec.paint_id;
+    else
+      insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
+      values (p_order_id, rec.paint_id, rec.paint_name, rec.qty, 0, 0)
+      on conflict (order_id, paint_id) where paint_id is not null
+      do update
+      set paint_name = coalesce(excluded.paint_name, order_paint_reservations.paint_name),
+          reserved_qty = excluded.reserved_qty,
+          used_qty = 0,
+          released_qty = 0,
+          updated_at = now();
+    end if;
+  end loop;
+
+  delete from order_paint_reservations r
+   where r.order_id = p_order_id
+     and not exists (
+       with requested as (
+         select nullif(trim(coalesce(value->>'paint_id', value->>'material_id')), '') as paint_id,
+                nullif(trim(coalesce(value->>'paint_name', value->>'name')), '') as paint_name,
+                coalesce(
+                  nullif(value->>'reserved_qty', '')::double precision,
+                  nullif(value->>'qty', '')::double precision,
+                  nullif(value->>'qty_g', '')::double precision,
+                  nullif(value->>'qty_grams', '')::double precision,
+                  nullif(value->>'qty_kg', '')::double precision * 1000,
+                  0
+                ) as qty
+         from jsonb_array_elements(p_reservations)
+       )
+       select 1
+       from requested req
+       left join lateral (
+         select p.id
+           from paints p
+          where req.paint_id is null
+            and req.paint_name is not null
+            and lower(trim(p.description)) = lower(trim(req.paint_name))
+          order by p.id
+          limit 1
+       ) p_by_name on true
+       where coalesce(req.paint_id, p_by_name.id) = r.paint_id
+         and req.qty > 0
+     );
+
+  perform recalculate_paint_reserved_qty((select array_agg(distinct x) from unnest(v_touched) as x where x is not null));
+end;
+$$;
+
+grant execute on function public.sync_order_paint_reservations(text, jsonb, text)
+to authenticated, anon;
+
+create or replace function public.release_order_paint_reservations(
+  p_order_id text,
+  p_reason text default null,
+  p_actor text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_touched text[];
+begin
+  if coalesce(trim(p_order_id), '') = '' then
+    raise exception 'order_id is required';
+  end if;
+
+  select array_agg(distinct paint_id) into v_touched
+    from order_paint_reservations
+   where order_id = p_order_id and paint_id is not null;
+
+  update order_paint_reservations
+     set released_qty = greatest(reserved_qty - used_qty, 0),
+         updated_at = now()
+   where order_id = p_order_id;
+
+  perform recalculate_paint_reserved_qty(v_touched);
+end;
+$$;
+
+grant execute on function public.release_order_paint_reservations(text, text, text)
+to authenticated, anon;
+
+create or replace function public.complete_flex_printing_stage(
+  p_task_id text,
+  p_order_id text,
+  p_stage_id text,
+  p_employee_id text,
+  p_paint_usages jsonb default '[]'::jsonb,
+  p_quantity_done text default null,
+  p_comment text default null,
+  p_actor text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  rec record;
+  rel record;
+  v_reserved_other double precision;
+  v_available double precision;
+  v_paint_name text;
+  v_now_ms bigint := floor(extract(epoch from clock_timestamp()) * 1000);
+  v_comments jsonb;
+  v_touched text[] := array[]::text[];
+begin
+  if coalesce(trim(p_task_id), '') = '' then raise exception 'task_id is required'; end if;
+  if coalesce(trim(p_order_id), '') = '' then raise exception 'order_id is required'; end if;
+  if p_paint_usages is null then p_paint_usages := '[]'::jsonb; end if;
+
+  perform 1 from tasks where id = p_task_id and order_id = p_order_id for update;
+  if not found then
+    raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
+  end if;
+
+  for rec in
+    with requested as (
+      select
+        nullif(trim(coalesce(value->>'paint_id', value->>'material_id')), '') as paint_id,
+        nullif(trim(coalesce(value->>'paint_name', value->>'name')), '') as paint_name,
+        coalesce(
+          nullif(value->>'used_qty', '')::double precision,
+          nullif(value->>'qty', '')::double precision,
+          nullif(value->>'qty_g', '')::double precision,
+          nullif(value->>'qty_grams', '')::double precision,
+          nullif(value->>'qty_kg', '')::double precision * 1000,
+          0
+        ) as qty
+      from jsonb_array_elements(p_paint_usages)
+    ), resolved as (
+      select coalesce(req.paint_id, p_by_name.id) as paint_id,
+             coalesce(req.paint_name, p_by_name.description) as paint_name,
+             req.qty
+      from requested req
+      left join lateral (
+        select p.id, p.description
+          from paints p
+         where req.paint_id is null
+           and req.paint_name is not null
+           and lower(trim(p.description)) = lower(trim(req.paint_name))
+         order by p.id
+         limit 1
+      ) p_by_name on true
+      where req.paint_id is not null or req.paint_name is not null
+    ), aggregated as (
+      select paint_id, max(paint_name) as paint_name, sum(qty) as qty
+      from resolved
+      group by paint_id
+    )
+    select a.paint_id, a.paint_name, a.qty, p.quantity as total_qty, p.description as stock_name
+    from aggregated a
+    left join paints p on p.id = a.paint_id
+    order by a.paint_id nulls last, a.paint_name
+    for update of p
+  loop
+    if rec.qty < 0 then
+      raise exception 'Нельзя списать отрицательное количество краски (%).', coalesce(rec.stock_name, rec.paint_name, rec.paint_id);
+    end if;
+    if rec.qty = 0 then
+      continue;
+    end if;
+    if rec.paint_id is null or rec.total_qty is null then
+      raise exception 'Краска % не найдена на складе.', coalesce(rec.paint_name, rec.paint_id);
+    end if;
+
+    select coalesce(sum(greatest(r.reserved_qty - r.used_qty - r.released_qty, 0)), 0)
+      into v_reserved_other
+      from order_paint_reservations r
+     where r.paint_id = rec.paint_id
+       and r.order_id <> p_order_id;
+
+    v_available := rec.total_qty - v_reserved_other;
+    if v_available < rec.qty then
+      v_paint_name := coalesce(rec.stock_name, rec.paint_name, rec.paint_id);
+      raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
+        v_paint_name, round(v_available::numeric, 2), round(rec.qty::numeric, 2);
+    end if;
+
+    insert into paints_writeoffs(paint_id, qty, reason, by_name)
+    values (
+      rec.paint_id,
+      rec.qty,
+      format('Списание флексопечати по заказу %s', p_order_id),
+      coalesce(nullif(trim(p_actor), ''), nullif(trim(p_employee_id), ''), 'system')
+    );
+
+    update paints
+       set quantity = greatest(quantity - rec.qty, 0)
+     where id = rec.paint_id;
+
+    update order_paint_reservations
+       set used_qty = rec.qty,
+           released_qty = greatest(reserved_qty - rec.qty, 0),
+           paint_name = coalesce(paint_name, rec.paint_name, rec.stock_name),
+           updated_at = now()
+     where order_id = p_order_id and paint_id = rec.paint_id;
+
+    if not found then
+      insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
+      values (p_order_id, rec.paint_id, coalesce(rec.paint_name, rec.stock_name), rec.qty, rec.qty, 0)
+      on conflict (order_id, paint_id) where paint_id is not null
+      do update set used_qty = excluded.used_qty,
+                    released_qty = greatest(order_paint_reservations.reserved_qty - excluded.used_qty, 0),
+                    updated_at = now();
+    end if;
+
+    v_touched := array_append(v_touched, rec.paint_id);
+  end loop;
+
+  for rel in
+    select paint_id
+      from order_paint_reservations
+     where order_id = p_order_id
+       and greatest(reserved_qty - used_qty - released_qty, 0) > 0
+     for update
+  loop
+    update order_paint_reservations
+       set released_qty = greatest(reserved_qty - used_qty, 0),
+           updated_at = now()
+     where order_id = p_order_id and paint_id = rel.paint_id;
+    v_touched := array_append(v_touched, rel.paint_id);
+  end loop;
+
+  perform recalculate_paint_reserved_qty((select array_agg(distinct x) from unnest(v_touched) as x where x is not null));
+
+  select coalesce(comments::jsonb, '[]'::jsonb) into v_comments
+    from tasks
+   where id = p_task_id
+   for update;
+
+  if p_quantity_done is not null and trim(p_quantity_done) <> '' then
+    v_comments := v_comments || jsonb_build_array(jsonb_build_object(
+      'id', gen_random_uuid()::text,
+      'type', 'quantity_done',
+      'text', p_quantity_done,
+      'userId', coalesce(nullif(trim(p_employee_id), ''), nullif(trim(p_actor), ''), 'system'),
+      'timestamp', v_now_ms
+    ));
+  end if;
+
+  if p_comment is not null and trim(p_comment) <> '' then
+    v_comments := v_comments || jsonb_build_array(jsonb_build_object(
+      'id', gen_random_uuid()::text,
+      'type', 'finish_note',
+      'text', p_comment,
+      'userId', coalesce(nullif(trim(p_employee_id), ''), nullif(trim(p_actor), ''), 'system'),
+      'timestamp', v_now_ms + 1
+    ));
+  end if;
+
+  update tasks
+     set status = 'completed',
+         started_at = null,
+         comments = v_comments
+   where id = p_task_id;
+
+  update tasks
+     set status = 'completed', started_at = null
+   where order_id = p_order_id
+     and stage_id = p_stage_id
+     and id <> p_task_id
+     and status <> 'completed';
+end;
+$$;
+
+grant execute on function public.complete_flex_printing_stage(text, text, text, text, jsonb, text, text, text)
+to authenticated, anon;


### PR DESCRIPTION
### Motivation
- Add atomic reservation and consumption of paints for orders (like paper) to avoid double-booking and runtime shortages during flex printing. 
- Ensure flex printing completion is transactional: validate reserves, write off stock, update reservation usage and task status, and surface shortage errors to users.

### Description
- Database: new migration `supabase/migrations/20260514_add_order_paint_reservations.sql` that adds `paints.reserved_qty`, creates `order_paint_reservations` with `reserved_qty/used_qty/released_qty`, indexes, constraints and RLS policies. 
- RPCs: added `sync_order_paint_reservations(p_order_id, p_reservations, p_actor)`, `release_order_paint_reservations(...)` and `complete_flex_printing_stage(...)` implementing aggregation, `FOR UPDATE` locking on `paints`, available = `total - reserved_other`, non-negative checks, writeoffs and task finalization. 
- Backend API: `OrdersRepository` extended with `syncPaintReservations`, `releasePaintReservations`, `getPaintReservations` and `completeFlexPrintingStage`, and `createOrder()`/paint persist paths now call `syncPaintReservations`. 
- Provider/UI: `OrdersProvider` now calls paint release RPC on order deletion; `EditOrderScreen` and production form call sync after persisting `order_paints`; tasks UI (`tasks_screen.dart`) now loads reservation data, shows `reserved/used/released` in the ink dialog and completes flex printing via the `completeFlexPrintingStage` RPC; added `_humanizeRpcError` to surface shortage messages like `Недостаточно краски: [название]. Доступно: X, требуется: Y`. 
- Files changed (key): `supabase/migrations/20260514_add_order_paint_reservations.sql`, `lib/modules/orders/orders_repository.dart`, `lib/modules/orders/edit_order_screen.dart`, `lib/modules/production_planning/form_editor_screen.dart`, `lib/modules/orders/orders_provider.dart`, `lib/modules/tasks/tasks_screen.dart`.

### Testing
- Attempted static check: `flutter analyze` could not run in CI because `flutter` is not available in the environment. 
- Performed automated structural check: ran a Python bracket-balance smoke check over the modified SQL/Dart files and it passed. 
- No runtime/integration tests were executed in this environment (DB migrations and RPCs need a running Postgres/Supabase instance to verify).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061884ef58832fbec39c83b977fcf5)