### PR TITLE
Fix workplace queue position sync

### DIFF
--- a/lib/modules/production/production_queue_provider.dart
+++ b/lib/modules/production/production_queue_provider.dart
@@ -15,6 +15,7 @@ class WorkplaceQueuePosition {
   final String stageId;
   final String? stageGroupKey;
   final int queuePosition;
+  final bool hasQueuePosition;
 
   const WorkplaceQueuePosition({
     required this.id,
@@ -24,6 +25,7 @@ class WorkplaceQueuePosition {
     required this.stageId,
     required this.stageGroupKey,
     required this.queuePosition,
+    this.hasQueuePosition = true,
   });
 
   String get queueKey => ProductionQueueProvider.queueKeyFor(
@@ -43,6 +45,7 @@ class WorkplaceQueuePosition {
       stageId: (map['stage_id'] ?? '').toString(),
       stageGroupKey: _nullableTrimmed(map['stage_group_key']),
       queuePosition: _intFrom(map['queue_position']) ?? (1 << 30),
+      hasQueuePosition: _intFrom(map['queue_position']) != null,
     );
   }
 
@@ -55,6 +58,123 @@ class WorkplaceQueuePosition {
     if (value is int) return value;
     if (value is num) return value.toInt();
     return int.tryParse(value?.toString() ?? '');
+  }
+}
+
+@visibleForTesting
+class WorkplaceQueuePositionInsertPlan {
+  const WorkplaceQueuePositionInsertPlan({
+    required this.entry,
+    required this.queuePosition,
+  });
+
+  final WorkplaceQueueEntry entry;
+  final int queuePosition;
+}
+
+@visibleForTesting
+class WorkplaceQueuePositionPlanner {
+  const WorkplaceQueuePositionPlanner._();
+
+  static int comparePositions(
+    WorkplaceQueuePosition left,
+    WorkplaceQueuePosition right,
+  ) {
+    if (left.hasQueuePosition != right.hasQueuePosition) {
+      return left.hasQueuePosition ? -1 : 1;
+    }
+    final byPosition = left.queuePosition.compareTo(right.queuePosition);
+    if (byPosition != 0) return byPosition;
+    return left.id.compareTo(right.id);
+  }
+
+  static List<WorkplaceQueuePosition> sortedPositions(
+    Iterable<WorkplaceQueuePosition> positions,
+  ) {
+    final sorted = positions.toList(growable: false);
+    sorted.sort(comparePositions);
+    return sorted;
+  }
+
+  static int maxAssignedPosition(Iterable<WorkplaceQueuePosition> positions) {
+    var maxPosition = 0;
+    for (final position in positions) {
+      if (!position.hasQueuePosition) continue;
+      if (position.queuePosition > maxPosition) {
+        maxPosition = position.queuePosition;
+      }
+    }
+    return maxPosition;
+  }
+
+  static List<WorkplaceQueueEntry> missingEntries({
+    required Iterable<WorkplaceQueuePosition> existing,
+    required Iterable<WorkplaceQueueEntry> entries,
+    required String workplaceId,
+  }) {
+    final normalizedWorkplace = workplaceId.trim();
+    final existingKeys = {
+      for (final position in existing)
+        if (position.workplaceId.trim() == normalizedWorkplace) position.queueKey,
+    };
+    final missing = <WorkplaceQueueEntry>[];
+    final seen = <String>{};
+    for (final entry in entries) {
+      if (entry.workplaceId.trim() != normalizedWorkplace) continue;
+      if (entry.orderId.trim().isEmpty || entry.stageId.trim().isEmpty) {
+        continue;
+      }
+      if (existingKeys.contains(entry.queueKey)) continue;
+      if (!seen.add(entry.queueKey)) continue;
+      missing.add(entry);
+    }
+    return missing;
+  }
+
+  static List<WorkplaceQueuePositionInsertPlan> appendMissingAfterMax({
+    required Iterable<WorkplaceQueuePosition> existing,
+    required Iterable<WorkplaceQueueEntry> entries,
+    required String workplaceId,
+  }) {
+    final missing = missingEntries(
+      existing: existing,
+      entries: entries,
+      workplaceId: workplaceId,
+    );
+    var nextPosition = maxAssignedPosition(existing) + 1;
+    return [
+      for (final entry in missing)
+        WorkplaceQueuePositionInsertPlan(
+          entry: entry,
+          queuePosition: nextPosition++,
+        ),
+    ];
+  }
+
+  static List<String> reorderedKeys({
+    required Iterable<WorkplaceQueuePosition> current,
+    required Iterable<WorkplaceQueueEntry> orderedEntries,
+    required String workplaceId,
+  }) {
+    final normalizedWorkplace = workplaceId.trim();
+    final entries = <WorkplaceQueueEntry>[];
+    final seen = <String>{};
+    for (final entry in orderedEntries) {
+      if (entry.workplaceId.trim() != normalizedWorkplace) continue;
+      if (!seen.add(entry.queueKey)) continue;
+      entries.add(entry);
+    }
+
+    final currentForWorkplace = sortedPositions(current.where(
+      (position) => position.workplaceId.trim() == normalizedWorkplace,
+    ));
+    final orderedKeys = entries.map((entry) => entry.queueKey).toSet();
+    return <String>[
+      ...entries.map((entry) => entry.queueKey),
+      ...currentForWorkplace
+          .where((position) => !orderedKeys.contains(position.queueKey))
+          .map((position) => position.queueKey),
+    ];
   }
 }
 
@@ -365,10 +485,13 @@ class ProductionQueueProvider with ChangeNotifier {
           .eq('workplace_id', normalized)
           .order('queue_position');
       if (raw is! List) return positionsForWorkplace(normalized);
-      final positions = raw
-          .whereType<Map>()
-          .map((row) => WorkplaceQueuePosition.fromMap(Map<String, dynamic>.from(row)))
-          .toList();
+      final positions = WorkplaceQueuePositionPlanner.sortedPositions(
+        raw.whereType<Map>().map(
+              (row) => WorkplaceQueuePosition.fromMap(
+                Map<String, dynamic>.from(row),
+              ),
+            ),
+      );
       _positionsByWorkplace[normalized] = {
         for (final position in positions) position.queueKey: position,
       };
@@ -383,8 +506,7 @@ class ProductionQueueProvider with ChangeNotifier {
   List<WorkplaceQueuePosition> positionsForWorkplace(String workplaceId) {
     final values = _positionsByWorkplace[_normalizeWorkplaceId(workplaceId)]?.values.toList() ??
         <WorkplaceQueuePosition>[];
-    values.sort((a, b) => a.queuePosition.compareTo(b.queuePosition));
-    return values;
+    return WorkplaceQueuePositionPlanner.sortedPositions(values);
   }
 
   int priorityOfEntry(WorkplaceQueueEntry entry) {
@@ -494,21 +616,27 @@ class ProductionQueueProvider with ChangeNotifier {
 
   Future<int> _nextPositionForWorkplace(String workplaceId) async {
     final normalized = _normalizeWorkplaceId(workplaceId);
-    final cached = _positionsByWorkplace[normalized]?.values ?? const <WorkplaceQueuePosition>[];
+    final cached = _positionsByWorkplace[normalized]?.values ??
+        const <WorkplaceQueuePosition>[];
     var maxPosition = 0;
     for (final item in cached) {
+      if (!item.hasQueuePosition) continue;
       if (item.queuePosition > maxPosition) maxPosition = item.queuePosition;
     }
     try {
       final raw = await _sb
           .from(_positionsTable)
           .select('queue_position')
-          .eq('workplace_id', normalized)
-          .order('queue_position', ascending: false)
-          .limit(1);
-      if (raw is List && raw.isNotEmpty && raw.first is Map) {
-        final remoteMax = WorkplaceQueuePosition._intFrom((raw.first as Map)['queue_position']);
-        if (remoteMax != null && remoteMax > maxPosition) maxPosition = remoteMax;
+          .eq('workplace_id', normalized);
+      if (raw is List) {
+        for (final row in raw.whereType<Map>()) {
+          final remoteMax = WorkplaceQueuePosition._intFrom(
+            row['queue_position'],
+          );
+          if (remoteMax != null && remoteMax > maxPosition) {
+            maxPosition = remoteMax;
+          }
+        }
       }
     } catch (_) {}
     return maxPosition + 1;
@@ -516,7 +644,9 @@ class ProductionQueueProvider with ChangeNotifier {
 
   Future<void> ensureEntryAtTail(WorkplaceQueueEntry entry) async {
     final workplaceId = _normalizeWorkplaceId(entry.workplaceId);
-    if (workplaceId.isEmpty || entry.orderId.trim().isEmpty || entry.stageId.trim().isEmpty) return;
+    if (workplaceId.isEmpty ||
+        entry.orderId.trim().isEmpty ||
+        entry.stageId.trim().isEmpty) return;
     if (_positionsByWorkplace[workplaceId]?.containsKey(entry.queueKey) == true) return;
     try {
       await _ensureAuthed();
@@ -524,44 +654,97 @@ class ProductionQueueProvider with ChangeNotifier {
       await _sb.from(_positionsTable).insert(entry.toInsertMap(position));
       await loadPositionsForWorkplace(workplaceId);
     } catch (e) {
-      debugPrint('⚠️ Failed to append workplace queue entry "${entry.queueKey}": $e');
+      debugPrint(
+        '⚠️ Failed to append workplace queue entry "${entry.queueKey}": $e',
+      );
       await loadPositionsForWorkplace(workplaceId);
     }
   }
 
-  /// Синхронизирует задания рабочего места: существующие позиции не меняются,
-  /// новые записи добавляются в конец очереди только внутри [workplaceId].
+  /// Синхронизирует задания рабочих мест: существующие позиции не меняются,
+  /// новые записи добавляются в конец очереди только внутри своего workplace.
   void syncWorkplaceEntries(
     Iterable<WorkplaceQueueEntry> entries, {
-    required String workplaceId,
+    String? workplaceId,
   }) {
     if (_isSyncingOrders) return;
-    final normalizedWorkplace = _normalizeWorkplaceId(workplaceId);
-    if (normalizedWorkplace.isEmpty) return;
+    final requestedWorkplace =
+        workplaceId == null ? null : _normalizeWorkplaceId(workplaceId);
+    if (workplaceId != null && requestedWorkplace!.isEmpty) return;
     _isSyncingOrders = true;
     try {
       unawaited(_bootstrapRemoteSync());
-      final normalizedEntries = <WorkplaceQueueEntry>[];
-      final seen = <String>{};
+      final entriesByWorkplace = <String, List<WorkplaceQueueEntry>>{};
+      final seenByWorkplace = <String, Set<String>>{};
       for (final entry in entries) {
-        if (_normalizeWorkplaceId(entry.workplaceId) != normalizedWorkplace) continue;
-        if (entry.orderId.trim().isEmpty || entry.stageId.trim().isEmpty) continue;
+        final normalized = _normalizeWorkplaceId(entry.workplaceId);
+        if (normalized.isEmpty) continue;
+        if (requestedWorkplace != null && normalized != requestedWorkplace) {
+          continue;
+        }
+        if (entry.orderId.trim().isEmpty || entry.stageId.trim().isEmpty) {
+          continue;
+        }
+        final seen = seenByWorkplace.putIfAbsent(normalized, () => <String>{});
         if (!seen.add(entry.queueKey)) continue;
-        normalizedEntries.add(entry);
+        entriesByWorkplace
+            .putIfAbsent(normalized, () => <WorkplaceQueueEntry>[])
+            .add(entry);
+      }
+      if (entriesByWorkplace.isEmpty) {
+        _isSyncingOrders = false;
+        return;
       }
       unawaited(() async {
         try {
-          await loadPositionsForWorkplace(normalizedWorkplace);
-          for (final entry in normalizedEntries) {
-            await ensureEntryAtTail(entry);
+          for (final workplaceEntry in entriesByWorkplace.entries) {
+            await _syncSingleWorkplaceEntries(
+              workplaceEntry.value,
+              workplaceId: workplaceEntry.key,
+            );
           }
-          await normalizePositions(workplaceId: normalizedWorkplace);
         } finally {
           _isSyncingOrders = false;
         }
       }());
     } catch (_) {
       _isSyncingOrders = false;
+    }
+  }
+
+  Future<void> _syncSingleWorkplaceEntries(
+    List<WorkplaceQueueEntry> entries, {
+    required String workplaceId,
+  }) async {
+    final positions = await loadPositionsForWorkplace(workplaceId);
+    if (positions.any((position) => !position.hasQueuePosition)) {
+      await normalizePositions(workplaceId: workplaceId);
+    }
+    final current = positionsForWorkplace(workplaceId);
+    final insertPlans = WorkplaceQueuePositionPlanner.appendMissingAfterMax(
+      existing: current,
+      entries: entries,
+      workplaceId: workplaceId,
+    );
+    for (final plan in insertPlans) {
+      await _insertEntryAtPosition(plan.entry, plan.queuePosition);
+    }
+    if (insertPlans.isNotEmpty) {
+      await loadPositionsForWorkplace(workplaceId);
+    }
+  }
+
+  Future<void> _insertEntryAtPosition(
+    WorkplaceQueueEntry entry,
+    int queuePosition,
+  ) async {
+    try {
+      await _ensureAuthed();
+      await _sb.from(_positionsTable).insert(entry.toInsertMap(queuePosition));
+    } catch (e) {
+      debugPrint(
+        '⚠️ Failed to append workplace queue entry "${entry.queueKey}": $e',
+      );
     }
   }
 
@@ -602,16 +785,13 @@ class ProductionQueueProvider with ChangeNotifier {
       await ensureEntryAtTail(entry);
     }
     final current = positionsForWorkplace(normalized);
-    final orderedKeys = entries.map((entry) => entry.queueKey).toSet();
-    final remaining = current
-        .where((position) => !orderedKeys.contains(position.queueKey))
-        .toList();
-    final nextKeys = <String>[
-      ...entries.map((entry) => entry.queueKey),
-      ...remaining.map((position) => position.queueKey),
-    ];
+    final nextKeys = WorkplaceQueuePositionPlanner.reorderedKeys(
+      current: current,
+      orderedEntries: entries,
+      workplaceId: normalized,
+    );
     final byKey = {
-      for (final position in positionsForWorkplace(normalized)) position.queueKey: position,
+      for (final position in current) position.queueKey: position,
     };
     for (var i = 0; i < nextKeys.length; i++) {
       final position = byKey[nextKeys[i]];

--- a/test/production_queue_position_planner_test.dart
+++ b/test/production_queue_position_planner_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/production/production_queue_provider.dart';
+
+WorkplaceQueueEntry _entry(
+  String workplaceId,
+  String orderId, {
+  String? taskId,
+  String? stageId,
+  String? stageGroupKey,
+}) {
+  return WorkplaceQueueEntry(
+    workplaceId: workplaceId,
+    taskId: taskId,
+    orderId: orderId,
+    stageId: stageId ?? 'stage-$orderId',
+    stageGroupKey: stageGroupKey ?? 'group-$orderId',
+  );
+}
+
+WorkplaceQueuePosition _position(
+  String workplaceId,
+  String orderId,
+  int queuePosition, {
+  String? id,
+  String? taskId,
+  String? stageId,
+  String? stageGroupKey,
+  bool hasQueuePosition = true,
+}) {
+  return WorkplaceQueuePosition(
+    id: id ?? '$workplaceId-$orderId',
+    workplaceId: workplaceId,
+    taskId: taskId,
+    orderId: orderId,
+    stageId: stageId ?? 'stage-$orderId',
+    stageGroupKey: stageGroupKey ?? 'group-$orderId',
+    queuePosition: queuePosition,
+    hasQueuePosition: hasQueuePosition,
+  );
+}
+
+void main() {
+  group('WorkplaceQueuePositionPlanner', () {
+    test('appends a new element to the end of the workplace queue', () {
+      final existing = [
+        _position('cut', 'order-1', 4),
+        _position('cut', 'order-2', 7),
+      ];
+      final entries = [
+        _entry('cut', 'order-2'),
+        _entry('cut', 'order-3'),
+      ];
+
+      final plan = WorkplaceQueuePositionPlanner.appendMissingAfterMax(
+        existing: existing,
+        entries: entries,
+        workplaceId: 'cut',
+      );
+
+      expect(plan, hasLength(1));
+      expect(plan.single.entry.orderId, 'order-3');
+      expect(plan.single.queuePosition, 8);
+    });
+
+    test('keeps incoming order for new tasks instead of priority sorting', () {
+      final existing = [
+        _position('cut', 'order-1', 1),
+      ];
+      final entries = [
+        _entry('cut', 'order-low'),
+        _entry('cut', 'order-high'),
+      ];
+
+      final plan = WorkplaceQueuePositionPlanner.appendMissingAfterMax(
+        existing: existing,
+        entries: entries,
+        workplaceId: 'cut',
+      );
+
+      expect(plan.map((item) => item.entry.orderId), [
+        'order-low',
+        'order-high',
+      ]);
+      expect(plan.map((item) => item.queuePosition), [2, 3]);
+    });
+
+    test('reorder in one workplace does not change another workplace', () {
+      final cutFirst = _position('cut', 'order-1', 1);
+      final cutSecond = _position('cut', 'order-2', 2);
+      final printFirst = _position('print', 'order-3', 1);
+      final printSecond = _position('print', 'order-4', 2);
+      final current = [cutFirst, cutSecond, printFirst, printSecond];
+
+      final cutKeys = WorkplaceQueuePositionPlanner.reorderedKeys(
+        current: current,
+        orderedEntries: [
+          _entry('cut', 'order-2'),
+          _entry('cut', 'order-1'),
+        ],
+        workplaceId: 'cut',
+      );
+      final printKeys = WorkplaceQueuePositionPlanner.sortedPositions(
+        current.where((position) => position.workplaceId == 'print'),
+      ).map((position) => position.queueKey);
+
+      expect(cutKeys, [cutSecond.queueKey, cutFirst.queueKey]);
+      expect(printKeys, [printFirst.queueKey, printSecond.queueKey]);
+    });
+
+    test('sync plan does not delete or reorder existing positions', () {
+      final existing = [
+        _position('pack', 'order-1', 10),
+        _position('pack', 'order-2', 30),
+      ];
+      final entries = [
+        _entry('pack', 'order-2'),
+        _entry('pack', 'order-3'),
+        _entry('pack', 'order-1'),
+      ];
+
+      final plan = WorkplaceQueuePositionPlanner.appendMissingAfterMax(
+        existing: existing,
+        entries: entries,
+        workplaceId: 'pack',
+      );
+      final existingAfterPlan = WorkplaceQueuePositionPlanner.sortedPositions(
+        existing,
+      );
+
+      expect(plan.map((item) => item.entry.orderId), ['order-3']);
+      expect(plan.map((item) => item.queuePosition), [31]);
+      expect(existingAfterPlan.map((position) => position.orderId), [
+        'order-1',
+        'order-2',
+      ]);
+      expect(existingAfterPlan.map((position) => position.queuePosition), [
+        10,
+        30,
+      ]);
+    });
+
+    test('loads legacy rows without a position after positioned rows', () {
+      final positioned = _position('lamination', 'order-1', 2);
+      final legacyWithoutPosition = _position(
+        'lamination',
+        'order-legacy',
+        1 << 30,
+        hasQueuePosition: false,
+      );
+
+      final sorted = WorkplaceQueuePositionPlanner.sortedPositions([
+        legacyWithoutPosition,
+        positioned,
+      ]);
+
+      expect(sorted.map((position) => position.orderId), [
+        'order-1',
+        'order-legacy',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- Existing `workplace_queue_positions` handling mixed legacy rows without `queue_position` with sentinel values and produced incorrect insert ordering and cross-workplace interference. 
- The goal is to append missing entries per `workplace_id` after that workplace's current maximum `queue_position` and avoid sorting new entries by unrelated fields (`priority`, `created_at`, etc.).

### Description
- Introduced `hasQueuePosition` on `WorkplaceQueuePosition` and a helper `WorkplaceQueuePositionPlanner` to separate sorting/normalization logic and compute per-workplace insert plans. 
- Updated `syncWorkplaceEntries` to group incoming `WorkplaceQueueEntry` items by their `workplace_id`, normalize legacy rows without positions once per workplace, and append only missing entries after the workplace-specific `max(queue_position)` using `appendMissingAfterMax` (no sorting of new entries by priority/dates/etc.).
- Reused planner logic in `saveWorkplaceReorder` via `reorderedKeys` so reorders affect only the target workplace and preserve other workplaces. 
- Added tests in `test/production_queue_position_planner_test.dart` that cover: new element appended to tail, incoming order preserved for new tasks, reorder isolation between workplaces, existing positions preserved and not deleted/reordered, and legacy rows without `queue_position` sorted after positioned rows.

### Testing
- Added unit tests in `test/production_queue_position_planner_test.dart` (new file) exercising `WorkplaceQueuePositionPlanner` behavior and `reorderedKeys`; tests are present but not executed in this environment. 
- Ran `git diff --check` which produced no warnings. 
- Attempts to run `flutter test` and `dart format` were not executed because the CI/dev environment used here does not have `flutter`/`dart` installed, so test execution and formatting were not performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acfce1810832f9d8c27ea82fff2a8)