### PR TITLE
Move paint reserve display to type table screens

### DIFF
--- a/lib/modules/warehouse/paint_table.dart
+++ b/lib/modules/warehouse/paint_table.dart
@@ -53,67 +53,6 @@ class _PaintTableState extends State<PaintTable> {
     ).then((_) => _loadData());
   }
 
-  String _fmtQty(double value) => value.toStringAsFixed(2);
-
-  double _num(dynamic value) {
-    if (value is num) return value.toDouble();
-    return double.tryParse('$value'.replaceAll(',', '.')) ?? 0;
-  }
-
-  String _orderLabel(Map<String, dynamic> row) {
-    final order = row['orders'];
-    if (order is Map) {
-      final code = (order['form_code'] ?? '').toString().trim();
-      if (code.isNotEmpty) return code;
-      final no = order['new_form_no'];
-      if (no != null) return '№$no';
-      final customer = (order['customer'] ?? '').toString().trim();
-      if (customer.isNotEmpty) return customer;
-    }
-    final orderId = (row['order_id'] ?? '').toString().trim();
-    return orderId.isEmpty ? 'Заказ' : orderId;
-  }
-
-  Future<void> _showReserveDetails(TmcModel item) async {
-    final provider = Provider.of<WarehouseProvider>(context, listen: false);
-    final rows = await provider.getPaintReservationsByPaint(item.id);
-    if (!mounted) return;
-    await showDialog<void>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text('Резервы: ${item.description}'),
-        content: SizedBox(
-          width: 420,
-          child: rows.isEmpty
-              ? const Text('Нет активных резервов')
-              : Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: rows
-                      .map(
-                        (row) => ListTile(
-                          dense: true,
-                          title: Text(_orderLabel(row)),
-                          subtitle: Text(
-                            'Заказ: ${(row['order_id'] ?? '').toString()}',
-                          ),
-                          trailing: Text(
-                            '${_fmtQty(_num(row['reserved_qty']))} ${item.unit}',
-                          ),
-                        ),
-                      )
-                      .toList(growable: false),
-                ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Закрыть'),
-          ),
-        ],
-      ),
-    );
-  }
-
   void _editItem(TmcModel item) {
     showDialog(
       context: context,
@@ -275,9 +214,7 @@ class _PaintTableState extends State<PaintTable> {
                               DataColumn(label: Text('№')),
                               DataColumn(label: Text('Фото')),
                               DataColumn(label: Text('Название')),
-                              DataColumn(label: Text('Общий остаток')),
-                              DataColumn(label: Text('Резерв')),
-                              DataColumn(label: Text('Доступно')),
+                              DataColumn(label: Text('Кол-во')),
                               DataColumn(label: Text('Ед.')),
                               DataColumn(label: Text('Действия')),
                             ],
@@ -296,14 +233,6 @@ class _PaintTableState extends State<PaintTable> {
                                         item.quantity
                                             .toString()
                                             .toLowerCase()
-                                            .contains(query) ||
-                                        item.reservedQty
-                                            .toString()
-                                            .toLowerCase()
-                                            .contains(query) ||
-                                        item.availableQty
-                                            .toString()
-                                            .toLowerCase()
                                             .contains(query);
                                   })
                                   .toList()
@@ -318,14 +247,6 @@ class _PaintTableState extends State<PaintTable> {
                                           .contains(query) ||
                                       item.unit.toLowerCase().contains(query) ||
                                       item.quantity
-                                          .toString()
-                                          .toLowerCase()
-                                          .contains(query) ||
-                                      item.reservedQty
-                                          .toString()
-                                          .toLowerCase()
-                                          .contains(query) ||
-                                      item.availableQty
                                           .toString()
                                           .toLowerCase()
                                           .contains(query);
@@ -400,20 +321,8 @@ class _PaintTableState extends State<PaintTable> {
                                             },
                                     );
                                   }),
-                                  DataCell(
-                                    Text(item.description),
-                                    onTap: () => _showReserveDetails(item),
-                                  ),
-                                  DataCell(Text(_fmtQty(item.quantity))),
-                                  DataCell(
-                                    TextButton(
-                                      onPressed: item.reservedQty > 0
-                                          ? () => _showReserveDetails(item)
-                                          : null,
-                                      child: Text(_fmtQty(item.reservedQty)),
-                                    ),
-                                  ),
-                                  DataCell(Text(_fmtQty(item.availableQty))),
+                                  DataCell(Text(item.description)),
+                                  DataCell(Text(item.quantity.toStringAsFixed(2))),
                                   DataCell(Text(item.unit)),
                                   DataCell(Row(
                                     children: [

--- a/lib/modules/warehouse/type_table_screen.dart
+++ b/lib/modules/warehouse/type_table_screen.dart
@@ -454,9 +454,10 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         ...woTables,
         ...invTables,
         ...arrTables,
-        // Бизнес-логика резерва: для бумаги обновляем таблицу
+        // Бизнес-логика резерва: для бумаги и краски обновляем таблицу
         // при любом изменении активных резервов.
         if (typeKey == 'paper') 'order_paper_reservations',
+        if (typeKey == 'paint') 'order_paint_reservations',
       ];
       for (final t in watchedTables) {
         ch.onPostgresChanges(
@@ -483,10 +484,54 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
     } catch (_) {}
   }
 
+  bool _isReserveAwareType(String typeKey) => typeKey == 'paper' || typeKey == 'paint';
+
+  Future<double> _reservedQtyForItem(TmcModel item, String typeKey) {
+    if (typeKey == 'paper') {
+      return context.read<WarehouseProvider>().paperReservedQty(item.id);
+    }
+    if (typeKey == 'paint') {
+      return Future<double>.value(item.reservedQty);
+    }
+    return Future<double>.value(0);
+  }
+
+  String _reserveUnitLabel(TmcModel item, String typeKey) {
+    if (typeKey == 'paper') return 'м';
+    return item.unit.trim().isEmpty ? 'ед.' : item.unit.trim();
+  }
+
+  String _orderLabelFromReservation(Map<String, dynamic> row) {
+    final orderName = (row['order_name'] ?? '').toString().trim();
+    final hasOrderName = orderName.isNotEmpty &&
+        orderName.toLowerCase() != 'null' &&
+        orderName.toLowerCase() != 'undefined' &&
+        orderName.toLowerCase() != 'nan' &&
+        orderName != '-';
+    if (hasOrderName) return orderName;
+
+    final order = row['orders'];
+    if (order is Map) {
+      final code = (order['form_code'] ?? '').toString().trim();
+      if (code.isNotEmpty) return code;
+      final no = (order['new_form_no'] ?? '').toString().trim();
+      if (no.isNotEmpty) return 'Форма №$no';
+      final customer = (order['customer'] ?? '').toString().trim();
+      if (customer.isNotEmpty) return customer;
+    }
+
+    final orderId = (row['order_id'] ?? '').toString().trim();
+    return orderId.isEmpty ? 'Заказ без названия' : 'Заказ $orderId';
+  }
+
   Future<void> _showReserveDetails(TmcModel item) async {
-    final details =
-        await context.read<WarehouseProvider>().paperReserveDetails(item.id);
+    final typeKey = _normalizeType(widget.type);
+    final provider = context.read<WarehouseProvider>();
+    final details = typeKey == 'paint'
+        ? await provider.getPaintReservationsByPaint(item.id)
+        : await provider.paperReserveDetails(item.id);
     if (!mounted) return;
+    final unit = _reserveUnitLabel(item, typeKey);
     await showDialog<void>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -494,20 +539,17 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         content: SizedBox(
           width: 420,
           child: details.isEmpty
-              ? const Text('По этой бумаге нет активного резерва.')
+              ? Text(typeKey == 'paint'
+                  ? 'По этой краске нет активного резерва.'
+                  : 'По этой бумаге нет активного резерва.')
               : ListView(
                   shrinkWrap: true,
                   children: details.map((row) {
-                    final orderName = (row['order_name'] ?? '').toString().trim();
-                    final hasOrderName = orderName.isNotEmpty &&
-                        orderName.toLowerCase() != 'null' &&
-                        orderName.toLowerCase() != 'undefined' &&
-                        orderName.toLowerCase() != 'nan' &&
-                        orderName != '-';
+                    final rawQty = row['qty'] ?? row['active_reserved_qty'];
                     final qty = (row['qty'] as num?)?.toDouble() ??
-                        double.tryParse('${row['qty']}') ??
+                        (row['active_reserved_qty'] as num?)?.toDouble() ??
+                        double.tryParse('$rawQty') ??
                         0;
-                    final orderLabel = hasOrderName ? orderName : 'Заказ без названия';
                     return Container(
                       margin: const EdgeInsets.only(bottom: 8),
                       padding: const EdgeInsets.symmetric(
@@ -520,7 +562,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                         color: Colors.grey.shade50,
                       ),
                       child: Text(
-                        '$orderLabel • ${qty.toStringAsFixed(2)} м',
+                        '${_orderLabelFromReservation(row)} • ${qty.toStringAsFixed(2)} $unit',
                         style: const TextStyle(fontWeight: FontWeight.w500),
                       ),
                     );
@@ -1423,10 +1465,13 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
 
   /// --- Вкладка «Список» ---
   Widget _listTab() {
-    final base = _normalizeType(widget.type) == 'paper'
+    final typeKey = _normalizeType(widget.type);
+    final base = typeKey == 'paper'
         ? _applyPaperMultiFilters(List<TmcModel>.from(_items))
         : List<TmcModel>.from(_items);
     final items = _applyFilterItems(base);
+    final showReserveColumns = _isReserveAwareType(typeKey);
+    final showAvailableColumn = typeKey == 'paint';
     return Padding(
       padding: const EdgeInsets.all(8),
       child: Card(
@@ -1449,7 +1494,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                       if (items.any((i) =>
                           i.grammage != null && i.grammage!.trim().isNotEmpty))
                         const DataColumn(label: Text('Граммаж')),
-                      if (_normalizeType(widget.type) != 'paper' &&
+                      if (typeKey != 'paper' &&
                           items.any((i) => i.weight != null))
                         const DataColumn(label: Text('Вес (кг)')),
                       if (items.any(
@@ -1458,7 +1503,9 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                       if (widget.enablePhoto)
                         const DataColumn(label: Text('Фото')),
                       const DataColumn(label: Text('Действия')),
-                      if (_normalizeType(widget.type) == 'paper')
+                      if (showAvailableColumn)
+                        const DataColumn(label: Text('Доступно')),
+                      if (showReserveColumns)
                         const DataColumn(label: Text('В резерве')),
                     ],
                     rows: List<DataRow>.generate(items.length, (i) {
@@ -1472,11 +1519,9 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                         DataCell(Text('${i + 1}')),
                         DataCell(Text(item.description)),
                         DataCell(
-                          _normalizeType(widget.type) == 'paper'
+                          typeKey == 'paper'
                               ? FutureBuilder<double>(
-                                  future: context
-                                      .read<WarehouseProvider>()
-                                      .paperReservedQty(item.id),
+                                  future: _reservedQtyForItem(item, typeKey),
                                   builder: (context, snapshot) {
                                     final reserved = snapshot.data ?? 0;
                                     final available = item.quantity - reserved;
@@ -1495,7 +1540,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                             i.grammage != null &&
                             i.grammage!.trim().isNotEmpty))
                           DataCell(Text(item.grammage ?? '')),
-                        if (_normalizeType(widget.type) != 'paper' &&
+                        if (typeKey != 'paper' &&
                             items.any((i) => i.weight != null))
                           DataCell(Text(fmtNum(item.weight, frac: 2))),
                         if (items.any(
@@ -1559,16 +1604,20 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                               tooltip: 'Удалить',
                               onPressed: () => _deleteItem(item)),
                         ])),
-                        if (_normalizeType(widget.type) == 'paper')
+                        if (showAvailableColumn)
+                          DataCell(Text(
+                            fmtNum(item.availableQty < 0 ? 0 : item.availableQty,
+                                frac: 2),
+                          )),
+                        if (showReserveColumns)
                           DataCell(
                             FutureBuilder<double>(
-                              future: context
-                                  .read<WarehouseProvider>()
-                                  .paperReservedQty(item.id),
+                              future: _reservedQtyForItem(item, typeKey),
                               builder: (context, snapshot) {
-                                final reserved = snapshot.data ?? 0;
+                                final reserved = snapshot.data ?? item.reservedQty;
+                                final unit = _reserveUnitLabel(item, typeKey);
                                 final reserveLabel =
-                                    '${reserved.toStringAsFixed(2)} м';
+                                    '${reserved.toStringAsFixed(2)} $unit';
                                 return TextButton(
                                   style: ButtonStyle(
                                     foregroundColor:

--- a/lib/modules/warehouse/type_table_tabs_screen.dart
+++ b/lib/modules/warehouse/type_table_tabs_screen.dart
@@ -511,9 +511,10 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         ...woTables,
         ...invTables,
         ...arrTables,
-        // Бизнес-логика резерва: для бумаги обновляем таблицу
+        // Бизнес-логика резерва: для бумаги и краски обновляем таблицу
         // при любом изменении активных резервов.
         if (typeKey == 'paper') 'order_paper_reservations',
+        if (typeKey == 'paint') 'order_paint_reservations',
       ];
       for (final t in watchedTables) {
         ch.onPostgresChanges(
@@ -540,10 +541,54 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
     } catch (_) {}
   }
 
+  bool _isReserveAwareType(String typeKey) => typeKey == 'paper' || typeKey == 'paint';
+
+  Future<double> _reservedQtyForItem(TmcModel item, String typeKey) {
+    if (typeKey == 'paper') {
+      return context.read<WarehouseProvider>().paperReservedQty(item.id);
+    }
+    if (typeKey == 'paint') {
+      return Future<double>.value(item.reservedQty);
+    }
+    return Future<double>.value(0);
+  }
+
+  String _reserveUnitLabel(TmcModel item, String typeKey) {
+    if (typeKey == 'paper') return 'м';
+    return item.unit.trim().isEmpty ? 'ед.' : item.unit.trim();
+  }
+
+  String _orderLabelFromReservation(Map<String, dynamic> row) {
+    final orderName = (row['order_name'] ?? '').toString().trim();
+    final hasOrderName = orderName.isNotEmpty &&
+        orderName.toLowerCase() != 'null' &&
+        orderName.toLowerCase() != 'undefined' &&
+        orderName.toLowerCase() != 'nan' &&
+        orderName != '-';
+    if (hasOrderName) return orderName;
+
+    final order = row['orders'];
+    if (order is Map) {
+      final code = (order['form_code'] ?? '').toString().trim();
+      if (code.isNotEmpty) return code;
+      final no = (order['new_form_no'] ?? '').toString().trim();
+      if (no.isNotEmpty) return 'Форма №$no';
+      final customer = (order['customer'] ?? '').toString().trim();
+      if (customer.isNotEmpty) return customer;
+    }
+
+    final orderId = (row['order_id'] ?? '').toString().trim();
+    return orderId.isEmpty ? 'Заказ без названия' : 'Заказ $orderId';
+  }
+
   Future<void> _showReserveDetails(TmcModel item) async {
-    final details =
-        await context.read<WarehouseProvider>().paperReserveDetails(item.id);
+    final typeKey = _normalizeType(widget.type);
+    final provider = context.read<WarehouseProvider>();
+    final details = typeKey == 'paint'
+        ? await provider.getPaintReservationsByPaint(item.id)
+        : await provider.paperReserveDetails(item.id);
     if (!mounted) return;
+    final unit = _reserveUnitLabel(item, typeKey);
     await showDialog<void>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -551,20 +596,17 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         content: SizedBox(
           width: 420,
           child: details.isEmpty
-              ? const Text('По этой бумаге нет активного резерва.')
+              ? Text(typeKey == 'paint'
+                  ? 'По этой краске нет активного резерва.'
+                  : 'По этой бумаге нет активного резерва.')
               : ListView(
                   shrinkWrap: true,
                   children: details.map((row) {
-                    final orderName = (row['order_name'] ?? '').toString().trim();
-                    final hasOrderName = orderName.isNotEmpty &&
-                        orderName.toLowerCase() != 'null' &&
-                        orderName.toLowerCase() != 'undefined' &&
-                        orderName.toLowerCase() != 'nan' &&
-                        orderName != '-';
+                    final rawQty = row['qty'] ?? row['active_reserved_qty'];
                     final qty = (row['qty'] as num?)?.toDouble() ??
-                        double.tryParse('${row['qty']}') ??
+                        (row['active_reserved_qty'] as num?)?.toDouble() ??
+                        double.tryParse('$rawQty') ??
                         0;
-                    final orderLabel = hasOrderName ? orderName : 'Заказ без названия';
                     return Container(
                       margin: const EdgeInsets.only(bottom: 8),
                       padding: const EdgeInsets.symmetric(
@@ -577,7 +619,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                         color: Colors.grey.shade50,
                       ),
                       child: Text(
-                        '$orderLabel • ${qty.toStringAsFixed(2)} м',
+                        '${_orderLabelFromReservation(row)} • ${qty.toStringAsFixed(2)} $unit',
                         style: const TextStyle(fontWeight: FontWeight.w500),
                       ),
                     );
@@ -1522,10 +1564,13 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
 
   /// --- Вкладка «Список» ---
   Widget _listTab() {
-    final base = _normalizeType(widget.type) == 'paper'
+    final typeKey = _normalizeType(widget.type);
+    final base = typeKey == 'paper'
         ? _applyPaperMultiFilters(List<TmcModel>.from(_items))
         : List<TmcModel>.from(_items);
     final items = _applyFilterItems(base);
+    final showReserveColumns = _isReserveAwareType(typeKey);
+    final showAvailableColumn = typeKey == 'paint';
     return Padding(
       padding: const EdgeInsets.all(8),
       child: Card(
@@ -1548,7 +1593,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                       if (items.any((i) =>
                           i.grammage != null && i.grammage!.trim().isNotEmpty))
                         const DataColumn(label: Text('Граммаж')),
-                      if (_normalizeType(widget.type) != 'paper' &&
+                      if (typeKey != 'paper' &&
                           items.any((i) => i.weight != null))
                         const DataColumn(label: Text('Вес (кг)')),
                       if (items.any(
@@ -1557,7 +1602,9 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                       if (widget.enablePhoto)
                         const DataColumn(label: Text('Фото')),
                       const DataColumn(label: Text('Действия')),
-                      if (_normalizeType(widget.type) == 'paper')
+                      if (showAvailableColumn)
+                        const DataColumn(label: Text('Доступно')),
+                      if (showReserveColumns)
                         const DataColumn(label: Text('В резерве')),
                     ],
                     rows: List<DataRow>.generate(items.length, (i) {
@@ -1571,11 +1618,9 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                         DataCell(Text('${i + 1}')),
                         DataCell(Text(item.description)),
                         DataCell(
-                          _normalizeType(widget.type) == 'paper'
+                          typeKey == 'paper'
                               ? FutureBuilder<double>(
-                                  future: context
-                                      .read<WarehouseProvider>()
-                                      .paperReservedQty(item.id),
+                                  future: _reservedQtyForItem(item, typeKey),
                                   builder: (context, snapshot) {
                                     final reserved = snapshot.data ?? 0;
                                     final available = item.quantity - reserved;
@@ -1594,7 +1639,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                             i.grammage != null &&
                             i.grammage!.trim().isNotEmpty))
                           DataCell(Text(item.grammage ?? '')),
-                        if (_normalizeType(widget.type) != 'paper' &&
+                        if (typeKey != 'paper' &&
                             items.any((i) => i.weight != null))
                           DataCell(Text(fmtNum(item.weight, frac: 2))),
                         if (items.any(
@@ -1658,16 +1703,20 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
                               tooltip: 'Удалить',
                               onPressed: () => _deleteItem(item)),
                         ])),
-                        if (_normalizeType(widget.type) == 'paper')
+                        if (showAvailableColumn)
+                          DataCell(Text(
+                            fmtNum(item.availableQty < 0 ? 0 : item.availableQty,
+                                frac: 2),
+                          )),
+                        if (showReserveColumns)
                           DataCell(
                             FutureBuilder<double>(
-                              future: context
-                                  .read<WarehouseProvider>()
-                                  .paperReservedQty(item.id),
+                              future: _reservedQtyForItem(item, typeKey),
                               builder: (context, snapshot) {
-                                final reserved = snapshot.data ?? 0;
+                                final reserved = snapshot.data ?? item.reservedQty;
+                                final unit = _reserveUnitLabel(item, typeKey);
                                 final reserveLabel =
-                                    '${reserved.toStringAsFixed(2)} м';
+                                    '${reserved.toStringAsFixed(2)} $unit';
                                 return TextButton(
                                   style: ButtonStyle(
                                     foregroundColor:

--- a/lib/modules/warehouse/warehouse_provider.dart
+++ b/lib/modules/warehouse/warehouse_provider.dart
@@ -2329,11 +2329,19 @@ class WarehouseProvider with ChangeNotifier {
     return double.tryParse('$value'.replaceAll(',', '.')) ?? 0.0;
   }
 
+  double _activePaintReserveQty(Map<String, dynamic> row) {
+    final reserved = _toDouble(row['reserved_qty']);
+    final used = _toDouble(row['used_qty']);
+    final released = _toDouble(row['released_qty']);
+    final active = reserved - used - released;
+    return active > 0 ? active : 0.0;
+  }
+
   Future<Map<String, double>> _loadPaintReservedQty() async {
     try {
       final rows = await _sb
           .from('order_paint_reservations')
-          .select('paint_id, reserved_qty');
+          .select('paint_id, reserved_qty, used_qty, released_qty');
       if (rows is! List) return const {};
       final out = <String, double>{};
       for (final raw in rows.whereType<Map>()) {
@@ -2342,8 +2350,8 @@ class WarehouseProvider with ChangeNotifier {
         if (paintId.isEmpty) continue;
         out.update(
           paintId,
-          (value) => value + _toDouble(row['reserved_qty']),
-          ifAbsent: () => _toDouble(row['reserved_qty']),
+          (value) => value + _activePaintReserveQty(row),
+          ifAbsent: () => _activePaintReserveQty(row),
         );
       }
       return out;
@@ -2362,13 +2370,20 @@ class WarehouseProvider with ChangeNotifier {
       final rows = await _sb
           .from('order_paint_reservations')
           .select(
-              'order_id, reserved_qty, orders(id, customer, new_form_no, form_code)')
+              'order_id, reserved_qty, used_qty, released_qty, orders(id, customer, new_form_no, form_code)')
           .eq('paint_id', normalizedId)
           .order('created_at');
       if (rows is! List) return const [];
       return rows
           .whereType<Map>()
-          .map((raw) => Map<String, dynamic>.from(raw as Map))
+          .map((raw) {
+            final row = Map<String, dynamic>.from(raw as Map);
+            final activeQty = _activePaintReserveQty(row);
+            row['active_reserved_qty'] = activeQty;
+            row['qty'] = activeQty;
+            return row;
+          })
+          .where((row) => _toDouble(row['active_reserved_qty']) > 0)
           .toList(growable: false);
     } catch (e) {
       debugPrint('⚠️ paint reservations details failed: $e');


### PR DESCRIPTION
### Motivation
- Centralize paint reservation UI into the generic type tables so paint reserves are shown together with other stock types and not duplicated in `paint_table.dart`.
- Ensure displayed available quantity for paints accounts for active reservations (reserved minus used minus released) so UI reflects what can actually be consumed.
- Refresh type tables on reservation changes so the UI updates immediately when `order_paint_reservations` change.

### Description
- Added active-reserve computation in `WarehouseProvider`: `_activePaintReserveQty`, updated `_loadPaintReservedQty()` and `getPaintReservationsByPaint()` to include `used_qty` and `released_qty` and return only active reserved amounts (stored as `active_reserved_qty`).
- Moved paint reserve UI and reservation-details dialog into the generic screens by updating `type_table_screen.dart` and `type_table_tabs_screen.dart` to add helper functions (`_isReserveAwareType`, `_reservedQtyForItem`, `_reserveUnitLabel`, `_orderLabelFromReservation`), realtime watch for `order_paint_reservations`, and columns `Доступно` + `В резерве` for type `paint`.
- Removed reserve/available columns and the per-paint reservation dialog from `paint_table.dart` so reserve presentation lives in the unified type tables.
- UI shows per-order reservation details with correct units and uses aggregated active reserve values for display.

### Testing
- Ran `git diff --check` to validate no simple diff/whitespace issues and it succeeded.
- Attempted to run `flutter test` and `dart format` but the Flutter/Dart CLI is not available in this environment, so unit/widget tests and formatting were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d8c0c29c832f936ee23ed2aa6366)