### PR TITLE
Workplace queue: reorder by task/stage keys and normalize positions per workplace

### DIFF
--- a/lib/modules/production/production_queue_provider.dart
+++ b/lib/modules/production/production_queue_provider.dart
@@ -156,25 +156,84 @@ class WorkplaceQueuePositionPlanner {
     required Iterable<WorkplaceQueueEntry> orderedEntries,
     required String workplaceId,
   }) {
+    return reorderedQueueKeys(
+      current: current,
+      orderedKeys: orderedEntries.map(
+        (entry) => WorkplaceQueueItemKey.fromEntry(entry),
+      ),
+      workplaceId: workplaceId,
+    );
+  }
+
+  static List<String> reorderedQueueKeys({
+    required Iterable<WorkplaceQueuePosition> current,
+    required Iterable<WorkplaceQueueItemKey> orderedKeys,
+    required String workplaceId,
+  }) {
     final normalizedWorkplace = workplaceId.trim();
-    final entries = <WorkplaceQueueEntry>[];
+    final visibleKeys = <String>[];
     final seen = <String>{};
-    for (final entry in orderedEntries) {
-      if (entry.workplaceId.trim() != normalizedWorkplace) continue;
-      if (!seen.add(entry.queueKey)) continue;
-      entries.add(entry);
+    for (final key in orderedKeys) {
+      if (key.workplaceId.trim() != normalizedWorkplace) continue;
+      final queueKey = key.queueKey;
+      if (!seen.add(queueKey)) continue;
+      visibleKeys.add(queueKey);
     }
 
     final currentForWorkplace = sortedPositions(current.where(
       (position) => position.workplaceId.trim() == normalizedWorkplace,
     ));
-    final orderedKeys = entries.map((entry) => entry.queueKey).toSet();
+    final visibleKeySet = visibleKeys.toSet();
     return <String>[
-      ...entries.map((entry) => entry.queueKey),
+      ...visibleKeys,
       ...currentForWorkplace
-          .where((position) => !orderedKeys.contains(position.queueKey))
+          .where((position) => !visibleKeySet.contains(position.queueKey))
           .map((position) => position.queueKey),
     ];
+  }
+}
+
+class WorkplaceQueueItemKey {
+  final String workplaceId;
+  final String? taskId;
+  final String orderId;
+  final String stageId;
+  final String? stageGroupKey;
+
+  const WorkplaceQueueItemKey({
+    required this.workplaceId,
+    this.taskId,
+    required this.orderId,
+    required this.stageId,
+    this.stageGroupKey,
+  });
+
+  factory WorkplaceQueueItemKey.fromEntry(WorkplaceQueueEntry entry) {
+    return WorkplaceQueueItemKey(
+      workplaceId: entry.workplaceId,
+      taskId: entry.taskId,
+      orderId: entry.orderId,
+      stageId: entry.stageId,
+      stageGroupKey: entry.stageGroupKey,
+    );
+  }
+
+  String get queueKey => ProductionQueueProvider.queueKeyFor(
+        workplaceId: workplaceId,
+        taskId: taskId,
+        orderId: orderId,
+        stageId: stageId,
+        stageGroupKey: stageGroupKey,
+      );
+
+  WorkplaceQueueEntry toEntry() {
+    return WorkplaceQueueEntry(
+      workplaceId: workplaceId,
+      taskId: taskId,
+      orderId: orderId,
+      stageId: stageId,
+      stageGroupKey: stageGroupKey,
+    );
   }
 }
 
@@ -769,25 +828,40 @@ class ProductionQueueProvider with ChangeNotifier {
     Iterable<WorkplaceQueueEntry> orderedEntries, {
     required String workplaceId,
   }) async {
+    await applyVisibleTaskReorder(
+      workplaceId: workplaceId,
+      orderedKeys: orderedEntries
+          .map((entry) => WorkplaceQueueItemKey.fromEntry(entry))
+          .toList(growable: false),
+    );
+  }
+
+  /// Applies the visible task/stage order for one workplace and rewrites only
+  /// that workplace's queue positions to a normalized 1-based sequence.
+  Future<void> applyVisibleTaskReorder({
+    required String workplaceId,
+    required List<WorkplaceQueueItemKey> orderedKeys,
+  }) async {
     final normalized = _normalizeWorkplaceId(workplaceId);
     if (normalized.isEmpty) return;
-    final entries = <WorkplaceQueueEntry>[];
+    final visibleKeys = <WorkplaceQueueItemKey>[];
     final seen = <String>{};
-    for (final entry in orderedEntries) {
-      if (_normalizeWorkplaceId(entry.workplaceId) != normalized) continue;
-      if (!seen.add(entry.queueKey)) continue;
-      entries.add(entry);
+    for (final key in orderedKeys) {
+      if (_normalizeWorkplaceId(key.workplaceId) != normalized) continue;
+      if (key.orderId.trim().isEmpty || key.stageId.trim().isEmpty) continue;
+      if (!seen.add(key.queueKey)) continue;
+      visibleKeys.add(key);
     }
-    if (entries.isEmpty) return;
+    if (visibleKeys.isEmpty) return;
 
     await loadPositionsForWorkplace(normalized);
-    for (final entry in entries) {
-      await ensureEntryAtTail(entry);
+    for (final key in visibleKeys) {
+      await ensureEntryAtTail(key.toEntry());
     }
     final current = positionsForWorkplace(normalized);
-    final nextKeys = WorkplaceQueuePositionPlanner.reorderedKeys(
+    final nextKeys = WorkplaceQueuePositionPlanner.reorderedQueueKeys(
       current: current,
-      orderedEntries: entries,
+      orderedKeys: visibleKeys,
       workplaceId: normalized,
     );
     final byKey = {

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -1383,13 +1383,17 @@ class _ProductionTabState extends State<_ProductionTab> {
                   final updated = List.of(ordered);
                   final item = updated.removeAt(oldIndex);
                   updated.insert(newIndex, item);
-                  queue.saveWorkplaceReorder(
-                    updated.map((order) => _queueEntryForOrder(
-                          order,
-                          groupingByOrder[order.id]!,
-                          tab.id,
-                        )),
+                  queue.applyVisibleTaskReorder(
                     workplaceId: tab.id,
+                    orderedKeys: updated
+                        .map((order) => WorkplaceQueueItemKey.fromEntry(
+                              _queueEntryForOrder(
+                                order,
+                                groupingByOrder[order.id]!,
+                                tab.id,
+                              ),
+                            ))
+                        .toList(growable: false),
                   );
                 },
                 itemBuilder: (context, index) {
@@ -1400,6 +1404,9 @@ class _ProductionTabState extends State<_ProductionTab> {
                     grouping.tasksByGroup,
                   );
                   final qty = order.product.quantity.toDouble();
+
+                  final queueEntry =
+                      _queueEntryForOrder(order, grouping, tab.id);
 
                   return _buildOrderRow(
                     context: context,
@@ -1412,6 +1419,7 @@ class _ProductionTabState extends State<_ProductionTab> {
                     orderLabel: _orderLabel(order),
                     showDragHandle: true,
                     dragIndex: index,
+                    rowKey: ValueKey(queueEntry.queueKey),
                   );
                 },
               )
@@ -1497,9 +1505,10 @@ class _ProductionTabState extends State<_ProductionTab> {
     required String orderLabel,
     required bool showDragHandle,
     int? dragIndex,
+    Key? rowKey,
   }) {
     return Container(
-      key: ValueKey(order.id),
+      key: rowKey ?? ValueKey(order.id),
       margin: const EdgeInsets.symmetric(vertical: 4),
       decoration: BoxDecoration(
         color: completed ? Colors.green.withOpacity(0.08) : Colors.white,

--- a/test/production_queue_position_planner_test.dart
+++ b/test/production_queue_position_planner_test.dart
@@ -107,6 +107,54 @@ void main() {
       expect(printKeys, [printFirst.queueKey, printSecond.queueKey]);
     });
 
+    test('reorders by concrete task keys inside selected workplace only', () {
+      final cutPaint = _position(
+        'cut',
+        'order-1',
+        1,
+        taskId: 'task-paint',
+        stageId: 'paint',
+        stageGroupKey: 'finish',
+      );
+      final cutCut = _position(
+        'cut',
+        'order-1',
+        2,
+        taskId: 'task-cut',
+        stageId: 'cut',
+        stageGroupKey: 'cut',
+      );
+      final print = _position('print', 'order-2', 1, taskId: 'task-print');
+
+      final keys = WorkplaceQueuePositionPlanner.reorderedQueueKeys(
+        current: [cutPaint, cutCut, print],
+        orderedKeys: [
+          WorkplaceQueueItemKey.fromEntry(_entry(
+            'cut',
+            'order-1',
+            taskId: 'task-cut',
+            stageId: 'cut',
+            stageGroupKey: 'cut',
+          )),
+          WorkplaceQueueItemKey.fromEntry(_entry(
+            'cut',
+            'order-1',
+            taskId: 'task-paint',
+            stageId: 'paint',
+            stageGroupKey: 'finish',
+          )),
+          WorkplaceQueueItemKey.fromEntry(_entry(
+            'print',
+            'order-2',
+            taskId: 'task-print',
+          )),
+        ],
+        workplaceId: 'cut',
+      );
+
+      expect(keys, [cutCut.queueKey, cutPaint.queueKey]);
+    });
+
     test('sync plan does not delete or reorder existing positions', () {
       final existing = [
         _position('pack', 'order-1', 10),


### PR DESCRIPTION
### Motivation
- Make drag-reorder operate on concrete task/stage items for the currently visible workplace tab instead of using only order IDs so the UI and persisted queue reflect task-level ordering for that workplace. 
- Persist a normalized 1-based `queue_position` sequence for a single workplace without touching other workplaces. 
- Keep existing UX restriction that prevents reordering when the stage is already in progress and show the same SnackBar.

### Description
- Added `WorkplaceQueueItemKey` to represent a task/stage-level queue item key and helpers to convert between entries and keys.  
- Introduced `WorkplaceQueuePositionPlanner.reorderedQueueKeys(...)` and kept the old `reorderedKeys(...)` as a wrapper to support both entry- and key-based inputs.  
- Added `ProductionQueueProvider.applyVisibleTaskReorder({required String workplaceId, required List<WorkplaceQueueItemKey> orderedKeys})` which: filters keys to the selected `workplaceId`, ensures missing visible entries exist, writes normalized `queue_position` values `1,2,3...` only for that workplace in Supabase, reloads that workplace positions, and does not modify other workplaces.  
- Changed `saveWorkplaceReorder` to delegate to the new `applyVisibleTaskReorder`.  
- Updated `production_screen.dart` to keep `ReorderableListView.builder` but send concrete `WorkplaceQueueItemKey` instances for the current `tab.id` when reordering, and set row widget keys to the `queueKey` so the draggable row key matches the visible task/stage item.  
- Preserved the existing check that blocks reordering when a stage is `inProgress` and preserved the same SnackBar text/UX.  
- Added a unit test covering concrete task-key reordering scoped to one workplace (`test/production_queue_position_planner_test.dart`).

### Testing
- Ran `git diff --check` to validate whitespace/merge conflicts and it passed.  
- Added unit test `test/production_queue_position_planner_test.dart` verifying `reorderedQueueKeys(...)` behavior, but `flutter test` was not executed in this environment because `flutter`/`dart` SDK is not available (test run failed to start).  
- `dart format` was not executed in this environment because `dart` is not available; files were committed formatted by changes made in the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad17dc01c832f94b8edd576cd84d3)