### PR TITLE
Allow packaging stage after previous stage starts

### DIFF
--- a/lib/modules/orders/stage_queue_builder.dart
+++ b/lib/modules/orders/stage_queue_builder.dart
@@ -1,3 +1,4 @@
+import '../tasks/stage_sequence_utils.dart' as stage_sequence;
 import 'order_stage_filter.dart';
 import 'material_model.dart';
 
@@ -30,7 +31,7 @@ const String kBobbinStageId = 'b92a89d1-8e95-4c6d-b990-e308486e4bf1';
 const String kFlexPrintingStageId = '0571c01c-f086-47e4-81b2-5d8b2ab91218';
 const Set<String> kLegacyBobbinStageAliases = {'w_bobiner', 'w_bobbin'};
 const Set<String> kLegacyFlexPrintingStageAliases = {'w_flexoprint', 'w_flexo'};
-const String kPackagingStageId = 'edeb85db-c7a3-4a24-8f33-70ccdd4aaae1';
+const String kPackagingStageId = stage_sequence.kPackagingStageId;
 const String kFriStageId = '92d96ee9-0519-40b9-bd17-9bec475496b6';
 const String kWindowStageId = '8337f16e-c2d1-42dc-966d-6277ba3c1a50';
 const String kAutoBigStageId = 'fdbf1735-a67c-47c9-a7e1-90546e1fe6ed';
@@ -346,7 +347,7 @@ List<Map<String, dynamic>> normalizeBuiltOrderStageQueue(
     } else if (_isFlexPrintingStage(map, canonicalId)) {
       map['stageName'] = 'Флексопечать';
       map['workplaceName'] = 'Флексопечать';
-    } else if (_isPackagingStage(map, canonicalId)) {
+    } else if (isPackagingStage(map, canonicalId)) {
       map['stageName'] = 'Упаковка';
       map['workplaceName'] = 'Упаковка';
     }
@@ -394,7 +395,7 @@ List<Map<String, dynamic>> _withPackagingStagesLast(
 
   for (final stage in stages) {
     final id = _stageIdFromMap(stage);
-    if (_isPackagingStage(stage, id)) {
+    if (isPackagingStage(stage, id)) {
       packaging.add(stage);
     } else {
       products.add(stage);
@@ -477,10 +478,18 @@ bool _isFlexPrintingStage(Map<String, dynamic> map, String? stageId) {
   return name.contains('флекс') || name.contains('flexo');
 }
 
-bool _isPackagingStage(Map<String, dynamic> map, String? stageId) {
-  if (stageId == kPackagingStageId) return true;
-  return _stageNameFromMap(map).contains('упаков');
-}
+bool isPackagingStage(Map<String, dynamic> map, String? stageId) =>
+    stage_sequence.isPackagingStage(
+      stageId: stageId,
+      stageName: _stageNameFromMap(map),
+      stageType: (map['stageType'] ?? map['stage_type'] ?? map['type'])
+          ?.toString(),
+      stageGroupKey: (map['stageGroupKey'] ??
+              map['stage_group_key'] ??
+              map['queueStageKey'] ??
+              map['queue_stage_key'])
+          ?.toString(),
+    );
 
 String _stageNameFromMap(Map<String, dynamic> map) => (map['stageName'] ??
         map['stage_name'] ??

--- a/lib/modules/tasks/stage_sequence_utils.dart
+++ b/lib/modules/tasks/stage_sequence_utils.dart
@@ -32,16 +32,74 @@ List<String> normalizeStageSequence(Iterable<String> rawSequence) {
 const String kCardboardCuttingStageId =
     'd7d91f75-2f85-446f-8c1d-a20606bdb3b1';
 
+const String kPackagingStageId = 'edeb85db-c7a3-4a24-8f33-70ccdd4aaae1';
+
+const Set<String> _packagingAliases = <String>{
+  'упаковка',
+  'packaging',
+  'package',
+};
+
+const Set<String> _packagingGroupKeys = <String>{
+  'pack',
+  'packing',
+  'packaging',
+  'package',
+  'packaging_stage',
+  'package_stage',
+  'packaging_group',
+  'package_group',
+  'pack_stage',
+  'упаковка',
+};
+
+String _normalizePackagingLookupValue(String? value) => (value ?? '')
+    .trim()
+    .toLowerCase()
+    .replaceAll('-', '_')
+    .replaceAll(RegExp(r'\s+'), '_');
+
+bool _matchesPackagingText(String? value) {
+  final normalized = _normalizePackagingLookupValue(value);
+  if (normalized.isEmpty) return false;
+  if (_packagingAliases.contains(normalized)) return true;
+  return normalized.contains('упаков') ||
+      normalized.contains('packaging') ||
+      normalized == 'package';
+}
+
+bool isPackagingStage({
+  String? stageId,
+  String? stageName,
+  String? stageType,
+  String? stageGroupKey,
+}) {
+  if ((stageId ?? '').trim() == kPackagingStageId) return true;
+  if (_matchesPackagingText(stageName) || _matchesPackagingText(stageType)) {
+    return true;
+  }
+
+  final normalizedGroupKey = _normalizePackagingLookupValue(stageGroupKey);
+  if (_packagingGroupKeys.contains(normalizedGroupKey)) return true;
+  return normalizedGroupKey.contains('упаков');
+}
+
 typedef StageGroupingResolver = String Function(String orderId, String stageId);
 
 class PendingStageState {
   final String stageId;
+  final String? stageName;
+  final String? stageType;
+  final String? stageGroupKey;
   final bool completed;
   final bool problem;
   final bool started;
 
   const PendingStageState({
     required this.stageId,
+    this.stageName,
+    this.stageType,
+    this.stageGroupKey,
     required this.completed,
     this.problem = false,
     this.started = false,
@@ -60,6 +118,9 @@ bool isFirstPendingStageInOrder({
   required Iterable<String> orderedStages,
   StageGroupingResolver? groupResolver,
   int Function(String a, String b)? fallbackStageComparator,
+  String? currentStageName,
+  String? currentStageType,
+  String? currentStageGroupKey,
 }) {
   if (canRunOutOfStageSequenceByStageId(currentStageId)) return true;
 
@@ -67,8 +128,25 @@ bool isFirstPendingStageInOrder({
       groupResolver?.call(orderId, stageId) ?? stageId;
 
   final stages = <String, Map<String, bool>>{};
+  var currentIsPackaging = isPackagingStage(
+    stageId: currentStageId,
+    stageName: currentStageName,
+    stageType: currentStageType,
+    stageGroupKey: currentStageGroupKey,
+  );
   for (final state in stageStates) {
     final key = groupKey(state.stageId);
+    if (state.stageId == currentStageId ||
+        (currentStageGroupKey != null &&
+            state.stageGroupKey == currentStageGroupKey)) {
+      currentIsPackaging = currentIsPackaging ||
+          isPackagingStage(
+            stageId: state.stageId,
+            stageName: state.stageName,
+            stageType: state.stageType,
+            stageGroupKey: state.stageGroupKey,
+          );
+    }
     final current = stages[key] ??
         {
           'pending': false,
@@ -100,18 +178,21 @@ bool isFirstPendingStageInOrder({
     final currentIndex = indexMap[currentKey];
     if (currentIndex == null || currentIndex <= 0) return true;
 
+    if (currentIsPackaging && currentIndex == orderedKeys.length - 1) {
+      final previousState = stages[orderedKeys[currentIndex - 1]];
+      return _stageUnlocksNext(previousState);
+    }
+
     for (var i = currentIndex - 1; i >= 0; i--) {
       final prevKey = orderedKeys[i];
       final prevState = stages[prevKey];
       if (prevState == null) continue;
 
       final hasPending = prevState['pending'] == true;
-      final hasProblem = prevState['problem'] == true;
-      final hasStarted = prevState['started'] == true;
       if (!hasPending && prevState['completed'] == true) {
         continue;
       }
-      return hasStarted || prevState['completed'] == true || hasProblem;
+      return _stageUnlocksNext(prevState);
     }
     return true;
   }
@@ -129,4 +210,11 @@ bool isFirstPendingStageInOrder({
   }
 
   return groupKey(currentStageId) == pendingStageIds.first;
+}
+
+bool _stageUnlocksNext(Map<String, bool>? stage) {
+  if (stage == null) return false;
+  return stage['started'] == true ||
+      stage['completed'] == true ||
+      stage['problem'] == true;
 }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -608,6 +608,13 @@ String? _workplaceUnit(PersonnelProvider personnel, String stageId) {
   return null;
 }
 
+String _stageDisplayName(PersonnelProvider personnel, String stageId) {
+  final wp = personnel.workplaceById(stageId);
+  final name = wp?.name.trim();
+  if (name != null && name.isNotEmpty) return name;
+  return stageId;
+}
+
 /// Разрешить старт только для самого первого незавершённого этапа заказа
 bool _canRunOutOfStageSequence(TaskModel task) =>
     task.stageId.trim() == kCardboardCuttingStageId;
@@ -660,6 +667,8 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     stageStates: all.map(
       (t) => stage_sequence.PendingStageState(
         stageId: t.stageId,
+        stageName: _stageDisplayName(personnel, t.stageId),
+        stageGroupKey: t.stageGroupKey,
         completed: _isEffectivelyCompleted(t),
         problem: t.status == TaskStatus.problem ||
             t.comments.any((c) => c.type == 'problem'),
@@ -669,6 +678,8 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     orderedStages: tasks.stageSequenceForOrder(task.orderId) ?? const [],
     groupResolver: groupResolver,
     fallbackStageComparator: byName,
+    currentStageName: _stageDisplayName(personnel, task.stageId),
+    currentStageGroupKey: task.stageGroupKey,
   );
 }
 

--- a/test/stage_sequence_utils_test.dart
+++ b/test/stage_sequence_utils_test.dart
@@ -136,4 +136,68 @@ void main() {
 
     expect(canStart, isTrue);
   });
+
+  test('isPackagingStage recognises id names types and group keys', () {
+    expect(isPackagingStage(stageId: kPackagingStageId), isTrue);
+    expect(isPackagingStage(stageName: 'Упаковка'), isTrue);
+    expect(isPackagingStage(stageName: 'упаковка'), isTrue);
+    expect(isPackagingStage(stageType: 'Packaging'), isTrue);
+    expect(isPackagingStage(stageType: 'package'), isTrue);
+    expect(isPackagingStage(stageGroupKey: 'packaging_stage'), isTrue);
+  });
+
+  test('packaging is available after cutting starts before cutting completes', () {
+    const flexo = 'flexo-stage';
+    const cutting = 'cutting-stage';
+
+    final canStartPackaging = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: kPackagingStageId,
+      currentStageName: 'Упаковка',
+      stageStates: const [
+        PendingStageState(stageId: flexo, completed: true),
+        PendingStageState(
+          stageId: cutting,
+          stageName: 'Резка',
+          completed: false,
+          started: true,
+        ),
+        PendingStageState(
+          stageId: kPackagingStageId,
+          stageName: 'Упаковка',
+          completed: false,
+        ),
+      ],
+      orderedStages: const [flexo, cutting, kPackagingStageId],
+    );
+
+    expect(canStartPackaging, isTrue);
+  });
+
+  test('packaging remains blocked while cutting is waiting', () {
+    const flexo = 'flexo-stage';
+    const cutting = 'cutting-stage';
+
+    final canStartPackaging = isFirstPendingStageInOrder(
+      orderId: 'order-1',
+      currentStageId: kPackagingStageId,
+      currentStageName: 'Упаковка',
+      stageStates: const [
+        PendingStageState(stageId: flexo, completed: true),
+        PendingStageState(
+          stageId: cutting,
+          stageName: 'Резка',
+          completed: false,
+        ),
+        PendingStageState(
+          stageId: kPackagingStageId,
+          stageName: 'Упаковка',
+          completed: false,
+        ),
+      ],
+      orderedStages: const [flexo, cutting, kPackagingStageId],
+    );
+
+    expect(canStartPackaging, isFalse);
+  });
 }


### PR DESCRIPTION
### Motivation
- Packaging stage should be recognised reliably by id, name/type and grouping so UI/queue logic can treat it consistently. 
- The last packaging step must be allowed to start once the immediately preceding stage has begun (inProgress/started), or if it is completed or in `problem`, but remain blocked while the previous stage is still `waiting`.

### Description
- Added `isPackagingStage` helper in `lib/modules/tasks/stage_sequence_utils.dart` that recognises packaging by saved `stage_id` (`kPackagingStageId`), Russian/English names/types and common packaging group keys. 
- Extended `PendingStageState` with `stageName`, `stageType` and `stageGroupKey` and updated `isFirstPendingStageInOrder` to accept `currentStageName/currentStageType/currentStageGroupKey` and detect packaging context. 
- Implemented packaging-specific unlock logic so a packaging stage (when final in the saved `orderedStages`) is unlocked if the immediately previous grouped stage `started`/`inProgress`/`completed`/`problem` via `_stageUnlocksNext`. 
- Reused the shared `isPackagingStage` from the tasks helper in `lib/modules/orders/stage_queue_builder.dart` and updated packaging checks there; updated `lib/modules/tasks/tasks_screen.dart` to provide display name and group key into the availability check. 
- Added unit tests in `test/stage_sequence_utils_test.dart` covering `isPackagingStage` detection and the `Флексопечать -> Резка -> Упаковка` scenario where packaging becomes available after `Резка` starts and remains blocked while `Резка` is waiting.

### Testing
- Added unit tests in `test/stage_sequence_utils_test.dart` that verify packaging detection and packaging availability for the Flexo → Cutting → Packaging queue. 
- Attempted to run `flutter test test/stage_sequence_utils_test.dart` in this environment but `flutter` is not installed, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0620e461fc832fba03530dee4a1fee)