### PR TITLE
Fix task paint repository scope

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4852,9 +4852,9 @@ class _TasksScreenState extends State<TasksScreen>
     List<Map<String, dynamic>> paints = const <Map<String, dynamic>>[];
     _QuantityInput? qtyInput = initialQtyInput;
     if (_isInkConfirmationStage(task)) {
+      final repo = OrdersRepository();
       List<Map<String, dynamic>> initialPaints = const <Map<String, dynamic>>[];
       try {
-        final repo = OrdersRepository();
         initialPaints = await repo.getPaints(task.orderId);
         final currentPaintIds = initialPaints
             .map((paint) => _stringFromRow(paint, const [


### PR DESCRIPTION
### Motivation
- Исправить ошибку компиляции, где переменная `repo` была недоступна в методе `_finalizeTask` при повторной загрузке красок после закрытия редактора из‑за ограниченной области видимости.

### Description
- Перенесено создание экземпляра `OrdersRepository` наружу блока `try` в `lib/modules/tasks/tasks_screen.dart`, чтобы `repo` оставался в области видимости при последующих вызовах `repo.getPaints(...)`.

### Testing
- Выполнена автоматическая проверка с `git diff --check`, которая прошла успешно, а команды `dart --version` и `flutter --version` не выполнились из‑за отсутствия соответствующих SDK в контейнере.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06edc115d0832f9f773f90f2066d17)