### PR TITLE
Prefer customer in reserve labels; add paint editor in tasks; queue chat attachments

### DIFF
--- a/lib/modules/chat/widgets/input_bar.dart
+++ b/lib/modules/chat/widgets/input_bar.dart
@@ -48,6 +48,39 @@ class _ChatInputBarState extends State<ChatInputBar> {
   final List<_PendingMention> _selectedMentions = <_PendingMention>[];
   int _mentionRequestId = 0;
   bool _isDisposed = false;
+  final List<_PendingChatAttachment> _pendingAttachments = <_PendingChatAttachment>[];
+
+  void _queueAttachment(_PendingChatAttachment attachment) {
+    if (_isDisposed || !mounted) return;
+    setState(() => _pendingAttachments.add(attachment));
+  }
+
+  void _removePendingAttachment(int index) {
+    if (_isDisposed || !mounted) return;
+    setState(() => _pendingAttachments.removeAt(index));
+  }
+
+  Future<void> _sendPendingAttachments(String? caption) async {
+    if (_pendingAttachments.isEmpty) return;
+    final chat = context.read<ChatProvider>();
+    final attachments = List<_PendingChatAttachment>.from(_pendingAttachments);
+    for (var i = 0; i < attachments.length; i++) {
+      final attachment = attachments[i];
+      await chat.sendFile(
+        roomId: widget.roomId,
+        senderId: widget.senderId,
+        senderName: widget.senderName,
+        bytes: attachment.bytes,
+        filename: attachment.filename,
+        mime: attachment.mime,
+        body: i == 0 ? caption : null,
+        kind: attachment.kind,
+      );
+    }
+    if (!_isDisposed && mounted) {
+      setState(() => _pendingAttachments.clear());
+    }
+  }
 
   /// Снимает фото через камеру устройства и отправляет его в чат. Если
   /// пользователь отменяет съёмку, ничего не происходит. Этот метод
@@ -56,26 +89,19 @@ class _ChatInputBarState extends State<ChatInputBar> {
   /// доступны только на мобильных платформах.
   Future<void> _takePhoto() async {
     if (_isDisposed || !mounted) return;
-    final chat = context.read<ChatProvider>();
     final picker = ImagePicker();
     try {
       final XFile? image = await picker.pickImage(source: ImageSource.camera, imageQuality: 85);
       if (image == null) return;
       final bytes = await image.readAsBytes();
       final mime = lookupMimeType(image.path, headerBytes: _mimeHeader(bytes)) ?? 'image/jpeg';
-      final caption = _attachmentCaption();
       if (_isDisposed || !mounted) return;
-      await chat.sendFile(
-        roomId: widget.roomId,
-        senderId: widget.senderId,
-        senderName: widget.senderName,
+      _queueAttachment(_PendingChatAttachment(
         bytes: bytes,
         filename: image.name.isNotEmpty ? image.name : p.basename(image.path),
         mime: mime,
-        body: caption,
         kind: _kindFromMime(mime),
-      );
-      _clearAttachmentCaption();
+      ));
     } catch (error) {
       _showErrorSnackBar('Не удалось отправить фото: $error');
     }
@@ -114,19 +140,22 @@ class _ChatInputBarState extends State<ChatInputBar> {
     if (_isDisposed || !mounted) return;
     _cleanupObsoleteMentions();
     var prepared = _controller.text;
-    if (prepared.trim().isEmpty) return;
     if (_selectedMentions.isNotEmpty) {
       prepared = _applyMentionMarkup(prepared);
     }
     prepared = prepared.trim();
-    if (prepared.isEmpty) return;
-    final chat = context.read<ChatProvider>();
-    await chat.sendText(
-      roomId: widget.roomId,
-      senderId: widget.senderId,
-      senderName: widget.senderName,
-      text: prepared,
-    );
+    if (prepared.isEmpty && _pendingAttachments.isEmpty) return;
+    if (_pendingAttachments.isNotEmpty) {
+      await _sendPendingAttachments(prepared.isEmpty ? null : prepared);
+    } else {
+      final chat = context.read<ChatProvider>();
+      await chat.sendText(
+        roomId: widget.roomId,
+        senderId: widget.senderId,
+        senderName: widget.senderName,
+        text: prepared,
+      );
+    }
     _controller.clear();
     _selectedMentions.clear();
     _hideMentionOverlay();
@@ -436,26 +465,19 @@ class _ChatInputBarState extends State<ChatInputBar> {
 
   Future<void> _pickImage() async {
     if (_isDisposed || !mounted) return;
-    final chat = context.read<ChatProvider>();
     final picker = ImagePicker();
     try {
       final x = await picker.pickImage(source: ImageSource.gallery, imageQuality: 85);
       if (x == null) return;
       final bytes = await x.readAsBytes();
       final mime = lookupMimeType(x.path, headerBytes: _mimeHeader(bytes)) ?? 'image/jpeg';
-      final caption = _attachmentCaption();
       if (_isDisposed || !mounted) return;
-      await chat.sendFile(
-        roomId: widget.roomId,
-        senderId: widget.senderId,
-        senderName: widget.senderName,
+      _queueAttachment(_PendingChatAttachment(
         bytes: bytes,
         filename: x.name.isNotEmpty ? x.name : p.basename(x.path),
         mime: mime,
-        body: caption,
         kind: _kindFromMime(mime),
-      );
-      _clearAttachmentCaption();
+      ));
     } catch (error) {
       _showErrorSnackBar('Не удалось отправить изображение: $error');
     }
@@ -463,26 +485,19 @@ class _ChatInputBarState extends State<ChatInputBar> {
 
   Future<void> _pickVideo() async {
     if (_isDisposed || !mounted) return;
-    final chat = context.read<ChatProvider>();
     final picker = ImagePicker();
     try {
       final x = await picker.pickVideo(source: ImageSource.gallery);
       if (x == null) return;
       final bytes = await x.readAsBytes();
       final mime = lookupMimeType(x.path, headerBytes: _mimeHeader(bytes)) ?? 'video/mp4';
-      final caption = _attachmentCaption();
       if (_isDisposed || !mounted) return;
-      await chat.sendFile(
-        roomId: widget.roomId,
-        senderId: widget.senderId,
-        senderName: widget.senderName,
+      _queueAttachment(_PendingChatAttachment(
         bytes: bytes,
         filename: x.name.isNotEmpty ? x.name : p.basename(x.path),
         mime: mime,
-        body: caption,
         kind: _kindFromMime(mime),
-      );
-      _clearAttachmentCaption();
+      ));
     } catch (error) {
       _showErrorSnackBar('Не удалось отправить видео: $error');
     }
@@ -490,7 +505,6 @@ class _ChatInputBarState extends State<ChatInputBar> {
 
   Future<void> _pickAnyFile() async {
     if (_isDisposed || !mounted) return;
-    final chat = context.read<ChatProvider>();
     try {
       final res = await FilePicker.platform.pickFiles(withReadStream: true);
       if (res == null || res.files.isEmpty) return;
@@ -501,19 +515,13 @@ class _ChatInputBarState extends State<ChatInputBar> {
             headerBytes: _mimeHeader(bytes),
           ) ??
           'application/octet-stream';
-      final caption = _attachmentCaption();
       if (_isDisposed || !mounted) return;
-      await chat.sendFile(
-        roomId: widget.roomId,
-        senderId: widget.senderId,
-        senderName: widget.senderName,
+      _queueAttachment(_PendingChatAttachment(
         bytes: bytes,
         filename: f.name,
         mime: mime,
-        body: caption,
         kind: _kindFromMime(mime),
-      );
-      _clearAttachmentCaption();
+      ));
     } catch (error) {
       _showErrorSnackBar('Не удалось отправить файл: $error');
     }
@@ -609,8 +617,29 @@ class _ChatInputBarState extends State<ChatInputBar> {
 
     return SafeArea(
       top: false,
-      child: Row(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
+          if (_pendingAttachments.isNotEmpty)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Wrap(
+                spacing: scaled(6),
+                runSpacing: scaled(4),
+                children: [
+                  for (var i = 0; i < _pendingAttachments.length; i++)
+                    Chip(
+                      label: Text(
+                        _pendingAttachments[i].filename,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      onDeleted: () => _removePendingAttachment(i),
+                    ),
+                ],
+              ),
+            ),
+          Row(
+            children: [
           IconButton(
             tooltip: 'Камера',
             visualDensity: density,
@@ -674,6 +703,8 @@ class _ChatInputBarState extends State<ChatInputBar> {
             icon: const Icon(Icons.send),
             onPressed: _sendText,
           ),
+            ],
+          ),
         ],
       ),
     );
@@ -684,4 +715,18 @@ class _PendingMention {
   final String display;
   final String id;
   const _PendingMention({required this.display, required this.id});
+}
+
+class _PendingChatAttachment {
+  final Uint8List bytes;
+  final String filename;
+  final String mime;
+  final String kind;
+
+  const _PendingChatAttachment({
+    required this.bytes,
+    required this.filename,
+    required this.mime,
+    required this.kind,
+  });
 }

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -726,6 +726,7 @@ class _QuantityInput {
   final double quantity;
   final String displayText;
   final bool openPaperEditor;
+  final bool openPaintEditor;
   final int? packsCount;
   final int? unitsPerPack;
 
@@ -733,6 +734,7 @@ class _QuantityInput {
     required this.quantity,
     required this.displayText,
     this.openPaperEditor = false,
+    this.openPaintEditor = false,
     this.packsCount,
     this.unitsPerPack,
   });
@@ -762,10 +764,12 @@ class _CommentDraft {
 class _InkUsageDialogResult {
   final List<Map<String, dynamic>> paints;
   final bool openPaperEditor;
+  final bool openPaintEditor;
 
   const _InkUsageDialogResult({
     required this.paints,
     this.openPaperEditor = false,
+    this.openPaintEditor = false,
   });
 }
 
@@ -1194,6 +1198,123 @@ class _TasksScreenState extends State<TasksScreen>
     return _workspacePaperItems();
   }
 
+  List<TmcModel> _workspacePaintItems() {
+    final warehouse = context.read<WarehouseProvider>();
+    bool isPaintType(TmcModel item) {
+      final raw = item.type.toLowerCase().trim();
+      return raw.contains('paint') ||
+          raw.contains('краск') ||
+          raw == 'краска';
+    }
+
+    final paints = warehouse.allTmc.where(isPaintType).toList();
+    paints.sort(
+      (a, b) => a.description.toLowerCase().compareTo(
+            b.description.toLowerCase(),
+          ),
+    );
+    return paints;
+  }
+
+  Future<List<TmcModel>> _workspacePaintItemsFresh() async {
+    final warehouse = context.read<WarehouseProvider>();
+    await warehouse.fetchTmc();
+    return _workspacePaintItems();
+  }
+
+  bool _matchPaintSearch(TmcModel paint, String query) {
+    final normalized = query.trim().toLowerCase();
+    if (normalized.isEmpty) return true;
+    final searchable = [
+      paint.description,
+      paint.note ?? '',
+      paint.unit,
+      paint.id,
+    ].join(' ').toLowerCase();
+    return normalized
+        .split(RegExp(r'[\s,;]+'))
+        .where((token) => token.isNotEmpty)
+        .every(searchable.contains);
+  }
+
+  Future<TmcModel?> _pickPaintForSlot({
+    required BuildContext context,
+    required List<TmcModel> paints,
+  }) async {
+    var search = '';
+    return showDialog<TmcModel>(
+      context: context,
+      builder: (pickerContext) {
+        return StatefulBuilder(
+          builder: (pickerContext, setPickerState) {
+            final filtered = paints
+                .where((paint) => _matchPaintSearch(paint, search))
+                .toList(growable: false);
+            return AlertDialog(
+              title: const Text('Выбор краски'),
+              content: SizedBox(
+                width: 540,
+                height: 420,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      key: ValueKey(search.isEmpty),
+                      initialValue: search,
+                      decoration: InputDecoration(
+                        labelText: 'Поиск краски',
+                        hintText: 'Наименование или цвет',
+                        prefixIcon: const Icon(Icons.search),
+                        suffixIcon: search.isEmpty
+                            ? null
+                            : IconButton(
+                                onPressed: () {
+                                  setPickerState(() {
+                                    search = '';
+                                  });
+                                },
+                                icon: const Icon(Icons.clear),
+                              ),
+                      ),
+                      onChanged: (value) =>
+                          setPickerState(() => search = value),
+                    ),
+                    const SizedBox(height: 12),
+                    Expanded(
+                      child: filtered.isEmpty
+                          ? const Center(child: Text('Ничего не найдено.'))
+                          : ListView.separated(
+                              itemCount: filtered.length,
+                              separatorBuilder: (_, __) =>
+                                  const Divider(height: 1),
+                              itemBuilder: (context, index) {
+                                final paint = filtered[index];
+                                return ListTile(
+                                  title: Text(paint.description),
+                                  subtitle: Text(
+                                    'Остаток: ${paint.quantity.toStringAsFixed(2)} ${paint.unit}',
+                                  ),
+                                  onTap: () =>
+                                      Navigator.of(pickerContext).pop(paint),
+                                );
+                              },
+                            ),
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(pickerContext).pop(),
+                  child: const Text('Отмена'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
   bool _matchPaperSearch(TmcModel paper, String query) {
     final normalized = query.trim().toLowerCase();
     if (normalized.isEmpty) return true;
@@ -1441,6 +1562,341 @@ class _TasksScreenState extends State<TasksScreen>
     }
     lines.add('Причина: ${reason.trim()}');
     return lines.join('\n');
+  }
+
+  Future<void> _addWorkspacePaintChangeComment({
+    required String orderId,
+    required String text,
+  }) async {
+    final taskProvider = context.read<TaskProvider>();
+    final candidates =
+        taskProvider.tasks.where((task) => task.orderId == orderId).toList();
+    if (candidates.isEmpty) return;
+    candidates.sort((a, b) {
+      final aPriority = (a.stageId == _selectedWorkplaceId ? 0 : 1) +
+          (_isEffectivelyCompleted(a) ? 10 : 0);
+      final bPriority = (b.stageId == _selectedWorkplaceId ? 0 : 1) +
+          (_isEffectivelyCompleted(b) ? 10 : 0);
+      if (aPriority != bPriority) return aPriority.compareTo(bPriority);
+      return a.id.compareTo(b.id);
+    });
+    await taskProvider.addCommentAutoUser(
+      taskId: candidates.first.id,
+      type: 'paint_change',
+      text: text,
+      userIdOverride: widget.employeeId,
+    );
+  }
+
+  String _buildWorkspacePaintChangeComment({
+    required List<Map<String, dynamic>> before,
+    required List<Map<String, dynamic>> after,
+    required String reason,
+  }) {
+    String label(Map<String, dynamic> paint) {
+      final name = (paint['name'] ?? paint['paint_name'] ?? '')
+          .toString()
+          .trim();
+      final qtyKg = _readDouble(paint['qty_kg']);
+      final qtyText = qtyKg == null || qtyKg <= 0
+          ? '—'
+          : '${(qtyKg * 1000).toStringAsFixed(2)} г';
+      return '${name.isEmpty ? 'Без названия' : name}: $qtyText';
+    }
+
+    final lines = <String>[
+      'Изменение красок из рабочего пространства.',
+    ];
+    final maxLen = before.length > after.length ? before.length : after.length;
+    for (var i = 0; i < maxLen; i++) {
+      final oldPaint = i < before.length ? before[i] : null;
+      final newPaint = i < after.length ? after[i] : null;
+      final slot = i + 1;
+      if (oldPaint != null && newPaint != null) {
+        lines.add('Краска №$slot Было: ${label(oldPaint)}. '
+            'Стало: ${label(newPaint)}.');
+      } else if (oldPaint == null && newPaint != null) {
+        lines.add('Краска №$slot Добавлена: ${label(newPaint)}.');
+      } else if (oldPaint != null && newPaint == null) {
+        lines.add('Краска №$slot Удалена: ${label(oldPaint)}.');
+      }
+    }
+    lines.add('Причина: ${reason.trim()}');
+    return lines.join('\n');
+  }
+
+  double? _readDouble(dynamic raw) {
+    if (raw is num) return raw.toDouble();
+    return double.tryParse((raw ?? '').toString().trim().replaceAll(',', '.'));
+  }
+
+  Future<void> _openPaintEditDialog(OrderModel baseOrder) async {
+    final latest = _orderById(baseOrder.id) ?? baseOrder;
+    final currentPaints = await OrdersRepository().getPaints(latest.id);
+    final paints = await _workspacePaintItemsFresh();
+    if (!mounted) return;
+    if (paints.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('На складе не найдено доступных красок.')),
+      );
+      return;
+    }
+
+    final selected = currentPaints.isNotEmpty
+        ? currentPaints.map((row) {
+            final name = (row['name'] ?? row['paint_name'] ?? '').toString();
+            final paint = paints.firstWhere(
+              (item) => item.description.toLowerCase() == name.toLowerCase(),
+              orElse: () => TmcModel(
+                id: (row['paint_id'] ?? '').toString(),
+                date: '',
+                type: 'paint',
+                description: name,
+                quantity: 0,
+                unit: 'г',
+              ),
+            );
+            return paint;
+          }).toList()
+        : <TmcModel>[paints.first];
+
+    final qtyControllers = <TextEditingController>[
+      for (final row in currentPaints.isNotEmpty
+          ? currentPaints
+          : const <Map<String, dynamic>>[])
+        TextEditingController(
+          text: (() {
+            final qtyKg = _readDouble(row['qty_kg']);
+            if (qtyKg == null || qtyKg <= 0) return '';
+            final grams = qtyKg * 1000;
+            return grams % 1 == 0
+                ? grams.toStringAsFixed(0)
+                : grams.toStringAsFixed(2);
+          })(),
+        ),
+    ];
+    if (qtyControllers.isEmpty) {
+      qtyControllers.add(TextEditingController());
+    }
+    final reasonController = TextEditingController();
+    final formKey = GlobalKey<FormState>();
+    String? errorText;
+    bool saving = false;
+
+    void addSlot(StateSetter setDialogState) {
+      setDialogState(() {
+        selected.add(paints.first);
+        qtyControllers.add(TextEditingController());
+      });
+    }
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            return AlertDialog(
+              title: const Text('Изменение красок в заказе'),
+              content: SizedBox(
+                width: 560,
+                child: SingleChildScrollView(
+                  child: Form(
+                    key: formKey,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (var i = 0; i < selected.length; i++)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 12),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  flex: 3,
+                                  child: InkWell(
+                                    onTap: saving
+                                        ? null
+                                        : () async {
+                                            final paint =
+                                                await _pickPaintForSlot(
+                                              context: dialogContext,
+                                              paints: paints,
+                                            );
+                                            if (paint == null) return;
+                                            setDialogState(() {
+                                              selected[i] = paint;
+                                            });
+                                          },
+                                    child: InputDecorator(
+                                      decoration: const InputDecoration(
+                                        labelText: 'Краска',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      child: Text(
+                                        selected[i].description.isEmpty
+                                            ? 'Выбрать краску'
+                                            : selected[i].description,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: qtyControllers[i],
+                                    keyboardType:
+                                        const TextInputType.numberWithOptions(
+                                      decimal: true,
+                                    ),
+                                    decoration: const InputDecoration(
+                                      labelText: 'Кол-во (г)',
+                                    ),
+                                    validator: (value) {
+                                      final qty = double.tryParse((value ?? '')
+                                          .trim()
+                                          .replaceAll(',', '.'));
+                                      if (qty == null || qty <= 0) {
+                                        return 'Введите > 0';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                                if (selected.length > 1)
+                                  IconButton(
+                                    tooltip: 'Удалить краску',
+                                    onPressed: saving
+                                        ? null
+                                        : () {
+                                            final removed =
+                                                qtyControllers[i];
+                                            setDialogState(() {
+                                              selected.removeAt(i);
+                                              qtyControllers.removeAt(i);
+                                            });
+                                            WidgetsBinding.instance
+                                                .addPostFrameCallback(
+                                                    (_) => removed.dispose());
+                                          },
+                                    icon: const Icon(Icons.delete_outline),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: TextButton.icon(
+                            onPressed: saving
+                                ? null
+                                : () => addSlot(setDialogState),
+                            icon: const Icon(Icons.add),
+                            label: const Text('Добавить краску'),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        TextFormField(
+                          controller: reasonController,
+                          maxLines: 3,
+                          decoration: const InputDecoration(
+                            labelText: 'Причина изменения',
+                            hintText: 'Без причины сохранить нельзя',
+                          ),
+                          validator: (value) => (value ?? '').trim().isEmpty
+                              ? 'Укажите причину изменения'
+                              : null,
+                        ),
+                        if (errorText != null) ...[
+                          const SizedBox(height: 8),
+                          Text(errorText!,
+                              style: const TextStyle(color: Colors.red)),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed:
+                      saving ? null : () => Navigator.of(dialogContext).pop(),
+                  child: const Text('Отмена'),
+                ),
+                FilledButton(
+                  onPressed: saving
+                      ? null
+                      : () async {
+                          if (!formKey.currentState!.validate()) return;
+                          setDialogState(() {
+                            saving = true;
+                            errorText = null;
+                          });
+                          final rows = <Map<String, dynamic>>[];
+                          for (var i = 0; i < selected.length; i++) {
+                            final qtyGrams = double.parse(qtyControllers[i]
+                                .text
+                                .trim()
+                                .replaceAll(',', '.'));
+                            final paint = selected[i];
+                            rows.add({
+                              'order_id': latest.id,
+                              'name': paint.description,
+                              'paint_name': paint.description,
+                              'paint_id': paint.id,
+                              'qty_kg': qtyGrams / 1000,
+                            });
+                          }
+
+                          try {
+                            final repo = OrdersRepository();
+                            await Supabase.instance.client
+                                .from('order_paints')
+                                .delete()
+                                .eq('order_id', latest.id);
+                            if (rows.isNotEmpty) {
+                              await Supabase.instance.client
+                                  .from('order_paints')
+                                  .insert(rows);
+                            }
+                            await repo.syncPaintReservations(
+                              orderId: latest.id,
+                              paints: rows,
+                              actor: widget.employeeId,
+                            );
+                            await _addWorkspacePaintChangeComment(
+                              orderId: latest.id,
+                              text: _buildWorkspacePaintChangeComment(
+                                before: currentPaints,
+                                after: rows,
+                                reason: reasonController.text,
+                              ),
+                            );
+                            if (!mounted) return;
+                            Navigator.of(dialogContext).pop();
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Краски успешно обновлены.'),
+                              ),
+                            );
+                          } catch (error) {
+                            setDialogState(() {
+                              saving = false;
+                              errorText =
+                                  'Не удалось сохранить изменения красок: $error';
+                            });
+                          }
+                        },
+                  child: Text(saving ? 'Сохранение...' : 'Сохранить'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    for (final controller in qtyControllers) {
+      controller.dispose();
+    }
+    reasonController.dispose();
   }
 
   Future<void> _addWorkspacePaperChangeComment({
@@ -4285,6 +4741,10 @@ class _TasksScreenState extends State<TasksScreen>
                 child: const Text('Изменить бумагу'),
               ),
             TextButton(
+              onPressed: () => Navigator.of(ctx).pop('__open_paint_edit__'),
+              child: const Text('Изменить краски'),
+            ),
+            TextButton(
               onPressed: () => Navigator.of(ctx).pop(),
               child: const Text('Отмена'),
             ),
@@ -4357,6 +4817,12 @@ class _TasksScreenState extends State<TasksScreen>
       return const _InkUsageDialogResult(
         paints: <Map<String, dynamic>>[],
         openPaperEditor: true,
+      );
+    }
+    if (result == '__open_paint_edit__') {
+      return const _InkUsageDialogResult(
+        paints: <Map<String, dynamic>>[],
+        openPaintEditor: true,
       );
     }
     if (result is _InkUsageDialogResult) {
@@ -4495,19 +4961,26 @@ class _TasksScreenState extends State<TasksScreen>
           allowPaperEdit: true,
         );
         if (dialogResult == null) return;
-        if (dialogResult.openPaperEditor) {
+        if (dialogResult.openPaperEditor || dialogResult.openPaintEditor) {
           final order = _orderById(task.orderId);
           if (order == null) {
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Не удалось найти заказ для редактирования бумаги.'),
+                SnackBar(
+                  content: Text(dialogResult.openPaintEditor
+                      ? 'Не удалось найти заказ для редактирования красок.'
+                      : 'Не удалось найти заказ для редактирования бумаги.'),
                 ),
               );
             }
             return;
           }
-          await _openPaperEditDialog(order);
+          if (dialogResult.openPaintEditor) {
+            await _openPaintEditDialog(order);
+            mutablePaints = await OrdersRepository().getPaints(task.orderId);
+          } else {
+            await _openPaperEditDialog(order);
+          }
           continue;
         }
         mutablePaints = dialogResult.paints;
@@ -4529,7 +5002,7 @@ class _TasksScreenState extends State<TasksScreen>
           initialQuantity: _initialMeterQuantityForTask(task, unitLabel),
         );
         if (result == null) return;
-        if (!result.openPaperEditor) {
+        if (!result.openPaperEditor && !result.openPaintEditor) {
           qtyInput = result;
           break;
         }
@@ -4544,7 +5017,11 @@ class _TasksScreenState extends State<TasksScreen>
           }
           return;
         }
-        await _openPaperEditDialog(order);
+        if (result.openPaintEditor) {
+          await _openPaintEditDialog(order);
+        } else {
+          await _openPaperEditDialog(order);
+        }
       }
     }
 
@@ -5080,7 +5557,7 @@ class _TasksScreenState extends State<TasksScreen>
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                                 content:
-                                    Text('Сначала завершите текущий активный заказ')));
+                                    Text('Сначала завершите текущий активный заказ или нажмите «Проблема»')));
                           }
                           return;
                         }
@@ -5206,7 +5683,8 @@ class _TasksScreenState extends State<TasksScreen>
                               _initialMeterQuantityForTask(task, unitLabel),
                         );
                         if (qtyInput == null) return;
-                        if (!qtyInput.openPaperEditor) break;
+                        if (!qtyInput.openPaperEditor &&
+                            !qtyInput.openPaintEditor) break;
                         if (order == null) {
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(
@@ -5218,7 +5696,11 @@ class _TasksScreenState extends State<TasksScreen>
                           }
                           return;
                         }
-                        await _openPaperEditDialog(order);
+                        if (qtyInput.openPaintEditor) {
+                          await _openPaintEditDialog(order);
+                        } else {
+                          await _openPaperEditDialog(order);
+                        }
                       }
                       if (qtyInput == null) return;
                       final qtyText = qtyInput.displayText;
@@ -5599,7 +6081,7 @@ class _TasksScreenState extends State<TasksScreen>
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                               content: Text(
-                                  'Сначала завершите текущий активный заказ')));
+                                  'Сначала завершите текущий активный заказ или нажмите «Проблема»')));
                         }
                         return;
                       }
@@ -5621,7 +6103,8 @@ class _TasksScreenState extends State<TasksScreen>
                                 _initialMeterQuantityForTask(task, unitLabel),
                           );
                           if (qtyInput == null) return;
-                          if (!qtyInput.openPaperEditor) break;
+                          if (!qtyInput.openPaperEditor &&
+                              !qtyInput.openPaintEditor) break;
                           final order = _orderById(task.orderId);
                           if (order == null) {
                             if (context.mounted) {
@@ -5635,7 +6118,11 @@ class _TasksScreenState extends State<TasksScreen>
                             }
                             return;
                           }
-                          await _openPaperEditDialog(order);
+                          if (qtyInput.openPaintEditor) {
+                            await _openPaintEditDialog(order);
+                          } else {
+                            await _openPaperEditDialog(order);
+                          }
                         }
                         if (qtyInput == null) return;
                         final qtyText = qtyInput.displayText;
@@ -7387,6 +7874,7 @@ Future<_QuantityInput?> _askQuantity(
   );
   final unitLabel = (unit ?? '').trim();
   const paperEditValue = '__open_paper_edit__';
+  const paintEditValue = '__open_paint_edit__';
   final v = await showDialog<_QuantityInput?>(
     context: context,
     builder: (ctx) {
@@ -7415,6 +7903,18 @@ Future<_QuantityInput?> _askQuantity(
                 ),
               ),
               child: const Text('Изменить бумагу'),
+            ),
+          if (allowPaperEdit)
+            TextButton(
+              onPressed: () => Navigator.pop(
+                ctx,
+                const _QuantityInput(
+                  quantity: 0,
+                  displayText: paintEditValue,
+                  openPaintEditor: true,
+                ),
+              ),
+              child: const Text('Изменить краски'),
             ),
           TextButton(
               onPressed: () => Navigator.pop(ctx), child: const Text('Отмена')),
@@ -7445,6 +7945,13 @@ Future<_QuantityInput?> _askQuantity(
       quantity: 0,
       displayText: '',
       openPaperEditor: true,
+    );
+  }
+  if (v.openPaintEditor || v.displayText == paintEditValue) {
+    return const _QuantityInput(
+      quantity: 0,
+      displayText: '',
+      openPaintEditor: true,
     );
   }
   return v;

--- a/lib/modules/warehouse/type_table_screen.dart
+++ b/lib/modules/warehouse/type_table_screen.dart
@@ -512,12 +512,12 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
 
     final order = row['orders'];
     if (order is Map) {
+      final customer = (order['customer'] ?? '').toString().trim();
+      if (customer.isNotEmpty) return customer;
       final code = (order['form_code'] ?? '').toString().trim();
       if (code.isNotEmpty) return code;
       final no = (order['new_form_no'] ?? '').toString().trim();
       if (no.isNotEmpty) return 'Форма №$no';
-      final customer = (order['customer'] ?? '').toString().trim();
-      if (customer.isNotEmpty) return customer;
     }
 
     final orderId = (row['order_id'] ?? '').toString().trim();
@@ -766,7 +766,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
       final rows = await Supabase.instance.client
           .from('orders')
           .select(
-              'id, assignment_id, title, name, order_name, product_name, new_form_no, data, product')
+              'id, customer, assignment_id, title, name, order_name, product_name, new_form_no, data, product')
           .inFilter('id', orderIds.toList(growable: false));
       if (rows is! List) return labels;
       for (final raw in rows.whereType<Map>()) {
@@ -788,6 +788,8 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
             : <String, dynamic>{};
 
         final label = _firstOrderLabel([
+          row['customer'],
+          data['customer'],
           row['assignment_id'],
           row['title'],
           row['order_name'],

--- a/lib/modules/warehouse/type_table_tabs_screen.dart
+++ b/lib/modules/warehouse/type_table_tabs_screen.dart
@@ -569,12 +569,12 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
 
     final order = row['orders'];
     if (order is Map) {
+      final customer = (order['customer'] ?? '').toString().trim();
+      if (customer.isNotEmpty) return customer;
       final code = (order['form_code'] ?? '').toString().trim();
       if (code.isNotEmpty) return code;
       final no = (order['new_form_no'] ?? '').toString().trim();
       if (no.isNotEmpty) return 'Форма №$no';
-      final customer = (order['customer'] ?? '').toString().trim();
-      if (customer.isNotEmpty) return customer;
     }
 
     final orderId = (row['order_id'] ?? '').toString().trim();
@@ -829,7 +829,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
       final rows = await Supabase.instance.client
           .from('orders')
           .select(
-              'id, assignment_id, title, name, order_name, product_name, new_form_no, data, product')
+              'id, customer, assignment_id, title, name, order_name, product_name, new_form_no, data, product')
           .inFilter('id', orderIds.toList(growable: false));
       if (rows is! List) return labels;
       for (final raw in rows.whereType<Map>()) {
@@ -851,6 +851,8 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
             : <String, dynamic>{};
 
         final label = _firstOrderLabel([
+          row['customer'],
+          data['customer'],
           row['assignment_id'],
           row['title'],
           row['order_name'],


### PR DESCRIPTION
### Motivation
- Prefer customer name (when available) when showing order labels for paper/paint reserves to make reserve details more user-friendly. 
- Allow editing paints from the production workspace (same UX flow as paper) so paints can be added/removed/edited before finalizing tasks without touching `paint_table.dart`.
- Prevent resuming a previous order while an employee has an active order, and clarify the user message to indicate finishing the active order or reporting a problem. 
- Improve chat UX by queuing selected attachments and uploading them only when the user taps `Send`, matching standard messenger behavior.

### Description
- Updated reserve label resolution in `lib/modules/warehouse/type_table_screen.dart` and `lib/modules/warehouse/type_table_tabs_screen.dart` to prefer `customer` and `data['customer']` when building order labels and when showing reservation details (`_loadOrderLabelsByIds`, `_orderLabelFromReservation`).
- Implemented paint editing in `lib/modules/tasks/tasks_screen.dart` by adding `List<TmcModel> _workspacePaintItems()`, `Future<List<TmcModel>> _workspacePaintItemsFresh()`, `_matchPaintSearch()`, `_pickPaintForSlot()`, `_openPaintEditDialog()`, `_addWorkspacePaintChangeComment()` and `_buildWorkspacePaintChangeComment()`, plus hooks to call paint editing from the ink-adjust dialog and finalize flows; introduced `openPaintEditor` flags in `_QuantityInput` and `_InkUsageDialogResult` to coordinate the flows.
- Integrated paint edit flow into existing dialogs: the ink adjustment dialog now exposes an "Изменить краски" action that opens the paint editor and then returns to the writeoff/finalize flow; `order_paints` is updated and `OrdersRepository().syncPaintReservations` is invoked to keep reservations consistent.
- Preserved and clarified blocking logic in tasks: kept the separate-mode active-order guard in `_hasBlockingActiveOrder` and updated user-facing snackbars to suggest finishing the active order or pressing `Проблема`.
- Changed chat input behavior in `lib/modules/chat/widgets/input_bar.dart` to collect attachments into a `_pendingAttachments` queue (`_PendingChatAttachment`), display pending chips, and only call upload (`ChatProvider.sendFile`) when `_sendText` is invoked; added helper methods `_queueAttachment`, `_removePendingAttachment`, and `_sendPendingAttachments`.
- Small wiring and UI changes to connect the above (buttons, dialog returns, text labels); all changes were made inside `type_table_*`, `tasks_screen.dart`, and `input_bar.dart` as requested.

### Testing
- Ran `git diff --check` to ensure there are no obvious whitespace/merge issues (passed).
- Attempted to run `dart format` and `flutter analyze` but the environment does not have Dart/Flutter installed, so code formatting and static analysis could not be executed here (tooling unavailable).
- All changes were validated by local code inspection and compilation-ready edits; further verification with `dart format`/`flutter analyze` and running the app is recommended in a developer environment with Flutter tooling available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e8799cdc832f8f582e06aef01957)