### PR TITLE
Fix task problem reporting provider reference

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5183,7 +5183,7 @@ class _TasksScreenState extends State<TasksScreen>
                           ..clear()
                           ..addAll(jointGroup);
                       }
-                      final saved = await taskProvider.reportProblem(
+                      final saved = await tp.reportProblem(
                         taskId: task.id,
                         text: comment,
                         userId: widget.employeeId,


### PR DESCRIPTION
### Motivation
- Fix a build-time error where `_TasksScreenState` attempted to call `reportProblem` on an undefined `taskProvider` identifier by using the in-scope `TaskProvider` variable.

### Description
- Replaced the undefined `taskProvider.reportProblem(...)` call with the available `tp.reportProblem(...)` in `lib/modules/tasks/tasks_screen.dart` so the `reportProblem` call uses the correct provider instance.

### Testing
- Ran `git diff --check` which reported no issues; `dart --version` and `flutter --version` were not available in this environment so a full Flutter build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06c587c804832faf08dfc835d1f8ce)