### PR TITLE
Validate paint write-off input and add parseGramsInput tests

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -120,6 +120,32 @@ String formatTaskInitialQuantity(double value) {
       .replaceFirst(RegExp(r'\.$'), '');
 }
 
+/// Parses a paint usage value entered in the dialog as grams.
+///
+/// The function intentionally returns only the normalized numeric value and
+/// never formats the original input text, so significant zeros typed by the
+/// user remain untouched in the UI controller.
+double? parseGramsInput(String text, {required bool checked}) {
+  final normalized = text.trim().replaceAll(',', '.');
+  if (normalized.isEmpty) {
+    if (checked) {
+      throw const FormatException('Укажите фактический расход.');
+    }
+    return null;
+  }
+
+  final parsed = double.tryParse(normalized);
+  if (parsed == null) {
+    throw const FormatException('Фактический расход должен быть числом.');
+  }
+  if (parsed <= 0) {
+    throw const FormatException(
+      'Фактический расход должен быть больше 0.',
+    );
+  }
+  return parsed;
+}
+
 class TasksScreen extends StatefulWidget {
   final String employeeId;
   final bool showListOnly;
@@ -4013,14 +4039,6 @@ class _TasksScreenState extends State<TasksScreen>
 
   double _gramsToKilogramsForPersistence(double grams) => grams / 1000;
 
-  double? _parsePositiveGrams(String text) {
-    final normalized = text.trim().replaceAll(',', '.');
-    if (normalized.isEmpty) return null;
-    final parsed = double.tryParse(normalized);
-    if (parsed == null || parsed <= 0) return null;
-    return parsed;
-  }
-
   String _formatAmountForDialog(double value) {
     if (value == value.roundToDouble()) return value.toStringAsFixed(0);
     return value
@@ -4280,8 +4298,27 @@ class _TasksScreenState extends State<TasksScreen>
                       controllers[row]?.text ?? row.actualUsedText;
                   row.actualUsedText = enteredText;
                   row.refreshStatus();
-                  final actualGrams = _parsePositiveGrams(enteredText);
+                  double? actualGrams;
+                  if (row.writeOffNow) {
+                    try {
+                      actualGrams = parseGramsInput(
+                        enteredText,
+                        checked: row.writeOffNow,
+                      );
+                    } on FormatException catch (error) {
+                      ScaffoldMessenger.of(ctx).showSnackBar(
+                        SnackBar(content: Text(error.message)),
+                      );
+                      return;
+                    }
+                  }
                   final output = Map<String, dynamic>.from(row.sourceRow)
+                    ..remove('actual_used_amount')
+                    ..remove('actualUsedAmount')
+                    ..remove('used_qty')
+                    ..remove('qty_g')
+                    ..remove('qty_grams')
+                    ..remove('qty_kg')
                     ..addAll({
                       'source': row.source,
                       'queue_id': row.queueId,
@@ -4299,19 +4336,9 @@ class _TasksScreenState extends State<TasksScreen>
                     });
 
                   if (row.writeOffNow) {
-                    if (actualGrams == null) {
-                      ScaffoldMessenger.of(ctx).showSnackBar(
-                        const SnackBar(
-                          content: Text(
-                            'Для строк со списанием укажите фактический расход больше 0.',
-                          ),
-                        ),
-                      );
-                      return;
-                    }
                     output['used_qty'] = actualGrams;
                     output['qty_kg'] =
-                        _gramsToKilogramsForPersistence(actualGrams);
+                        _gramsToKilogramsForPersistence(actualGrams!);
                   }
                   resultRows.add(output);
                 }

--- a/test/tasks_grams_input_test.dart
+++ b/test/tasks_grams_input_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/tasks/tasks_screen.dart';
+
+void main() {
+  group('parseGramsInput', () {
+    test('keeps whole gram values unchanged', () {
+      expect(parseGramsInput('1000', checked: true), 1000);
+      expect(parseGramsInput('1500', checked: true), 1500);
+    });
+
+    test('keeps decimal gram values when interface unit is grams', () {
+      expect(parseGramsInput('0.5', checked: true), 0.5);
+    });
+
+    test('rejects zero for checked write-off rows', () {
+      expect(
+        () => parseGramsInput('0', checked: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects empty input only for checked write-off rows', () {
+      expect(parseGramsInput('', checked: false), isNull);
+      expect(
+        () => parseGramsInput('', checked: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects non-numeric and negative checked values', () {
+      expect(
+        () => parseGramsInput('abc', checked: true),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => parseGramsInput('-1', checked: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- Ensure paint write-off dialog validates and persists actual usage only for rows explicitly marked `Списать сейчас`, while allowing empty input for unchecked rows and preserving user-entered formatting in the UI.
- Centralize gram normalization so numeric validation and conversion to kilograms are reliable and testable without mutating the input text shown to users.

### Description
- Added `parseGramsInput(String text, {required bool checked})` which normalizes comma decimals to dot, returns a numeric grams value, and throws `FormatException` for invalid checked inputs.
- Updated the paint write-off confirmation handler to call `parseGramsInput` only for rows with `writeOffNow`, to omit factual fields for unchecked rows, and to convert normalized grams to kilograms via `_gramsToKilogramsForPersistence` when needed.
- Removed the old `_parsePositiveGrams` helper and ensured existing UI text in controllers is not reformatted by the parser.
- Added unit tests `test/tasks_grams_input_test.dart` covering the required cases (`1000`, `1500`, `0.5`, zero/empty/invalid/negative behaviors).

### Testing
- Static pre-save checks were executed in the environment and passed.
- New unit tests were added at `test/tasks_grams_input_test.dart` but were not executed here because the environment does not have the Flutter SDK installed.
- `dart format` was not run in this environment because the `dart` tool was unavailable.
- No further automated runtime tests were executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d5104008832fa109eca18411c2d4)