### PR TITLE
Учёт резерва красок: `reserved_qty`/`available_qty`, UI и проверка доступности

### DIFF
--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -192,6 +192,8 @@ class OrdersProvider with ChangeNotifier {
 
   Future<String> _materialShortageMessage(OrderModel order) async {
     final papers = _resolveOrderPapers(order);
+    final paintShortage = await _paintShortageMessage(order);
+    if (paintShortage.isNotEmpty) return paintShortage;
     if (papers.isEmpty) return 'Материал не выбран в заказе.';
     for (final paper in papers) {
       final requiredLength = _requiredPaperReserveQty(order, paper);
@@ -305,8 +307,83 @@ class OrdersProvider with ChangeNotifier {
         .toList(growable: false);
   }
 
+  Future<List<Map<String, dynamic>>> _paintReservationsForOrder(
+    String orderId,
+  ) async {
+    final normalizedId = orderId.trim();
+    if (normalizedId.isEmpty) return const [];
+    try {
+      final rows = await _supabase
+          .from('order_paint_reservations')
+          .select('paint_id, paint_name, reserved_qty')
+          .eq('order_id', normalizedId);
+      if (rows is! List) return const [];
+      return rows
+          .whereType<Map>()
+          .map((raw) => Map<String, dynamic>.from(raw as Map))
+          .toList(growable: false);
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  Future<double?> _fetchPaintAvailableQty(String paintId) async {
+    final id = paintId.trim();
+    if (id.isEmpty) return null;
+    try {
+      final row = await _supabase
+          .from('paints')
+          .select('quantity')
+          .eq('id', id)
+          .maybeSingle();
+      if (row == null) return null;
+      final baseQty = _toDouble(row['quantity']);
+      final rows = await _supabase
+          .from('order_paint_reservations')
+          .select('reserved_qty')
+          .eq('paint_id', id);
+      double reservedQty = 0;
+      if (rows is List) {
+        for (final raw in rows.whereType<Map>()) {
+          reservedQty += _toDouble((raw as Map)['reserved_qty']);
+        }
+      }
+      return baseQty - reservedQty;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> _hasEnoughPaintForLaunch(OrderModel order) async {
+    final reservations = await _paintReservationsForOrder(order.id);
+    for (final row in reservations) {
+      final paintId = (row['paint_id'] ?? '').toString().trim();
+      final requiredQty = _toDouble(row['reserved_qty']);
+      if (paintId.isEmpty || requiredQty <= 0) continue;
+      final availableQty = await _fetchPaintAvailableQty(paintId);
+      if (availableQty == null || availableQty < 0) return false;
+    }
+    return true;
+  }
+
+  Future<String> _paintShortageMessage(OrderModel order) async {
+    final reservations = await _paintReservationsForOrder(order.id);
+    for (final row in reservations) {
+      final paintId = (row['paint_id'] ?? '').toString().trim();
+      if (paintId.isEmpty) continue;
+      final availableQty = await _fetchPaintAvailableQty(paintId);
+      if (availableQty != null && availableQty >= 0) continue;
+      final requiredQty = _toDouble(row['reserved_qty']);
+      final name = (row['paint_name'] ?? paintId).toString();
+      return 'Недостаточно краски "$name": требуется ${requiredQty.toStringAsFixed(2)}, '
+          'доступно ${(availableQty ?? 0).toStringAsFixed(2)}.';
+    }
+    return '';
+  }
+
   Future<bool> _hasEnoughMaterialForLaunch(OrderModel order) async {
     final papers = _resolveOrderPapers(order);
+    if (!await _hasEnoughPaintForLaunch(order)) return false;
     if (papers.isEmpty) return true;
     for (final paper in papers) {
       final String materialId = (paper.id ?? '').trim();
@@ -2004,7 +2081,7 @@ class OrdersProvider with ChangeNotifier {
     if (value == null) {
       return 0;
     }
-    return double.tryParse(value.toString()) ?? 0;
+    return double.tryParse(value.toString().replaceAll(',', '.')) ?? 0;
   }
 
   double? _toDoubleNullable(dynamic value) {

--- a/lib/modules/warehouse/paint_table.dart
+++ b/lib/modules/warehouse/paint_table.dart
@@ -53,6 +53,67 @@ class _PaintTableState extends State<PaintTable> {
     ).then((_) => _loadData());
   }
 
+  String _fmtQty(double value) => value.toStringAsFixed(2);
+
+  double _num(dynamic value) {
+    if (value is num) return value.toDouble();
+    return double.tryParse('$value'.replaceAll(',', '.')) ?? 0;
+  }
+
+  String _orderLabel(Map<String, dynamic> row) {
+    final order = row['orders'];
+    if (order is Map) {
+      final code = (order['form_code'] ?? '').toString().trim();
+      if (code.isNotEmpty) return code;
+      final no = order['new_form_no'];
+      if (no != null) return '№$no';
+      final customer = (order['customer'] ?? '').toString().trim();
+      if (customer.isNotEmpty) return customer;
+    }
+    final orderId = (row['order_id'] ?? '').toString().trim();
+    return orderId.isEmpty ? 'Заказ' : orderId;
+  }
+
+  Future<void> _showReserveDetails(TmcModel item) async {
+    final provider = Provider.of<WarehouseProvider>(context, listen: false);
+    final rows = await provider.getPaintReservationsByPaint(item.id);
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Резервы: ${item.description}'),
+        content: SizedBox(
+          width: 420,
+          child: rows.isEmpty
+              ? const Text('Нет активных резервов')
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: rows
+                      .map(
+                        (row) => ListTile(
+                          dense: true,
+                          title: Text(_orderLabel(row)),
+                          subtitle: Text(
+                            'Заказ: ${(row['order_id'] ?? '').toString()}',
+                          ),
+                          trailing: Text(
+                            '${_fmtQty(_num(row['reserved_qty']))} ${item.unit}',
+                          ),
+                        ),
+                      )
+                      .toList(growable: false),
+                ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Закрыть'),
+          ),
+        ],
+      ),
+    );
+  }
+
   void _editItem(TmcModel item) {
     showDialog(
       context: context,
@@ -214,7 +275,9 @@ class _PaintTableState extends State<PaintTable> {
                               DataColumn(label: Text('№')),
                               DataColumn(label: Text('Фото')),
                               DataColumn(label: Text('Название')),
-                              DataColumn(label: Text('Количество')),
+                              DataColumn(label: Text('Общий остаток')),
+                              DataColumn(label: Text('Резерв')),
+                              DataColumn(label: Text('Доступно')),
                               DataColumn(label: Text('Ед.')),
                               DataColumn(label: Text('Действия')),
                             ],
@@ -233,6 +296,14 @@ class _PaintTableState extends State<PaintTable> {
                                         item.quantity
                                             .toString()
                                             .toLowerCase()
+                                            .contains(query) ||
+                                        item.reservedQty
+                                            .toString()
+                                            .toLowerCase()
+                                            .contains(query) ||
+                                        item.availableQty
+                                            .toString()
+                                            .toLowerCase()
                                             .contains(query);
                                   })
                                   .toList()
@@ -247,6 +318,14 @@ class _PaintTableState extends State<PaintTable> {
                                           .contains(query) ||
                                       item.unit.toLowerCase().contains(query) ||
                                       item.quantity
+                                          .toString()
+                                          .toLowerCase()
+                                          .contains(query) ||
+                                      item.reservedQty
+                                          .toString()
+                                          .toLowerCase()
+                                          .contains(query) ||
+                                      item.availableQty
                                           .toString()
                                           .toLowerCase()
                                           .contains(query);
@@ -321,8 +400,20 @@ class _PaintTableState extends State<PaintTable> {
                                             },
                                     );
                                   }),
-                                  DataCell(Text(item.description)),
-                                  DataCell(Text(item.quantity.toString())),
+                                  DataCell(
+                                    Text(item.description),
+                                    onTap: () => _showReserveDetails(item),
+                                  ),
+                                  DataCell(Text(_fmtQty(item.quantity))),
+                                  DataCell(
+                                    TextButton(
+                                      onPressed: item.reservedQty > 0
+                                          ? () => _showReserveDetails(item)
+                                          : null,
+                                      child: Text(_fmtQty(item.reservedQty)),
+                                    ),
+                                  ),
+                                  DataCell(Text(_fmtQty(item.availableQty))),
                                   DataCell(Text(item.unit)),
                                   DataCell(Row(
                                     children: [

--- a/lib/modules/warehouse/tmc_model.dart
+++ b/lib/modules/warehouse/tmc_model.dart
@@ -5,22 +5,34 @@ class TmcModel {
   final String type;
   final String description;
   final double quantity;
+
+  /// Количество, зарезервированное под заказы.
+  final double reservedQty;
+
+  /// Доступный остаток: общий остаток минус резерв.
+  final double availableQty;
   final String unit;
   final String? format; // для бумаги
   final String? grammage; // граммаж бумаги
   final double? weight; // вес бумаги
   final String? note;
+
   /// URL изображения, если для записи загрузили фото (например, для красок).
   final String? imageUrl;
+
   /// base64-строка изображения. Используется для отображения изображений без
   /// необходимости загружать их из интернета (например, в веб-версии).
   final String? imageBase64;
+
   /// Пороговое значение для предупреждения о низком остатке (желтый индикатор).
   final double? lowThreshold;
+
   /// Пороговое значение для предупреждения о критически низком остатке (красный индикатор).
   final double? criticalThreshold;
+
   /// Время создания записи (ISO 8601). Используется для отображения даты/времени в UI.
   final String? createdAt;
+
   /// Время последнего обновления записи (ISO 8601). Используется для отображения даты/времени в UI.
   final String? updatedAt;
 
@@ -31,6 +43,8 @@ class TmcModel {
     required this.type,
     required this.description,
     required this.quantity,
+    double? reservedQty,
+    double? availableQty,
     required this.unit,
     this.format,
     this.grammage,
@@ -42,17 +56,33 @@ class TmcModel {
     this.criticalThreshold,
     this.createdAt,
     this.updatedAt,
-  });
+  })  : reservedQty = reservedQty ?? 0.0,
+        availableQty = availableQty ?? (quantity - (reservedQty ?? 0.0));
 
   // Создание модели из [Map], полученного из базы данных (например, Supabase).
   factory TmcModel.fromMap(Map<String, dynamic> map) {
+    final quantity = (map['quantity'] as num?)?.toDouble() ?? 0.0;
+    final reservedQty = (map['reserved_qty'] ?? map['reservedQty']) is num
+        ? ((map['reserved_qty'] ?? map['reservedQty']) as num).toDouble()
+        : double.tryParse(
+              '${map['reserved_qty'] ?? map['reservedQty'] ?? ''}',
+            ) ??
+            0.0;
+    final availableQty = (map['available_qty'] ?? map['availableQty']) is num
+        ? ((map['available_qty'] ?? map['availableQty']) as num).toDouble()
+        : double.tryParse(
+              '${map['available_qty'] ?? map['availableQty'] ?? ''}',
+            ) ??
+            (quantity - reservedQty);
     return TmcModel(
       id: map['id'] ?? '',
       date: map['date'] ?? '',
       supplier: map['supplier'],
       type: map['type'] ?? '',
       description: map['description'] ?? '',
-      quantity: (map['quantity'] as num?)?.toDouble() ?? 0.0,
+      quantity: quantity,
+      reservedQty: reservedQty,
+      availableQty: availableQty,
       unit: map['unit'] ?? '',
       format: map['format'],
       grammage: map['grammage'],
@@ -60,9 +90,16 @@ class TmcModel {
       note: map['note'],
       // image fields may come in different cases or snake_case from Postgres
       imageUrl: map['image_url'] ?? map['imageUrl'] ?? map['imageurl'],
-      imageBase64: map['image_base64'] ?? map['imageBase64'] ?? map['imagebase64'],
-      lowThreshold: (map['low_threshold'] ?? map['lowThreshold']) is num ? (map['low_threshold'] ?? map['lowThreshold'])?.toDouble() : null,
-      criticalThreshold: (map['critical_threshold'] ?? map['criticalThreshold']) is num ? (map['critical_threshold'] ?? map['criticalThreshold'])?.toDouble() : null,
+      imageBase64:
+          map['image_base64'] ?? map['imageBase64'] ?? map['imagebase64'],
+      lowThreshold: (map['low_threshold'] ?? map['lowThreshold']) is num
+          ? (map['low_threshold'] ?? map['lowThreshold'])?.toDouble()
+          : null,
+      criticalThreshold:
+          (map['critical_threshold'] ?? map['criticalThreshold']) is num
+              ? (map['critical_threshold'] ?? map['criticalThreshold'])
+                  ?.toDouble()
+              : null,
       createdAt: map['created_at'] ?? map['createdAt'],
       updatedAt: map['updated_at'] ?? map['updatedAt'],
     );
@@ -77,6 +114,8 @@ class TmcModel {
       'type': type,
       'description': description,
       'quantity': quantity,
+      'reserved_qty': reservedQty,
+      'available_qty': availableQty,
       'unit': unit,
       if (format != null) 'format': format,
       if (grammage != null) 'grammage': grammage,
@@ -90,5 +129,55 @@ class TmcModel {
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
     };
+  }
+
+  factory TmcModel.fromJson(Map<String, dynamic> json) => TmcModel.fromMap(json);
+
+  Map<String, dynamic> toJson() => toMap();
+
+  TmcModel copyWith({
+    String? id,
+    String? date,
+    String? supplier,
+    String? type,
+    String? description,
+    double? quantity,
+    double? reservedQty,
+    double? availableQty,
+    String? unit,
+    String? format,
+    String? grammage,
+    double? weight,
+    String? note,
+    String? imageUrl,
+    String? imageBase64,
+    double? lowThreshold,
+    double? criticalThreshold,
+    String? createdAt,
+    String? updatedAt,
+  }) {
+    final nextQuantity = quantity ?? this.quantity;
+    final nextReservedQty = reservedQty ?? this.reservedQty;
+    return TmcModel(
+      id: id ?? this.id,
+      date: date ?? this.date,
+      supplier: supplier ?? this.supplier,
+      type: type ?? this.type,
+      description: description ?? this.description,
+      quantity: nextQuantity,
+      reservedQty: nextReservedQty,
+      availableQty: availableQty ?? (nextQuantity - nextReservedQty),
+      unit: unit ?? this.unit,
+      format: format ?? this.format,
+      grammage: grammage ?? this.grammage,
+      weight: weight ?? this.weight,
+      note: note ?? this.note,
+      imageUrl: imageUrl ?? this.imageUrl,
+      imageBase64: imageBase64 ?? this.imageBase64,
+      lowThreshold: lowThreshold ?? this.lowThreshold,
+      criticalThreshold: criticalThreshold ?? this.criticalThreshold,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
   }
 }

--- a/lib/modules/warehouse/tmc_model.g.dart
+++ b/lib/modules/warehouse/tmc_model.g.dart
@@ -24,13 +24,15 @@ class TmcModelAdapter extends TypeAdapter<TmcModel> {
       description: fields[4] as String,
       quantity: fields[5] as double,
       unit: fields[6] as String,
+      reservedQty: fields[7] as double? ?? 0.0,
+      availableQty: fields[8] as double?,
     );
   }
 
   @override
   void write(BinaryWriter writer, TmcModel obj) {
     writer
-      ..writeByte(7)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -44,7 +46,11 @@ class TmcModelAdapter extends TypeAdapter<TmcModel> {
       ..writeByte(5)
       ..write(obj.quantity)
       ..writeByte(6)
-      ..write(obj.unit);
+      ..write(obj.unit)
+      ..writeByte(7)
+      ..write(obj.reservedQty)
+      ..writeByte(8)
+      ..write(obj.availableQty);
   }
 
   @override

--- a/lib/modules/warehouse/warehouse_provider.dart
+++ b/lib/modules/warehouse/warehouse_provider.dart
@@ -58,6 +58,7 @@ class WarehouseProvider with ChangeNotifier {
   RealtimeChannel? _chanMaterials;
   RealtimeChannel? _chanPapers;
   RealtimeChannel? _chanPaperReservations;
+  RealtimeChannel? _chanPaintReservations;
   RealtimeChannel? _chanStationery;
 
   final List<TmcModel> _allTmc = [];
@@ -378,6 +379,9 @@ class WarehouseProvider with ChangeNotifier {
     if (_chanPaperReservations != null) {
       _sb.removeChannel(_chanPaperReservations!);
     }
+    if (_chanPaintReservations != null) {
+      _sb.removeChannel(_chanPaintReservations!);
+    }
     if (_chanStationery != null) _sb.removeChannel(_chanStationery!);
     super.dispose();
   }
@@ -429,6 +433,16 @@ class WarehouseProvider with ChangeNotifier {
         )
         .subscribe();
 
+    _chanPaintReservations = _sb
+        .channel('wh:paint_reservations')
+        .onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          schema: 'public',
+          table: 'order_paint_reservations',
+          callback: (_) => fetchTmc(),
+        )
+        .subscribe();
+
     _resubscribeStationery();
   }
 
@@ -460,13 +474,20 @@ class WarehouseProvider with ChangeNotifier {
         _loadStationeryRows(),
       ]);
       final p = results[0] as List;
+      final paintReservedQty = await _loadPaintReservedQty();
       final m = results[1] as List;
       final pr = results[2] as List;
       final pensRows = results[3] as List<Map<String, dynamic>>;
       final stationeryRows = results[4] as List<Map<String, dynamic>>;
       final List<TmcModel> merged = [];
       for (final e in p) {
-        merged.add(_fromRow(type: 'paint', row: Map<String, dynamic>.from(e)));
+        final row = Map<String, dynamic>.from(e);
+        final quantity = _toDouble(row['quantity']);
+        final reservedQty = paintReservedQty[(row['id'] ?? '').toString()] ??
+            _toDouble(row['reserved_qty']);
+        row['reserved_qty'] = reservedQty;
+        row['available_qty'] = quantity - reservedQty;
+        merged.add(_fromRow(type: 'paint', row: row));
       }
       for (final e in m) {
         merged
@@ -2282,6 +2303,10 @@ class WarehouseProvider with ChangeNotifier {
       type: type,
       description: (row['description'] ?? '').toString(),
       quantity: _d(row['quantity']),
+      reservedQty: _d(row['reserved_qty']),
+      availableQty: row.containsKey('available_qty')
+          ? _d(row['available_qty'])
+          : _d(row['quantity']) - _d(row['reserved_qty']),
       unit: (row['unit'] as String?) ?? '',
       note: row['note'] as String?,
       format: row['format'] as String?,
@@ -2297,6 +2322,58 @@ class WarehouseProvider with ChangeNotifier {
       createdAt: row['created_at']?.toString(),
       updatedAt: row['updated_at']?.toString(),
     );
+  }
+
+  double _toDouble(dynamic value) {
+    if (value is num) return value.toDouble();
+    return double.tryParse('$value'.replaceAll(',', '.')) ?? 0.0;
+  }
+
+  Future<Map<String, double>> _loadPaintReservedQty() async {
+    try {
+      final rows = await _sb
+          .from('order_paint_reservations')
+          .select('paint_id, reserved_qty');
+      if (rows is! List) return const {};
+      final out = <String, double>{};
+      for (final raw in rows.whereType<Map>()) {
+        final row = Map<String, dynamic>.from(raw as Map);
+        final paintId = (row['paint_id'] ?? '').toString().trim();
+        if (paintId.isEmpty) continue;
+        out.update(
+          paintId,
+          (value) => value + _toDouble(row['reserved_qty']),
+          ifAbsent: () => _toDouble(row['reserved_qty']),
+        );
+      }
+      return out;
+    } catch (e) {
+      debugPrint('⚠️ paint reservations load failed: $e');
+      return const {};
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getPaintReservationsByPaint(
+    String paintId,
+  ) async {
+    final normalizedId = paintId.trim();
+    if (normalizedId.isEmpty) return const [];
+    try {
+      final rows = await _sb
+          .from('order_paint_reservations')
+          .select(
+              'order_id, reserved_qty, orders(id, customer, new_form_no, form_code)')
+          .eq('paint_id', normalizedId)
+          .order('created_at');
+      if (rows is! List) return const [];
+      return rows
+          .whereType<Map>()
+          .map((raw) => Map<String, dynamic>.from(raw as Map))
+          .toList(growable: false);
+    } catch (e) {
+      debugPrint('⚠️ paint reservations details failed: $e');
+      return const [];
+    }
   }
 
   Future<String> _uploadImage(


### PR DESCRIPTION
### Motivation
- Учесть резервы красок по заказам и обеспечить проверку возможности запуска заказа по доступному остатку, а также показать эти значения в UI таблицы и детализации краски.

### Description
- Добавлена поддержка полей `reservedQty` и `availableQty` в модели склада `TmcModel` с обновлёнными `fromMap`/`toMap`/`fromJson`/`toJson`/`copyWith` и обновлённым Hive-адаптером в `lib/modules/warehouse/tmc_model.dart` и `lib/modules/warehouse/tmc_model.g.dart`.
- В `WarehouseProvider` добавлена агрегация строк из `order_paint_reservations`, вычисление `available_qty = quantity - reserved_qty`, подписка на изменения таблицы резервов и метод `getPaintReservationsByPaint(...)` для получения деталей резервов по заказам (`form_code`/`new_form_no`/`customer`).
- В `lib/modules/warehouse/paint_table.dart` добавлены колонки «Общий остаток», «Резерв», «Доступно», обновлён фильтр поиска на новые поля и реализован диалог с деталями резервов по заказам (номер/код заказа и количество) по клику на название/резерв.
- В логике проверки запуска заказа (`lib/modules/orders/orders_provider.dart`) добавлены функции `_paintReservationsForOrder`, `_fetchPaintAvailableQty`, `_hasEnoughPaintForLaunch` и `_paintShortageMessage`, и теперь перед проверкой бумаги учитывается доступность красок (проверка по `available`, а не по `quantity`), при этом существующая логика прихода/списания не изменялась.

### Testing
- `git diff --check` выполнен и ошибок не показал (успешно).
- `flutter analyze` не был выполнен в CI окружении, потому что в текущем окружении отсутствует Flutter SDK (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061af3094c832f90fede9db6edb2d3)