### PR TITLE
Unify task problem handling and centralize attachment picking

### DIFF
--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -1345,6 +1345,223 @@ class TaskProvider with ChangeNotifier {
   }
 
 
+  Future<bool> reportProblem({
+    required String taskId,
+    required String text,
+    required String userId,
+    required List<String> participantsSnapshot,
+    required List<String> subjectUserIds,
+    String? workplaceId,
+    String? executionMode,
+    List<AttachmentDraft> attachments = const <AttachmentDraft>[],
+  }) async {
+    final localIndex = _tasks.indexWhere((task) => task.id == taskId);
+    if (localIndex == -1) return false;
+    final localTask = _tasks[localIndex];
+    if (localTask.status != TaskStatus.inProgress) return false;
+
+    final now = DateTime.now().toUtc();
+    final timestamp = now.millisecondsSinceEpoch;
+    final commentId = '$timestamp';
+    final normalizedSubjects = subjectUserIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (normalizedSubjects.isEmpty) normalizedSubjects.add(userId);
+
+    final uploaded = <TaskCommentAttachment>[];
+    List<Map<String, dynamic>> previousComments = const <Map<String, dynamic>>[];
+    var commentsPersisted = false;
+    var statusPersisted = false;
+    Map<String, dynamic>? previousTaskUpdates;
+
+    Future<void> cleanupUploads() async {
+      for (final attachment in uploaded) {
+        await _attachmentService.removeAttachment(attachment);
+      }
+    }
+
+    try {
+      for (final draft in attachments) {
+        uploaded.add(await _attachmentService.uploadTaskCommentAttachment(
+          draft: draft,
+          taskId: localTask.id,
+          orderId: localTask.orderId,
+          stageId: localTask.stageId,
+          commentId: commentId,
+          userId: userId,
+        ));
+      }
+
+      final row = await _supabase
+          .from('tasks')
+          .select(
+            'comments,status,spent_seconds,started_at,'
+            'captured_by_workplace_id,captured_at,captured_by_user_id',
+          )
+          .eq('id', taskId)
+          .single();
+      final status = (row['status'] ?? '').toString();
+      if (status != TaskStatus.inProgress.name) {
+        await cleanupUploads();
+        await refresh();
+        return false;
+      }
+
+      previousTaskUpdates = {
+        'status': row['status'],
+        'spent_seconds': row['spent_seconds'],
+        'started_at': row['started_at'],
+        'captured_by_workplace_id': row['captured_by_workplace_id'],
+        'captured_at': row['captured_at'],
+        'captured_by_user_id': row['captured_by_user_id'],
+      };
+      previousComments = _normalizeComments(row['comments']);
+      final comments = previousComments
+          .map((comment) => Map<String, dynamic>.from(comment))
+          .toList(growable: true);
+      comments.add({
+        'id': commentId,
+        'type': 'problem',
+        'text': text,
+        'userId': userId,
+        'timestamp': timestamp,
+      });
+
+      for (final subjectUserId in normalizedSubjects) {
+        final openIndex = _findOpenTimeEventIndex(comments, subjectUserId);
+        if (openIndex != null) {
+          final open = comments[openIndex];
+          final openEvent = TaskTimeEvent.fromPayload(
+            open['text']?.toString() ?? '',
+            open['id']?.toString() ?? '',
+            _parseCommentTimestamp(open['timestamp']),
+            open['userId']?.toString() ?? '',
+          );
+          if (openEvent != null && openEvent.endTime == null) {
+            open['text'] = TaskTimeEvent.encodePayload(
+              openEvent.copyWith(endTime: now, note: text),
+            );
+          }
+        }
+
+        final event = TaskTimeEvent(
+          id: '$timestamp-$subjectUserId',
+          type: TaskTimeType.problem,
+          startTime: now,
+          endTime: null,
+          initiatedBy: userId,
+          subjectUserId: subjectUserId,
+          taskId: localTask.id,
+          workplaceId: workplaceId ?? localTask.stageId,
+          participantsSnapshot: participantsSnapshot,
+          executionMode: executionMode,
+          helperId: subjectUserId == userId ? null : subjectUserId,
+          note: text,
+        );
+        comments.add({
+          'id': event.id,
+          'type': 'time_event',
+          'text': TaskTimeEvent.encodePayload(event),
+          'userId': subjectUserId,
+          'timestamp': timestamp,
+        });
+      }
+
+      comments.sort((a, b) => _parseCommentTimestamp(a['timestamp'])
+          .compareTo(_parseCommentTimestamp(b['timestamp'])));
+      await _supabase
+          .from('tasks')
+          .update({'comments': comments}).eq('id', taskId);
+      commentsPersisted = true;
+
+      final spentSeconds = localTask.startedAt == null
+          ? localTask.spentSeconds
+          : localTask.spentSeconds +
+              ((DateTime.now().millisecondsSinceEpoch - localTask.startedAt!) ~/
+                  1000);
+      final updates = <String, dynamic>{
+        'status': TaskStatus.problem.name,
+        'spent_seconds': spentSeconds,
+        'started_at': null,
+        'captured_by_workplace_id': null,
+        'captured_at': null,
+        'captured_by_user_id': null,
+      };
+      final statusRows = await _supabase
+          .from('tasks')
+          .update(updates)
+          .eq('id', taskId)
+          .eq('status', TaskStatus.inProgress.name)
+          .select();
+      if ((statusRows as List).isEmpty) {
+        await _supabase
+            .from('tasks')
+            .update({'comments': previousComments}).eq('id', taskId);
+        await cleanupUploads();
+        await refresh();
+        return false;
+      }
+
+      statusPersisted = true;
+
+      final groupKey = localTask.stageGroupKey.trim();
+      if (groupKey.isNotEmpty) {
+        await _supabase
+            .from('tasks')
+            .update({
+              'status': TaskStatus.problem.name,
+              'spent_seconds': spentSeconds,
+              'started_at': null,
+              'captured_by_workplace_id': null,
+              'captured_at': null,
+              'captured_by_user_id': null,
+            })
+            .eq('order_id', localTask.orderId)
+            .eq('stage_group_key', groupKey);
+      }
+
+      await _syncStageGroupStatusToSharedSources(
+        localTask.copyWith(
+          status: TaskStatus.problem,
+          spentSeconds: spentSeconds,
+          startedAt: null,
+          clearStartedAt: true,
+        ),
+        TaskStatus.problem,
+        spentSeconds: spentSeconds,
+        startedAt: null,
+      );
+
+      if (uploaded.isNotEmpty) {
+        _attachmentsByComment[commentId] = uploaded;
+      }
+      await refresh();
+      notifyListeners();
+      return true;
+    } catch (e, st) {
+      if (statusPersisted && previousTaskUpdates != null) {
+        try {
+          await _supabase
+              .from('tasks')
+              .update(previousTaskUpdates)
+              .eq('id', taskId);
+        } catch (_) {}
+      }
+      if (commentsPersisted) {
+        try {
+          await _supabase
+              .from('tasks')
+              .update({'comments': previousComments}).eq('id', taskId);
+        } catch (_) {}
+      }
+      await cleanupUploads();
+      debugPrint('❌ reportProblem error: $e\n$st');
+      rethrow;
+    }
+  }
+
   Future<void> createCommentWithAttachments({
     required String taskId,
     required String type,

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1,14 +1,8 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
-import 'dart:typed_data';
-import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:mime/mime.dart';
 import 'package:open_filex/open_filex.dart';
-import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -3081,90 +3075,17 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
 
-  List<int>? _mimeHeader(Uint8List bytes) {
-    if (bytes.isEmpty) return null;
-    return bytes.length > 16 ? bytes.sublist(0, 16) : bytes;
-  }
-
-  Future<Uint8List> _readPickedFileBytes(PlatformFile file) async {
-    if (file.bytes != null) return file.bytes!;
-    if (file.readStream != null) {
-      final builder = BytesBuilder(copy: false);
-      await for (final chunk in file.readStream!) {
-        builder.add(chunk);
-      }
-      return builder.takeBytes();
-    }
-    final path = file.path;
-    if (path == null) throw Exception('Не удалось прочитать файл');
-    return File(path).readAsBytes();
-  }
-
   bool get _shouldUseFilePickerForMedia =>
-      kIsWeb ||
-      defaultTargetPlatform == TargetPlatform.windows ||
-      defaultTargetPlatform == TargetPlatform.macOS ||
-      defaultTargetPlatform == TargetPlatform.linux;
+      AttachmentService.shouldUseFilePickerForMedia;
 
   Future<void> _pickCommentAttachment({
     required String source,
     required void Function(void Function()) updateDialogState,
   }) async {
     try {
-      AttachmentDraft? draft;
-      if (_shouldUseFilePickerForMedia && source != 'file') {
-        await _pickCommentAttachment(
-          source: 'file',
-          updateDialogState: updateDialogState,
-        );
-        return;
-      }
-      if (source == 'camera') {
-        final image = await ImagePicker().pickImage(
-          source: ImageSource.camera,
-          imageQuality: 85,
-        );
-        if (image == null) return;
-        final bytes = await image.readAsBytes();
-        draft = AttachmentDraft(
-          bytes: bytes,
-          fileName: image.name.isNotEmpty ? image.name : p.basename(image.path),
-          mimeType: lookupMimeType(image.path, headerBytes: _mimeHeader(bytes)) ?? 'image/jpeg',
-        );
-      } else if (source == 'photo') {
-        final image = await ImagePicker().pickImage(
-          source: ImageSource.gallery,
-          imageQuality: 85,
-        );
-        if (image == null) return;
-        final bytes = await image.readAsBytes();
-        draft = AttachmentDraft(
-          bytes: bytes,
-          fileName: image.name.isNotEmpty ? image.name : p.basename(image.path),
-          mimeType: lookupMimeType(image.path, headerBytes: _mimeHeader(bytes)) ?? 'image/jpeg',
-        );
-      } else if (source == 'video') {
-        final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
-        if (video == null) return;
-        final bytes = await video.readAsBytes();
-        draft = AttachmentDraft(
-          bytes: bytes,
-          fileName: video.name.isNotEmpty ? video.name : p.basename(video.path),
-          mimeType: lookupMimeType(video.path, headerBytes: _mimeHeader(bytes)) ?? 'video/mp4',
-        );
-      } else {
-        final result = await FilePicker.platform.pickFiles(withReadStream: true);
-        if (result == null || result.files.isEmpty) return;
-        final file = result.files.first;
-        final bytes = await _readPickedFileBytes(file);
-        draft = AttachmentDraft(
-          bytes: bytes,
-          fileName: file.name,
-          mimeType: lookupMimeType(file.path ?? file.name, headerBytes: _mimeHeader(bytes)) ??
-              'application/octet-stream',
-        );
-      }
-      updateDialogState(() => _pendingCommentAttachments.add(draft!));
+      final draft = await AttachmentService().pickAttachmentDraft(source: source);
+      if (draft == null) return;
+      updateDialogState(() => _pendingCommentAttachments.add(draft));
     } catch (error) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -4879,8 +4800,9 @@ class _TasksScreenState extends State<TasksScreen>
                             (stateRowUser == UserRunState.active &&
                                 isSetupActiveForRow));
                     final bool shouldShowContinueLabel =
-                        stateRowUser == UserRunState.finished &&
-                            stageExecMode == ExecutionMode.separate;
+                        stateRowUser == UserRunState.problem ||
+                            (stateRowUser == UserRunState.finished &&
+                                stageExecMode == ExecutionMode.separate);
                     final bool canPauseRow = isMyRow &&
                         canPause &&
                         stateRowUser == UserRunState.active;
@@ -5288,18 +5210,35 @@ class _TasksScreenState extends State<TasksScreen>
                       );
                       if (problemDraft == null) return;
                       final comment = problemDraft.text;
-                      await context.read<TaskProvider>().createCommentWithAttachments(
-                            taskId: task.id,
-                            type: 'problem',
-                            text: comment,
-                            userId: widget.employeeId,
-                            attachments: problemDraft.attachments,
-                          );
-                      await recordTimeEventForUser(TaskTimeType.problem,
-                          note: comment);
-                      await context
-                          .read<TaskProvider>()
-                          .updateStatus(task.id, TaskStatus.problem);
+                      final subjects = <String>[currentRowUserId];
+                      if (jointGroup != null && isMyRow) {
+                        subjects
+                          ..clear()
+                          ..addAll(jointGroup);
+                      }
+                      final saved = await taskProvider.reportProblem(
+                        taskId: task.id,
+                        text: comment,
+                        userId: widget.employeeId,
+                        participantsSnapshot:
+                            _participantsSnapshot(task, widget.employeeId),
+                        subjectUserIds: subjects,
+                        workplaceId: task.stageId,
+                        executionMode: _executionModeCode(
+                          stageExecMode ??
+                              _execModeForUser(task, widget.employeeId),
+                        ),
+                        attachments: problemDraft.attachments,
+                      );
+                      if (!saved && context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text(
+                              'Проблему можно зафиксировать только для этапа в работе.',
+                            ),
+                          ),
+                        );
+                      }
                     }
 
                     Future<void> onAddHelper() async {
@@ -5850,7 +5789,9 @@ class _TasksScreenState extends State<TasksScreen>
                                       ),
                                       child: Text(
                                           shouldShowContinueLabel
-                                              ? '▶ Продолжить'
+                                              ? (stateRowUser == UserRunState.problem
+                                                  ? '↩ Вернуть в работу'
+                                                  : '▶ Продолжить')
                                               : '▶ Начать')),
                                   ElevatedButton(
                                       onPressed: canPauseRow ? onPause : null,
@@ -6645,31 +6586,24 @@ class _TasksScreenState extends State<TasksScreen>
     );
     if (problemDraft == null) return;
     final comment = problemDraft.text;
-    final seconds = _elapsed(task).inSeconds;
-
-    await provider.updateStatus(
-      task.id,
-      TaskStatus.problem,
-      spentSeconds: seconds,
-      startedAt: null,
-    );
-
-    await provider.createCommentWithAttachments(
+    final saved = await provider.reportProblem(
       taskId: task.id,
-      type: 'problem',
       text: comment,
       userId: widget.employeeId,
+      participantsSnapshot: _participantsSnapshot(task, widget.employeeId),
+      subjectUserIds: [widget.employeeId],
+      workplaceId: task.stageId,
+      executionMode: _executionModeCode(_execModeForUser(task, widget.employeeId)),
       attachments: problemDraft.attachments,
     );
-    await provider.recordTimeEvent(
-      task: task,
-      type: TaskTimeType.problem,
-      initiatedBy: widget.employeeId,
-      subjectUserId: widget.employeeId,
-      workplaceId: task.stageId,
-      participantsSnapshot: _participantsSnapshot(task, widget.employeeId),
-      note: comment,
-    );
+    if (!saved && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Проблему можно зафиксировать только для этапа в работе.'),
+        ),
+      );
+      return;
+    }
 
     final analytics = context.read<AnalyticsProvider>();
     await analytics.logEvent(
@@ -6681,6 +6615,7 @@ class _TasksScreenState extends State<TasksScreen>
       details: comment,
     );
   }
+
 
   List<_StageComment> _collectOrderComments(
       TaskProvider provider, TaskModel pivot) {

--- a/lib/services/attachment_service.dart
+++ b/lib/services/attachment_service.dart
@@ -1,5 +1,10 @@
+import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:image_picker/image_picker.dart';
 import 'package:mime/mime.dart';
 import 'package:path/path.dart' as p;
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -30,6 +35,92 @@ class AttachmentService {
 
   final SupabaseClient _supabase;
   final Uuid _uuid = const Uuid();
+
+
+  static bool get shouldUseFilePickerForMedia =>
+      kIsWeb ||
+      defaultTargetPlatform == TargetPlatform.windows ||
+      defaultTargetPlatform == TargetPlatform.macOS ||
+      defaultTargetPlatform == TargetPlatform.linux;
+
+  List<int>? _mimeHeader(Uint8List bytes) {
+    if (bytes.isEmpty) return null;
+    return bytes.take(bytes.length < 16 ? bytes.length : 16).toList();
+  }
+
+  Future<Uint8List> _readPickedFileBytes(PlatformFile file) async {
+    if (file.bytes != null) return file.bytes!;
+    if (file.readStream != null) {
+      final builder = BytesBuilder(copy: false);
+      await for (final chunk in file.readStream!) {
+        builder.add(chunk);
+      }
+      return builder.takeBytes();
+    }
+    final path = file.path;
+    if (path == null) throw Exception('Не удалось прочитать файл');
+    return File(path).readAsBytes();
+  }
+
+  Future<AttachmentDraft?> pickAttachmentDraft({required String source}) async {
+    if (shouldUseFilePickerForMedia && source != 'file') {
+      return pickAttachmentDraft(source: 'file');
+    }
+
+    if (source == 'camera') {
+      final image = await ImagePicker().pickImage(
+        source: ImageSource.camera,
+        imageQuality: 85,
+      );
+      if (image == null) return null;
+      final bytes = await image.readAsBytes();
+      return AttachmentDraft(
+        bytes: bytes,
+        fileName: image.name.isNotEmpty ? image.name : p.basename(image.path),
+        mimeType: lookupMimeType(image.path, headerBytes: _mimeHeader(bytes)) ??
+            'image/jpeg',
+      );
+    }
+
+    if (source == 'photo') {
+      final image = await ImagePicker().pickImage(
+        source: ImageSource.gallery,
+        imageQuality: 85,
+      );
+      if (image == null) return null;
+      final bytes = await image.readAsBytes();
+      return AttachmentDraft(
+        bytes: bytes,
+        fileName: image.name.isNotEmpty ? image.name : p.basename(image.path),
+        mimeType: lookupMimeType(image.path, headerBytes: _mimeHeader(bytes)) ??
+            'image/jpeg',
+      );
+    }
+
+    if (source == 'video') {
+      final video = await ImagePicker().pickVideo(source: ImageSource.gallery);
+      if (video == null) return null;
+      final bytes = await video.readAsBytes();
+      return AttachmentDraft(
+        bytes: bytes,
+        fileName: video.name.isNotEmpty ? video.name : p.basename(video.path),
+        mimeType: lookupMimeType(video.path, headerBytes: _mimeHeader(bytes)) ??
+            'video/mp4',
+      );
+    }
+
+    final result = await FilePicker.platform.pickFiles(withReadStream: true);
+    if (result == null || result.files.isEmpty) return null;
+    final file = result.files.first;
+    final bytes = await _readPickedFileBytes(file);
+    return AttachmentDraft(
+      bytes: bytes,
+      fileName: file.name,
+      mimeType: lookupMimeType(file.path ?? file.name,
+              headerBytes: _mimeHeader(bytes)) ??
+          'application/octet-stream',
+    );
+  }
 
   String detectFileType(String mimeType, {String? fileName}) {
     final normalized = mimeType.toLowerCase().trim();


### PR DESCRIPTION
### Motivation

- Устранить дублирование логики фиксации проблемы и обеспечить атомарный, откатываемый путь: загрузка файлов → запись комментария/problem time event → перевод задачи в `problem` → освобождение захвата рабочего места. 
- Вынести выбор/чтение вложений в общий сервис, чтобы диалоги проблемы и другие места использовали единый механизм работы с фото/видео/файлами.

### Description

- Added `TaskProvider.reportProblem(...)` which: проверяет, что задача в `inProgress`, загружает файлы в Storage, добавляет комментарий типа `problem` и соответствующие `time_event` записи, сохраняет metadata вложений, переводит задачу/группу этапов в `TaskStatus.problem`, освобождает захват рабочего места и синхронизирует статус группы; при ошибке откатывает DB изменения и удаляет загруженные Storage объекты. (lib/modules/tasks/task_provider.dart)
- Вынес логику выбора/чтения вложений в `AttachmentService.pickAttachmentDraft(...)` и хелперы (`shouldUseFilePickerForMedia`, `_readPickedFileBytes`, `_mimeHeader`) с поддержкой camera/gallery/file picker и корректной детекцией MIME. (lib/services/attachment_service.dart)
- Заменил локальную логику выбора вложений в UI на вызов `AttachmentService`, и перевёл все точки фиксации проблемы (диалог кнопки и internal handler) на новый `reportProblem(...)`. UI теперь использует общий flow и показывает ошибку, если этап уже не в работе. (lib/modules/tasks/tasks_screen.dart)
- Добавил откат uploaded storage objects если сохранение metadata комментария/статуса не удалось (в `reportProblem`). (lib/modules/tasks/task_provider.dart)
- Оставил и явно поддержал отображение статуса `problem` в модуле управления производством (не приравнивается к `completed`), и добавил действие/метку для возобновления работы из `problem` ("↩ Вернуть в работу"). (lib/modules/production/production_screen.dart, lib/modules/tasks/tasks_screen.dart)
- Снижено дублирование: удалён второй порядок операций для проблемы (`_handleProblem`/onProblem теперь используют `reportProblem`). (lib/modules/tasks/tasks_screen.dart)

### Testing

- Запущена проверка стиля/целостности `git diff --check`, она прошла успешно in this environment. 
- Попытки запустить `flutter test` и `dart format` не выполнились в CI-контейнере из-за отсутствия Flutter/Dart (`flutter: command not found`, `dart: command not found`).
- В ходе изменения выполнены локальные grep/inspection, и интеграция UI заменена на вызовы нового API; не было запущено полного набора unit/widget тестов в текущем окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06223c4e54832f870d8d1fbee15f0e)