### PR TITLE
Filter pending flex paint writeoffs and merge into ink-adjust dialog

### DIFF
--- a/lib/modules/orders/orders_repository.dart
+++ b/lib/modules/orders/orders_repository.dart
@@ -145,6 +145,76 @@ class PaintUsageUpdate {
   double get kilograms => grams / 1000.0;
 }
 
+class PaintPendingWriteoff {
+  final String id;
+  final String orderId;
+  final String taskId;
+  final String stageId;
+  final String stageName;
+  final String paintId;
+  final String paintName;
+  final double? plannedAmount;
+  final double? actualUsedAmount;
+  final String unit;
+  final String status;
+
+  const PaintPendingWriteoff({
+    required this.id,
+    required this.orderId,
+    required this.taskId,
+    required this.stageId,
+    required this.stageName,
+    required this.paintId,
+    required this.paintName,
+    this.plannedAmount,
+    this.actualUsedAmount,
+    required this.unit,
+    required this.status,
+  });
+
+  factory PaintPendingWriteoff.fromMap(Map<String, dynamic> row) {
+    return PaintPendingWriteoff(
+      id: _topLevelTrimmedString(row, 'id'),
+      orderId: _topLevelTrimmedString(row, 'order_id'),
+      taskId: _topLevelTrimmedString(row, 'task_id'),
+      stageId: _topLevelTrimmedString(row, 'stage_id'),
+      stageName: _topLevelTrimmedString(row, 'stage_name'),
+      paintId: _topLevelTrimmedString(row, 'paint_id'),
+      paintName: _topLevelTrimmedString(row, 'paint_name'),
+      plannedAmount: _topLevelReadDouble(row, 'planned_amount'),
+      actualUsedAmount: _topLevelReadDouble(row, 'actual_used_amount'),
+      unit: _topLevelTrimmedString(row, 'unit'),
+      status: _topLevelTrimmedString(row, 'status'),
+    );
+  }
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
+        'order_id': orderId,
+        'task_id': taskId,
+        'stage_id': stageId,
+        'stage_name': stageName,
+        'paint_id': paintId,
+        'paint_name': paintName,
+        'planned_amount': plannedAmount,
+        'actual_used_amount': actualUsedAmount,
+        'unit': unit,
+        'status': status,
+      };
+}
+
+String _topLevelTrimmedString(Map<String, dynamic> row, String key) =>
+    (row[key] ?? '').toString().trim();
+
+double? _topLevelReadDouble(Map<String, dynamic> row, String key) {
+  final value = row[key];
+  if (value is num) return value.toDouble();
+  return double.tryParse((value ?? '').toString().trim().replaceAll(',', '.'));
+}
+
+String _normalizePaintNameForMatching(String value) =>
+    value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+
 class PdfAttachment {
   final Uint8List bytes;
   final String filename;
@@ -309,11 +379,60 @@ class OrdersRepository {
         .eq('status', 'pending');
     final rows = (excludeOrderId ?? '').trim().isEmpty
         ? await query.order('created_at')
-        : await query.neq('order_id', excludeOrderId!.trim()).order('created_at');
+        : await query
+            .neq('order_id', excludeOrderId!.trim())
+            .order('created_at');
     if (rows is List) {
       return rows.cast<Map<String, dynamic>>();
     }
     return const [];
+  }
+
+  Future<List<PaintPendingWriteoff>> getPendingFlexPaintWriteoffs({
+    required String currentOrderId,
+    required List<String> currentPaintIds,
+    required List<String> currentPaintNames,
+  }) async {
+    final normalizedCurrentOrderId = currentOrderId.trim();
+    final paintIds = currentPaintIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    final paintNames = currentPaintNames
+        .map(_normalizePaintNameForMatching)
+        .where((name) => name.isNotEmpty)
+        .toSet();
+
+    if (paintIds.isEmpty && paintNames.isEmpty) {
+      return const <PaintPendingWriteoff>[];
+    }
+
+    final query = _sb
+        .from('order_paint_pending_writeoffs')
+        .select('id, order_id, task_id, stage_id, stage_name, paint_id, '
+            'paint_name, planned_amount, actual_used_amount, unit, status')
+        .eq('status', 'pending');
+    final rows = normalizedCurrentOrderId.isEmpty
+        ? await query.order('created_at')
+        : await query
+            .neq('order_id', normalizedCurrentOrderId)
+            .order('created_at');
+
+    if (rows is! List) {
+      return const <PaintPendingWriteoff>[];
+    }
+
+    return rows
+        .cast<Map<String, dynamic>>()
+        .map(PaintPendingWriteoff.fromMap)
+        .where((row) {
+          final hasMatchingPaintId =
+              row.paintId.isNotEmpty && paintIds.contains(row.paintId);
+          final hasMatchingPaintName = row.paintName.isNotEmpty &&
+              paintNames.contains(_normalizePaintNameForMatching(row.paintName));
+          return hasMatchingPaintId || hasMatchingPaintName;
+        })
+        .toList(growable: false);
   }
 
   Future<void> completeTaskStage({

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4369,8 +4369,26 @@ class _TasksScreenState extends State<TasksScreen>
       try {
         final repo = OrdersRepository();
         initialPaints = await repo.getPaints(task.orderId);
-        final pendingWriteoffs = await repo.getPendingPaintWriteoffs(
-          excludeOrderId: task.orderId,
+        final currentPaintIds = initialPaints
+            .map((paint) => _stringFromRow(paint, const [
+                  'paint_id',
+                  'material_id',
+                  'paintId',
+                ]))
+            .where((id) => id.isNotEmpty)
+            .toList(growable: false);
+        final currentPaintNames = initialPaints
+            .map((paint) => _stringFromRow(paint, const [
+                  'paint_name',
+                  'name',
+                  'paintName',
+                ]))
+            .where((name) => name.isNotEmpty)
+            .toList(growable: false);
+        final pendingWriteoffs = await repo.getPendingFlexPaintWriteoffs(
+          currentOrderId: task.orderId,
+          currentPaintIds: currentPaintIds,
+          currentPaintNames: currentPaintNames,
         );
         final reservations = await repo.getPaintReservations(task.orderId);
         final order = _orderById(task.orderId);
@@ -4419,18 +4437,19 @@ class _TasksScreenState extends State<TasksScreen>
           return merged;
         }).toList(growable: false);
         final pendingPaints = pendingWriteoffs.map((pending) {
-          final row = Map<String, dynamic>.from(pending);
+          final row = pending.toMap();
           return row
             ..addAll({
               'source': 'pending',
-              'pending_writeoff_id': row['id'],
-              'order_id': row['order_id'],
-              'source_order_id': row['order_id'],
-              'source_task_id': row['task_id'],
-              'order_label': row['order_id'] ?? 'Заказ',
-              'planned_amount': row['planned_amount'],
-              'actual_used_amount': row['actual_used_amount'],
-              'actual_used_text': row['actual_used_amount']?.toString() ?? '',
+              'pending_writeoff_id': pending.id,
+              'order_id': pending.orderId,
+              'source_order_id': pending.orderId,
+              'source_task_id': pending.taskId,
+              'order_label':
+                  pending.orderId.isEmpty ? 'Заказ' : pending.orderId,
+              'planned_amount': pending.plannedAmount,
+              'actual_used_amount': pending.actualUsedAmount,
+              'actual_used_text': pending.actualUsedAmount?.toString() ?? '',
             });
         }).toList(growable: false);
         initialPaints = <Map<String, dynamic>>[


### PR DESCRIPTION
### Motivation
- Only show pending paint writeoffs that are relevant to the current flex printing task by matching `paint_id` or a normalized `paint_name` so the user sees real continuations of the same paint. 
- Exclude the current order from pending groups so current-order rows remain visibly grouped with the current order. 
- Merge current order paints with matching pending writeoffs before showing the ink-adjust dialog so the UI presents a single combined model for adjustment.

### Description
- Added a typed model `PaintPendingWriteoff` with `fromMap`/`toMap` and small top-level helpers (`_topLevelTrimmedString`, `_topLevelReadDouble`, `_normalizePaintNameForMatching`) in `lib/modules/orders/orders_repository.dart` to represent pending writeoff rows. 
- Implemented `getPendingFlexPaintWriteoffs({required String currentOrderId, required List<String> currentPaintIds, required List<String> currentPaintNames})` in `OrdersRepository` to read `order_paint_pending_writeoffs` with `status='pending'`, exclude `currentOrderId`, and filter rows by matching `paint_id` or normalized `paint_name`. 
- Updated `_finalizeTask` in `lib/modules/tasks/tasks_screen.dart` to collect `currentPaintIds`/`currentPaintNames` from `order_paints`, call the new `getPendingFlexPaintWriteoffs`, convert pending items to maps, and merge them with current paints. 
- The merged paint list is now passed as the UI model to `_showInkAdjustDialog` so pending items appear under the pending section and current-order items remain in the current-order section.

### Testing
- Ran `git diff --check` which produced no issues and allowed committing the changes. 
- Attempted to run `flutter test` but it could not be executed in this environment because `flutter` is not installed (command not found), so no unit/widget tests were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d3f0d5b0832f90c8879116ca2dab)