### PR TITLE
Allow next task stage after previous starts

### DIFF
--- a/lib/modules/tasks/stage_sequence_utils.dart
+++ b/lib/modules/tasks/stage_sequence_utils.dart
@@ -38,11 +38,13 @@ class PendingStageState {
   final String stageId;
   final bool completed;
   final bool problem;
+  final bool started;
 
   const PendingStageState({
     required this.stageId,
     required this.completed,
     this.problem = false,
+    this.started = false,
   });
 
   bool get pending => !completed;
@@ -68,11 +70,17 @@ bool isFirstPendingStageInOrder({
   for (final state in stageStates) {
     final key = groupKey(state.stageId);
     final current = stages[key] ??
-        {'pending': false, 'completed': false, 'problem': false};
+        {
+          'pending': false,
+          'completed': false,
+          'problem': false,
+          'started': false,
+        };
     stages[key] = {
       'pending': current['pending'] == true || state.pending,
       'completed': current['completed'] == true || state.completed,
       'problem': current['problem'] == true || state.problem,
+      'started': current['started'] == true || state.started,
     };
   }
 
@@ -99,10 +107,11 @@ bool isFirstPendingStageInOrder({
 
       final hasPending = prevState['pending'] == true;
       final hasProblem = prevState['problem'] == true;
+      final hasStarted = prevState['started'] == true;
       if (!hasPending && prevState['completed'] == true) {
         continue;
       }
-      return prevState['completed'] == true || hasProblem;
+      return hasStarted || prevState['completed'] == true || hasProblem;
     }
     return true;
   }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -612,6 +612,27 @@ String? _workplaceUnit(PersonnelProvider personnel, String stageId) {
 bool _canRunOutOfStageSequence(TaskModel task) =>
     task.stageId.trim() == kCardboardCuttingStageId;
 
+bool _hasStartedForStageSequence(TaskModel task) {
+  if (task.status == TaskStatus.inProgress ||
+      task.status == TaskStatus.completed ||
+      task.status == TaskStatus.problem) {
+    return true;
+  }
+
+  final hasStartComment = task.comments.any(
+    (c) =>
+        c.type == 'start' ||
+        c.type == 'resume' ||
+        c.type == 'user_done' ||
+        c.type == 'problem',
+  );
+  if (hasStartComment) return true;
+
+  return _taskTimeEvents(task).any(
+    (event) => event.type == TaskTimeType.production,
+  );
+}
+
 bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     TaskModel task,
     {stage_sequence.StageGroupingResolver? groupResolver}) {
@@ -642,6 +663,7 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
         completed: _isEffectivelyCompleted(t),
         problem: t.status == TaskStatus.problem ||
             t.comments.any((c) => c.type == 'problem'),
+        started: _hasStartedForStageSequence(t),
       ),
     ),
     orderedStages: tasks.stageSequenceForOrder(task.orderId) ?? const [],
@@ -6875,8 +6897,8 @@ class _TaskCard extends StatelessWidget {
     final double statusSize = scaled(11.5);
     final String? stageHint = showStageHint
         ? (readyForStage
-            ? 'Можно начинать: предыдущий этап завершён'
-            : 'Ожидает завершения предыдущего этапа')
+            ? 'Можно начинать: предыдущий этап начат'
+            : 'Ожидает начала предыдущего этапа')
         : null;
     final Color readyColor = Colors.green.shade600;
     final Color stageHintColor =

--- a/test/stage_sequence_utils_test.dart
+++ b/test/stage_sequence_utils_test.dart
@@ -81,4 +81,59 @@ void main() {
 
     expect(canStart, isTrue);
   });
+
+  test('second stage is available after first stage has started', () {
+    final canStart = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: 'stage-2',
+      stageStates: const [
+        PendingStageState(
+          stageId: 'stage-1',
+          completed: false,
+          started: true,
+        ),
+        PendingStageState(stageId: 'stage-2', completed: false),
+      ],
+      orderedStages: const ['stage-1', 'stage-2', 'stage-3'],
+    );
+
+    expect(canStart, isTrue);
+  });
+
+  test('third stage remains blocked while second stage is waiting', () {
+    final canStart = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: 'stage-3',
+      stageStates: const [
+        PendingStageState(
+          stageId: 'stage-1',
+          completed: false,
+          started: true,
+        ),
+        PendingStageState(stageId: 'stage-2', completed: false),
+        PendingStageState(stageId: 'stage-3', completed: false),
+      ],
+      orderedStages: const ['stage-1', 'stage-2', 'stage-3'],
+    );
+
+    expect(canStart, isFalse);
+  });
+
+  test('problem stage opens the next stage', () {
+    final canStart = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: 'stage-2',
+      stageStates: const [
+        PendingStageState(
+          stageId: 'stage-1',
+          completed: false,
+          problem: true,
+        ),
+        PendingStageState(stageId: 'stage-2', completed: false),
+      ],
+      orderedStages: const ['stage-1', 'stage-2'],
+    );
+
+    expect(canStart, isTrue);
+  });
 }


### PR DESCRIPTION
### Motivation
- Make stage sequencing follow project rule that a next stage is unlocked when the previous stage is started (not only when completed or in problem), while preserving the rule that stage[i+2] stays blocked until stage[i+1] is started. 
- Ensure UI hint text matches the new rule so users see that the previous stage must be started rather than completed.

### Description
- Added a `started` boolean to `PendingStageState` in `lib/modules/tasks/stage_sequence_utils.dart` and aggregate it when grouping stage states. 
- Updated `isFirstPendingStageInOrder()` to allow the next stage when the previous relevant stage is `started || completed || problem` while keeping the earlier blocking semantics for further stages. 
- Introduced `_hasStartedForStageSequence(TaskModel)` in `lib/modules/tasks/tasks_screen.dart` to detect `started` from `TaskStatus.inProgress|completed|problem`, `start|resume|user_done|problem` comments, or open/closed production time events, and pass its result into `PendingStageState` construction. 
- Updated `_TaskCard` hint strings in `lib/modules/tasks/tasks_screen.dart` to replace “предыдущий этап завершён” with “предыдущий этап начат” and the corresponding waiting text. 
- Added unit tests to `test/stage_sequence_utils_test.dart` covering: second stage unlocked after first is started, third stage blocked while second is waiting, and `problem` opening the next stage.

### Testing
- Added unit tests in `test/stage_sequence_utils_test.dart` for the new sequencing behavior (three new cases added). 
- Attempted to run the test suite with `flutter test`, but test execution was not performed because `flutter` is not available in the current environment (tests were not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061ffb1cc8832f9dbfab8332da74e6)