### PR TITLE
Обновить контракт завершения флексопечати — поддержка очереди списаний красок

### DIFF
--- a/lib/modules/orders/orders_repository.dart
+++ b/lib/modules/orders/orders_repository.dart
@@ -299,6 +299,23 @@ class OrdersRepository {
     return const [];
   }
 
+  Future<List<Map<String, dynamic>>> getPendingPaintWriteoffs({
+    String? excludeOrderId,
+  }) async {
+    final query = _sb
+        .from('order_paint_pending_writeoffs')
+        .select('id, order_id, task_id, stage_id, stage_name, paint_id, '
+            'paint_name, planned_amount, actual_used_amount, unit, status')
+        .eq('status', 'pending');
+    final rows = (excludeOrderId ?? '').trim().isEmpty
+        ? await query.order('created_at')
+        : await query.neq('order_id', excludeOrderId!.trim()).order('created_at');
+    if (rows is List) {
+      return rows.cast<Map<String, dynamic>>();
+    }
+    return const [];
+  }
+
   Future<void> completeTaskStage({
     required String taskId,
     required String orderId,
@@ -327,55 +344,130 @@ class OrdersRepository {
     required String orderId,
     required String stageId,
     required String employeeId,
-    required List<Map<String, dynamic>> paintUsages,
+    List<Map<String, dynamic>> currentOrderRows = const <Map<String, dynamic>>[],
+    List<Map<String, dynamic>> pendingRows = const <Map<String, dynamic>>[],
+    List<Map<String, dynamic>>? paintUsages,
     String? quantityDone,
     String? comment,
     String? actor,
   }) async {
     await ensureSignedIn();
-    final usages = paintUsages
-        .where((row) =>
-            row['write_off_now'] != false && row['writeOffNow'] != false)
-        .map((row) {
-          final usedQty = (row['used_qty'] is num)
-              ? (row['used_qty'] as num).toDouble()
-              : double.tryParse(
-                  (row['used_qty'] ?? row['qty_g'] ?? row['qty_grams'] ?? '')
-                      .toString()
-                      .replaceAll(',', '.'),
-                );
-          final qtyKg = (row['qty_kg'] is num)
-              ? (row['qty_kg'] as num).toDouble()
-              : double.tryParse(
-                  (row['qty_kg'] ?? '').toString().replaceAll(',', '.'),
-                );
-          final name =
-              (row['paint_name'] ?? row['name'] ?? '').toString().trim();
-          final paintId = (row['paint_id'] ?? row['material_id'] ?? '')
-              .toString()
-              .trim();
-          return <String, dynamic>{
-            if (paintId.isNotEmpty) 'paint_id': paintId,
-            if (name.isNotEmpty) 'paint_name': name,
-            'used_qty': usedQty ?? ((qtyKg ?? 0) * 1000),
-          };
-        })
-        .where((row) =>
-            (((row['paint_id'] ?? '') as String).isNotEmpty ||
-                ((row['paint_name'] ?? '') as String).isNotEmpty) &&
-            ((row['used_qty'] as num?)?.toDouble() ?? 0) > 0)
-        .toList(growable: false);
+    final effectiveCurrentRows = currentOrderRows.isNotEmpty
+        ? currentOrderRows
+        : (paintUsages ?? const <Map<String, dynamic>>[]);
 
-    await _sb.rpc('complete_flex_printing_stage', params: {
+    await _sb.rpc('complete_flex_printing_stage_with_paint_queue', params: {
       'p_task_id': taskId,
       'p_order_id': orderId,
       'p_stage_id': stageId,
       'p_employee_id': employeeId,
-      'p_paint_usages': usages,
+      'p_current_order_rows': effectiveCurrentRows
+          .map((row) => _paintQueueRpcRow(
+                row,
+                fallbackOrderId: orderId,
+                fallbackTaskId: taskId,
+              ))
+          .toList(growable: false),
+      'p_pending_rows': pendingRows
+          .map((row) => _paintQueueRpcRow(row))
+          .toList(growable: false),
       'p_quantity_done': quantityDone,
       'p_comment': comment,
       'p_actor': actor ?? '',
     });
+  }
+
+  Map<String, dynamic> _paintQueueRpcRow(
+    Map<String, dynamic> row, {
+    String? fallbackOrderId,
+    String? fallbackTaskId,
+  }) {
+    final pendingWriteoffId = _trimmedString(row, const [
+      'pending_writeoff_id',
+      'pendingWriteoffId',
+      'id',
+    ]);
+    final sourceOrderId = _trimmedString(row, const [
+      'source_order_id',
+      'sourceOrderId',
+      'order_id',
+      'orderId',
+    ], fallback: fallbackOrderId);
+    final sourceTaskId = _trimmedString(row, const [
+      'source_task_id',
+      'sourceTaskId',
+      'task_id',
+      'taskId',
+    ], fallback: fallbackTaskId);
+    final paintId = _trimmedString(row, const [
+      'paint_id',
+      'paintId',
+      'material_id',
+    ]);
+    final paintName = _trimmedString(row, const [
+      'paint_name',
+      'paintName',
+      'name',
+    ]);
+    final unit = _trimmedString(row, const ['unit'], fallback: 'г');
+    final actualUsedAmount = _readDouble(row, const [
+      'actual_used_amount',
+      'actualUsedAmount',
+      'used_qty',
+      'qty_g',
+      'qty_grams',
+    ]) ?? (_readDouble(row, const ['qty_kg']) == null
+        ? null
+        : _readDouble(row, const ['qty_kg'])! * 1000);
+    final plannedAmount = _readDouble(row, const [
+      'planned_amount',
+      'plannedAmount',
+      'planned_qty',
+      'planned_qty_g',
+      'reserved_qty',
+    ]) ?? (_readDouble(row, const ['qty_kg']) == null
+        ? null
+        : _readDouble(row, const ['qty_kg'])! * 1000);
+    final writeOffNow = row['write_off_now'] == true ||
+        row['writeOffNow'] == true ||
+        row['write_off_now']?.toString().toLowerCase() == 'true' ||
+        row['writeOffNow']?.toString().toLowerCase() == 'true';
+
+    return _cleanForInsert({
+      if (pendingWriteoffId.isNotEmpty) 'pending_writeoff_id': pendingWriteoffId,
+      if (sourceOrderId.isNotEmpty) 'source_order_id': sourceOrderId,
+      if (sourceTaskId.isNotEmpty) 'source_task_id': sourceTaskId,
+      if (paintId.isNotEmpty) 'paint_id': paintId,
+      if (paintName.isNotEmpty) 'paint_name': paintName,
+      'actual_used_amount': actualUsedAmount,
+      'planned_amount': plannedAmount,
+      'unit': unit.isEmpty ? 'г' : unit,
+      'write_off_now': writeOffNow,
+    });
+  }
+
+  String _trimmedString(
+    Map<String, dynamic> row,
+    List<String> keys, {
+    String? fallback,
+  }) {
+    for (final key in keys) {
+      final value = (row[key] ?? '').toString().trim();
+      if (value.isNotEmpty) return value;
+    }
+    return (fallback ?? '').trim();
+  }
+
+  double? _readDouble(Map<String, dynamic> row, List<String> keys) {
+    for (final key in keys) {
+      final value = row[key];
+      if (value is num) return value.toDouble();
+      final parsed = double.tryParse(
+        (value ?? '').toString().trim().replaceAll(',', '.'),
+      );
+      if (parsed != null) return parsed;
+    }
+    return null;
   }
 
   Future<List<Map<String, dynamic>>> getPaints(String orderId) async {

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4037,6 +4037,18 @@ class _TasksScreenState extends State<TasksScreen>
     return '';
   }
 
+  bool _isPendingPaintRow(Map<String, dynamic> row) {
+    final normalized = _stringFromRow(row, const [
+      'source',
+      'writeoff_source',
+      'write_off_source',
+    ]).trim().toLowerCase();
+    return normalized == 'pending' ||
+        normalized == 'pending_queue' ||
+        normalized == 'queued' ||
+        normalized == 'writeoff_queue';
+  }
+
   FlexPaintWriteoffRow _paintWriteoffRowFromMap(
     Map<String, dynamic> row,
     String? defaultUnit,
@@ -4268,24 +4280,26 @@ class _TasksScreenState extends State<TasksScreen>
                       controllers[row]?.text ?? row.actualUsedText;
                   row.actualUsedText = enteredText;
                   row.refreshStatus();
+                  final actualGrams = _parsePositiveGrams(enteredText);
                   final output = Map<String, dynamic>.from(row.sourceRow)
                     ..addAll({
                       'source': row.source,
                       'queue_id': row.queueId,
                       'order_id': row.orderId,
+                      'source_order_id': row.orderId,
                       'order_label': row.orderLabel,
                       'paint_id': row.paintId,
                       'paint_name': row.paintName,
                       'planned_amount': row.plannedAmount,
                       'unit': row.unit,
                       'actual_used_text': row.actualUsedText,
+                      'actual_used_amount': actualGrams,
                       'write_off_now': row.writeOffNow,
                       'status': row.status,
                     });
 
                   if (row.writeOffNow) {
-                    final grams = _parsePositiveGrams(enteredText);
-                    if (grams == null) {
+                    if (actualGrams == null) {
                       ScaffoldMessenger.of(ctx).showSnackBar(
                         const SnackBar(
                           content: Text(
@@ -4295,8 +4309,9 @@ class _TasksScreenState extends State<TasksScreen>
                       );
                       return;
                     }
-                    output['used_qty'] = grams;
-                    output['qty_kg'] = _gramsToKilogramsForPersistence(grams);
+                    output['used_qty'] = actualGrams;
+                    output['qty_kg'] =
+                        _gramsToKilogramsForPersistence(actualGrams);
                   }
                   resultRows.add(output);
                 }
@@ -4496,6 +4511,9 @@ class _TasksScreenState extends State<TasksScreen>
       try {
         final repo = OrdersRepository();
         initialPaints = await repo.getPaints(task.orderId);
+        final pendingWriteoffs = await repo.getPendingPaintWriteoffs(
+          excludeOrderId: task.orderId,
+        );
         final reservations = await repo.getPaintReservations(task.orderId);
         final order = _orderById(task.orderId);
         final orderLabel =
@@ -4510,7 +4528,7 @@ class _TasksScreenState extends State<TasksScreen>
           if (id.isNotEmpty) reservationsByKey['id:$id'] = reservation;
           if (name.isNotEmpty) reservationsByKey['name:$name'] = reservation;
         }
-        initialPaints = initialPaints.map((paint) {
+        final currentPaints = initialPaints.map((paint) {
           final merged = Map<String, dynamic>.from(paint);
           final id = (merged['paint_id'] ?? merged['material_id'] ?? '')
               .toString()
@@ -4525,6 +4543,8 @@ class _TasksScreenState extends State<TasksScreen>
           merged.addAll({
             'source': 'current_order',
             'order_id': task.orderId,
+            'source_order_id': task.orderId,
+            'source_task_id': task.id,
             'order_label': orderLabel,
           });
           if (reservation != null) {
@@ -4540,6 +4560,25 @@ class _TasksScreenState extends State<TasksScreen>
           }
           return merged;
         }).toList(growable: false);
+        final pendingPaints = pendingWriteoffs.map((pending) {
+          final row = Map<String, dynamic>.from(pending);
+          return row
+            ..addAll({
+              'source': 'pending',
+              'pending_writeoff_id': row['id'],
+              'order_id': row['order_id'],
+              'source_order_id': row['order_id'],
+              'source_task_id': row['task_id'],
+              'order_label': row['order_id'] ?? 'Заказ',
+              'planned_amount': row['planned_amount'],
+              'actual_used_amount': row['actual_used_amount'],
+              'actual_used_text': row['actual_used_amount']?.toString() ?? '',
+            });
+        }).toList(growable: false);
+        initialPaints = <Map<String, dynamic>>[
+          ...currentPaints,
+          ...pendingPaints,
+        ];
       } catch (e) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -4618,7 +4657,12 @@ class _TasksScreenState extends State<TasksScreen>
           orderId: task.orderId,
           stageId: task.stageId,
           employeeId: widget.employeeId,
-          paintUsages: paints,
+          currentOrderRows: paints
+              .where((row) => !_isPendingPaintRow(row))
+              .toList(growable: false),
+          pendingRows: paints
+              .where(_isPendingPaintRow)
+              .toList(growable: false),
           quantityDone: qtyInput?.displayText,
           comment: note,
         );

--- a/supabase/migrations/20260515_complete_flex_printing_stage_paint_queue.sql
+++ b/supabase/migrations/20260515_complete_flex_printing_stage_paint_queue.sql
@@ -1,0 +1,441 @@
+-- Complete flex printing and atomically handle current-order and queued paint write-offs.
+
+create or replace function public.complete_flex_printing_stage_with_paint_queue(
+  p_task_id text,
+  p_order_id text,
+  p_stage_id text,
+  p_employee_id text,
+  p_current_order_rows jsonb default '[]'::jsonb,
+  p_pending_rows jsonb default '[]'::jsonb,
+  p_quantity_done text default null,
+  p_comment text default null,
+  p_actor text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_task tasks%rowtype;
+  v_pending order_paint_pending_writeoffs%rowtype;
+  rec record;
+  v_paint_id text;
+  v_paint_name text;
+  v_stock_name text;
+  v_stock_qty double precision;
+  v_reserved_other double precision;
+  v_available double precision;
+  v_amount double precision;
+  v_source_order_id text;
+  v_source_task_id text;
+  v_pending_writeoff_id uuid;
+  v_unit text;
+  v_rows_updated integer;
+  v_now_ms bigint := floor(extract(epoch from clock_timestamp()) * 1000);
+  v_comments jsonb;
+  v_touched text[] := array[]::text[];
+  v_user_id text := coalesce(nullif(trim(p_employee_id), ''), nullif(trim(p_actor), ''), 'system');
+  v_assignee text;
+begin
+  if coalesce(trim(p_task_id), '') = '' then raise exception 'task_id is required'; end if;
+  if coalesce(trim(p_order_id), '') = '' then raise exception 'order_id is required'; end if;
+  if coalesce(trim(p_stage_id), '') = '' then raise exception 'stage_id is required'; end if;
+  if p_current_order_rows is null then p_current_order_rows := '[]'::jsonb; end if;
+  if p_pending_rows is null then p_pending_rows := '[]'::jsonb; end if;
+
+  select * into v_task
+    from tasks
+   where id = p_task_id and order_id = p_order_id and stage_id = p_stage_id
+   for update;
+  if not found then
+    raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
+  end if;
+  if v_task.status = 'completed' then
+    raise exception 'Этап уже завершен.';
+  end if;
+  if v_task.status not in ('inProgress', 'paused', 'problem', 'waiting', 'pending', 'planned') then
+    raise exception 'Нельзя завершить этап из статуса %.', v_task.status;
+  end if;
+  if v_user_id <> 'system' and array_position(coalesce(v_task.assignees, array[]::text[]), v_user_id) is null then
+    raise exception 'Сотрудник не назначен исполнителем этапа.';
+  end if;
+
+  -- Rows of the current order that were intentionally left unchecked become queued write-offs.
+  for rec in
+    select value as row_data
+      from jsonb_array_elements(p_current_order_rows) value
+     where coalesce((value->>'write_off_now')::boolean, false) = false
+  loop
+    v_paint_id := null;
+    v_paint_name := null;
+    v_stock_name := null;
+    v_stock_qty := null;
+    v_amount := null;
+    v_source_order_id := coalesce(nullif(trim(rec.row_data->>'source_order_id'), ''), p_order_id);
+    v_source_task_id := coalesce(nullif(trim(rec.row_data->>'source_task_id'), ''), p_task_id);
+    v_paint_id := nullif(trim(coalesce(rec.row_data->>'paint_id', rec.row_data->>'material_id')), '');
+    v_paint_name := nullif(trim(coalesce(rec.row_data->>'paint_name', rec.row_data->>'name')), '');
+    v_amount := coalesce(
+      nullif(rec.row_data->>'actual_used_amount', '')::double precision,
+      nullif(rec.row_data->>'planned_amount', '')::double precision,
+      nullif(rec.row_data->>'planned_qty', '')::double precision,
+      nullif(rec.row_data->>'reserved_qty', '')::double precision,
+      nullif(rec.row_data->>'qty_kg', '')::double precision * 1000
+    );
+    v_unit := coalesce(nullif(trim(rec.row_data->>'unit'), ''), 'г');
+
+    if coalesce(v_paint_id, '') = '' and coalesce(v_paint_name, '') = '' then
+      continue;
+    end if;
+    if v_amount is not null and v_amount < 0 then
+      raise exception 'Нельзя поставить в очередь отрицательный расход краски (%).', coalesce(v_paint_name, v_paint_id);
+    end if;
+
+    if v_paint_id is not null then
+      insert into order_paint_pending_writeoffs(
+        order_id, task_id, stage_id, stage_name, paint_id, paint_name,
+        planned_amount, actual_used_amount, unit, status, created_by, comment
+      )
+      values (
+        v_source_order_id,
+        v_source_task_id,
+        p_stage_id,
+        p_stage_id,
+        v_paint_id,
+        v_paint_name,
+        coalesce(nullif(rec.row_data->>'planned_amount', '')::double precision, v_amount),
+        v_amount,
+        v_unit,
+        'pending',
+        v_user_id,
+        'Создано при завершении флексопечати без немедленного списания'
+      )
+      on conflict (
+        order_id,
+        (coalesce(task_id, '')),
+        (coalesce(stage_id, '')),
+        paint_id
+      ) where status = 'pending' and paint_id is not null
+      do update set
+        paint_name = coalesce(excluded.paint_name, order_paint_pending_writeoffs.paint_name),
+        planned_amount = excluded.planned_amount,
+        actual_used_amount = excluded.actual_used_amount,
+        unit = excluded.unit,
+        updated_at = now();
+    else
+      insert into order_paint_pending_writeoffs(
+        order_id, task_id, stage_id, stage_name, paint_id, paint_name,
+        planned_amount, actual_used_amount, unit, status, created_by, comment
+      )
+      values (
+        v_source_order_id,
+        v_source_task_id,
+        p_stage_id,
+        p_stage_id,
+        null,
+        v_paint_name,
+        coalesce(nullif(rec.row_data->>'planned_amount', '')::double precision, v_amount),
+        v_amount,
+        v_unit,
+        'pending',
+        v_user_id,
+        'Создано при завершении флексопечати без немедленного списания'
+      )
+      on conflict (
+        order_id,
+        (coalesce(task_id, '')),
+        (coalesce(stage_id, '')),
+        (lower(trim(paint_name)))
+      ) where status = 'pending'
+          and paint_id is null
+          and coalesce(trim(paint_name), '') <> ''
+      do update set
+        planned_amount = excluded.planned_amount,
+        actual_used_amount = excluded.actual_used_amount,
+        unit = excluded.unit,
+        updated_at = now();
+    end if;
+  end loop;
+
+  -- Current-order rows checked by the operator are written off immediately.
+  for rec in
+    select value as row_data
+      from jsonb_array_elements(p_current_order_rows) value
+     where coalesce((value->>'write_off_now')::boolean, false) = true
+  loop
+    v_paint_id := null;
+    v_paint_name := null;
+    v_stock_name := null;
+    v_stock_qty := null;
+    v_amount := null;
+    v_source_order_id := coalesce(nullif(trim(rec.row_data->>'source_order_id'), ''), p_order_id);
+    v_paint_id := nullif(trim(coalesce(rec.row_data->>'paint_id', rec.row_data->>'material_id')), '');
+    v_paint_name := nullif(trim(coalesce(rec.row_data->>'paint_name', rec.row_data->>'name')), '');
+    v_amount := coalesce(
+      nullif(rec.row_data->>'actual_used_amount', '')::double precision,
+      nullif(rec.row_data->>'used_qty', '')::double precision,
+      nullif(rec.row_data->>'qty_g', '')::double precision,
+      nullif(rec.row_data->>'qty_grams', '')::double precision,
+      nullif(rec.row_data->>'qty_kg', '')::double precision * 1000,
+      0
+    );
+    if v_amount <= 0 then
+      raise exception 'Для краски % укажите фактический расход больше 0.', coalesce(v_paint_name, v_paint_id, 'без названия');
+    end if;
+
+    if v_paint_id is null then
+      select p.id, p.description into v_paint_id, v_paint_name
+        from paints p
+       where v_paint_name is not null and lower(trim(p.description)) = lower(trim(v_paint_name))
+       order by p.id
+       limit 1
+       for update;
+    else
+      select p.description, p.quantity into v_stock_name, v_stock_qty
+        from paints p
+       where p.id = v_paint_id
+       for update;
+    end if;
+    if v_stock_qty is null then
+      select p.description, p.quantity into v_stock_name, v_stock_qty
+        from paints p
+       where p.id = v_paint_id
+       for update;
+    end if;
+    if v_paint_id is null or v_stock_qty is null then
+      raise exception 'Краска % не найдена на складе.', coalesce(v_paint_name, v_paint_id);
+    end if;
+
+    select coalesce(sum(greatest(r.reserved_qty - r.used_qty - r.released_qty, 0)), 0)
+      into v_reserved_other
+      from order_paint_reservations r
+     where r.paint_id = v_paint_id
+       and r.order_id <> v_source_order_id;
+    v_available := v_stock_qty - v_reserved_other;
+    if v_available < v_amount then
+      raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
+        coalesce(v_stock_name, v_paint_name, v_paint_id), round(v_available::numeric, 2), round(v_amount::numeric, 2);
+    end if;
+
+    insert into paints_writeoffs(paint_id, qty, reason, by_name)
+    values (
+      v_paint_id,
+      v_amount,
+      format('Списание флексопечати по заказу %s', v_source_order_id),
+      coalesce(nullif(trim(p_actor), ''), nullif(trim(p_employee_id), ''), 'system')
+    );
+
+    update paints set quantity = greatest(quantity - v_amount, 0) where id = v_paint_id;
+
+    update order_paint_reservations
+       set used_qty = v_amount,
+           released_qty = greatest(reserved_qty - v_amount, 0),
+           paint_name = coalesce(paint_name, v_paint_name, v_stock_name),
+           updated_at = now()
+     where order_id = v_source_order_id and paint_id = v_paint_id;
+    if not found then
+      insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
+      values (v_source_order_id, v_paint_id, coalesce(v_paint_name, v_stock_name), v_amount, v_amount, 0)
+      on conflict (order_id, paint_id) where paint_id is not null
+      do update set used_qty = excluded.used_qty,
+                    released_qty = greatest(order_paint_reservations.reserved_qty - excluded.used_qty, 0),
+                    updated_at = now();
+    end if;
+    v_touched := array_append(v_touched, v_paint_id);
+  end loop;
+
+  -- Previously queued rows are locked and may be consumed only while still pending.
+  for rec in
+    select value as row_data
+      from jsonb_array_elements(p_pending_rows) value
+     where coalesce((value->>'write_off_now')::boolean, false) = true
+  loop
+    v_paint_id := null;
+    v_paint_name := null;
+    v_stock_name := null;
+    v_stock_qty := null;
+    v_amount := null;
+    v_pending_writeoff_id := nullif(trim(rec.row_data->>'pending_writeoff_id'), '')::uuid;
+    if v_pending_writeoff_id is null then
+      raise exception 'Для строки очереди списания не указан pending_writeoff_id.';
+    end if;
+
+    select * into v_pending
+      from order_paint_pending_writeoffs
+     where id = v_pending_writeoff_id
+     for update;
+    if not found then
+      raise exception 'Очередь списания % не найдена.', v_pending_writeoff_id;
+    end if;
+    if v_pending.status <> 'pending' then
+      raise exception 'Краска по заказу % уже обработана или имеет статус %, повторное списание запрещено.', v_pending.order_id, v_pending.status;
+    end if;
+
+    v_source_order_id := coalesce(nullif(trim(rec.row_data->>'source_order_id'), ''), v_pending.order_id);
+    v_source_task_id := coalesce(nullif(trim(rec.row_data->>'source_task_id'), ''), v_pending.task_id);
+    v_paint_id := coalesce(nullif(trim(rec.row_data->>'paint_id'), ''), v_pending.paint_id);
+    v_paint_name := coalesce(nullif(trim(rec.row_data->>'paint_name'), ''), v_pending.paint_name);
+    v_amount := coalesce(
+      nullif(rec.row_data->>'actual_used_amount', '')::double precision,
+      v_pending.actual_used_amount,
+      v_pending.planned_amount,
+      0
+    );
+    if v_amount <= 0 then
+      raise exception 'Для очереди списания % укажите фактический расход больше 0.', v_pending_writeoff_id;
+    end if;
+
+    if v_paint_id is null then
+      select p.id, p.description, p.quantity into v_paint_id, v_stock_name, v_stock_qty
+        from paints p
+       where v_paint_name is not null and lower(trim(p.description)) = lower(trim(v_paint_name))
+       order by p.id
+       limit 1
+       for update;
+    else
+      select p.description, p.quantity into v_stock_name, v_stock_qty
+        from paints p
+       where p.id = v_paint_id
+       for update;
+    end if;
+    if v_paint_id is null or v_stock_qty is null then
+      raise exception 'Краска % не найдена на складе.', coalesce(v_paint_name, v_paint_id);
+    end if;
+
+    select coalesce(sum(greatest(r.reserved_qty - r.used_qty - r.released_qty, 0)), 0)
+      into v_reserved_other
+      from order_paint_reservations r
+     where r.paint_id = v_paint_id
+       and r.order_id <> v_source_order_id;
+    v_available := v_stock_qty - v_reserved_other;
+    if v_available < v_amount then
+      raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
+        coalesce(v_stock_name, v_paint_name, v_paint_id), round(v_available::numeric, 2), round(v_amount::numeric, 2);
+    end if;
+
+    insert into paints_writeoffs(paint_id, qty, reason, by_name)
+    values (
+      v_paint_id,
+      v_amount,
+      format('Списание флексопечати по заказу %s из очереди', v_source_order_id),
+      coalesce(nullif(trim(p_actor), ''), nullif(trim(p_employee_id), ''), 'system')
+    );
+
+    update paints set quantity = greatest(quantity - v_amount, 0) where id = v_paint_id;
+
+    update order_paint_reservations
+       set used_qty = v_amount,
+           released_qty = greatest(reserved_qty - v_amount, 0),
+           paint_name = coalesce(paint_name, v_paint_name, v_stock_name),
+           updated_at = now()
+     where order_id = v_source_order_id and paint_id = v_paint_id;
+    if not found then
+      insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
+      values (v_source_order_id, v_paint_id, coalesce(v_paint_name, v_stock_name), v_amount, v_amount, 0)
+      on conflict (order_id, paint_id) where paint_id is not null
+      do update set used_qty = excluded.used_qty,
+                    released_qty = greatest(order_paint_reservations.reserved_qty - excluded.used_qty, 0),
+                    updated_at = now();
+    end if;
+
+    update order_paint_pending_writeoffs
+       set status = 'written_off',
+           paint_id = v_paint_id,
+           paint_name = coalesce(v_paint_name, v_stock_name),
+           actual_used_amount = v_amount,
+           unit = coalesce(nullif(trim(rec.row_data->>'unit'), ''), v_pending.unit, 'г'),
+           written_off_at = now(),
+           written_off_by = v_user_id,
+           updated_at = now()
+     where id = v_pending_writeoff_id
+       and status = 'pending';
+    get diagnostics v_rows_updated = row_count;
+    if v_rows_updated = 0 then
+      raise exception 'Очередь списания % уже обработана, повторное списание запрещено.', v_pending_writeoff_id;
+    end if;
+
+    v_touched := array_append(v_touched, v_paint_id);
+  end loop;
+
+  for rec in
+    select paint_id
+      from order_paint_reservations
+     where order_id = p_order_id
+       and greatest(reserved_qty - used_qty - released_qty, 0) > 0
+     for update
+  loop
+    update order_paint_reservations
+       set released_qty = greatest(reserved_qty - used_qty, 0),
+           updated_at = now()
+     where order_id = p_order_id and paint_id = rec.paint_id;
+    v_touched := array_append(v_touched, rec.paint_id);
+  end loop;
+
+  perform recalculate_paint_reserved_qty((select array_agg(distinct x) from unnest(v_touched) as x where x is not null));
+
+  v_comments := public.task_comments_to_array(v_task.comments::jsonb);
+
+  if p_quantity_done is not null and trim(p_quantity_done) <> '' then
+    if coalesce(array_length(v_task.assignees, 1), 0) > 1 then
+      v_comments := v_comments || jsonb_build_array(jsonb_build_object(
+        'id', gen_random_uuid()::text,
+        'type', 'quantity_team_total',
+        'text', p_quantity_done,
+        'userId', v_user_id,
+        'timestamp', v_now_ms
+      ));
+      foreach v_assignee in array v_task.assignees loop
+        v_comments := v_comments || jsonb_build_array(jsonb_build_object(
+          'id', gen_random_uuid()::text,
+          'type', 'user_done',
+          'text', 'done',
+          'userId', v_assignee,
+          'timestamp', v_now_ms + 1
+        ));
+      end loop;
+    else
+      v_comments := v_comments || jsonb_build_array(jsonb_build_object(
+        'id', gen_random_uuid()::text,
+        'type', 'quantity_done',
+        'text', p_quantity_done,
+        'userId', v_user_id,
+        'timestamp', v_now_ms
+      ));
+      v_comments := v_comments || jsonb_build_array(jsonb_build_object(
+        'id', gen_random_uuid()::text,
+        'type', 'user_done',
+        'text', 'done',
+        'userId', v_user_id,
+        'timestamp', v_now_ms + 1
+      ));
+    end if;
+  end if;
+
+  if p_comment is not null and trim(p_comment) <> '' then
+    v_comments := v_comments || jsonb_build_array(jsonb_build_object(
+      'id', gen_random_uuid()::text,
+      'type', 'finish_note',
+      'text', p_comment,
+      'userId', v_user_id,
+      'timestamp', v_now_ms + 2
+    ));
+  end if;
+
+  update tasks
+     set status = 'completed',
+         started_at = null,
+         comments = v_comments
+   where id = p_task_id;
+
+  perform public.advance_order_after_task_completion(
+    p_order_id,
+    p_stage_id,
+    coalesce(nullif(v_task.stage_group_key, ''), p_stage_id),
+    coalesce(nullif(trim(p_actor), ''), v_user_id)
+  );
+end;
+$$;
+
+grant execute on function public.complete_flex_printing_stage_with_paint_queue(text, text, text, text, jsonb, jsonb, text, text, text)
+to authenticated, anon;


### PR DESCRIPTION
### Motivation
- Необходимо поддержать безопасное атомарное завершение этапа флексопечати с учётом строк текущего заказа и отложенной очереди списаний красок. 
- Защита от повторного списания и правильное разделение расходов между заказами требуют изменений в UI → репозитории → SQL RPC контракте. 
- Новый контракт должен позволять создавать pending-записи для строк без галочки и атомарно выполнять все складские и комментные операции перед отметкой этапа как завершённого.

### Description
- Изменён метод `OrdersRepository.completeFlexPrintingStage` в `lib/modules/orders/orders_repository.dart` так, что он принимает `currentOrderRows` и `pendingRows`, нормализует поля и вызывает новый RPC `complete_flex_printing_stage_with_paint_queue`.
- Добавлены вспомогательные функции `_paintQueueRpcRow`, `_trimmedString` и `_readDouble` для подготовки JSON-строк с полями `pending_writeoff_id`, `source_order_id`, `source_task_id`, `paint_id`, `paint_name`, `actual_used_amount`, `planned_amount`, `unit`, `write_off_now`.
- UI: в `lib/modules/tasks/tasks_screen.dart` диалог списания расширен — теперь возвращается `actual_used_amount`, `source_order_id` и прочие нормализованные поля; загружаются pending-строки через `getPendingPaintWriteoffs` и результаты разделяются на текущие и pending-строки перед RPC-вызовом.
- SQL: добавлен миграционный файл `supabase/migrations/20260515_complete_flex_printing_stage_paint_queue.sql` который реализует функцию `complete_flex_printing_stage_with_paint_queue`; внутри одной транзакции функция: блокирует `tasks` строку `for update`, создаёт/обновляет pending-записи для unchecked текущих строк, списывает отмеченные текущие строки, блокирует выбранные pending-записи `for update`, проверяет `status = 'pending'`, списывает только `write_off_now = true` строки и обновляет `order_paint_pending_writeoffs` с `status = 'written_off'` через `where id = ... and status = 'pending'`, и выбрасывает понятную ошибку при попытке повторного списания; также пересчитываются резервы, добавляются комментарии и вызывается `advance_order_after_task_completion` только после успешных складских операций.

### Testing
- Запущена проверка целостности изменений с `git diff --check`, ошибок не найдено (успешно). 
- Поиск по коду (`rg`) подтвердил наличие новых контрактов и вызовов RPC в `lib/modules/orders/orders_repository.dart`, `lib/modules/tasks/tasks_screen.dart` и новом SQL-файле (успешно).
- Выполнены синтаксические подсчёты пар/скобок для изменённых файлов (простая целостностная проверка), раскладка пар/скобок совпадает (успешно).
- `dart analyze` и `flutter analyze` не запускались из-за отсутствия `dart`/`flutter` в окружении (не выполнено).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cf674138832f9e4ef5b4abda2776)