### PR TITLE
Align paints_writeoffs.paint_id type and validate RPC paint_id payloads

### DIFF
--- a/lib/modules/orders/orders_repository.dart
+++ b/lib/modules/orders/orders_repository.dart
@@ -517,16 +517,21 @@ class OrdersRepository {
       'task_id',
       'taskId',
     ], fallback: fallbackTaskId);
-    final paintId = _trimmedString(row, const [
+    final rawPaintId = _trimmedString(row, const [
       'paint_id',
       'paintId',
       'material_id',
     ]);
-    final paintName = _trimmedString(row, const [
+    final isValidPaintUuid = _isUuidString(rawPaintId);
+    final paintId = isValidPaintUuid ? rawPaintId : '';
+    final explicitPaintName = _trimmedString(row, const [
       'paint_name',
       'paintName',
       'name',
     ]);
+    final paintName = explicitPaintName.isNotEmpty
+        ? explicitPaintName
+        : (isValidPaintUuid ? '' : rawPaintId);
     final unit = _trimmedString(row, const ['unit'], fallback: 'г');
     final actualUsedAmount = _readDouble(row, const [
       'actual_used_amount',
@@ -562,6 +567,12 @@ class OrdersRepository {
       'unit': unit.isEmpty ? 'г' : unit,
       'write_off_now': writeOffNow,
     });
+  }
+
+  bool _isUuidString(String value) {
+    return RegExp(
+      r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$',
+    ).hasMatch(value.trim());
   }
 
   String _trimmedString(

--- a/supabase/migrations/20260518_align_paints_writeoffs_paint_id_type.sql
+++ b/supabase/migrations/20260518_align_paints_writeoffs_paint_id_type.sql
@@ -1,0 +1,182 @@
+-- Align paints_writeoffs.paint_id with public.paints.id so paint queue RPC
+-- comparisons/inserts use one canonical paint id type end-to-end.
+
+do $$
+declare
+  v_paint_id_type text;
+  v_writeoffs_paint_id_type text;
+  v_invalid_count bigint := 0;
+begin
+  select format_type(a.atttypid, a.atttypmod)
+    into v_paint_id_type
+    from pg_attribute a
+    join pg_class c on c.oid = a.attrelid
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public'
+     and c.relname = 'paints'
+     and a.attname = 'id'
+     and a.attnum > 0
+     and not a.attisdropped;
+
+  if v_paint_id_type is null then
+    raise exception 'public.paints.id column was not found';
+  end if;
+
+  select format_type(a.atttypid, a.atttypmod)
+    into v_writeoffs_paint_id_type
+    from pg_attribute a
+    join pg_class c on c.oid = a.attrelid
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public'
+     and c.relname = 'paints_writeoffs'
+     and a.attname = 'paint_id'
+     and a.attnum > 0
+     and not a.attisdropped;
+
+  if v_writeoffs_paint_id_type is null then
+    raise exception 'public.paints_writeoffs.paint_id column was not found';
+  end if;
+
+  execute 'drop function if exists public.safe_paint_id(text)';
+  if v_paint_id_type = 'uuid' then
+    execute $sql$
+      create function public.safe_paint_id(p_value text)
+      returns uuid
+      language sql
+      immutable
+      as $fn$
+        select case
+          when nullif(trim(p_value), '') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            then nullif(trim(p_value), '')::uuid
+          else null
+        end
+      $fn$
+    $sql$;
+  else
+    execute format($sql$
+      create function public.safe_paint_id(p_value text)
+      returns %1$s
+      language sql
+      immutable
+      as $fn$
+        select nullif(trim(p_value), '')::%1$s
+      $fn$
+    $sql$, v_paint_id_type);
+  end if;
+
+  if v_writeoffs_paint_id_type <> v_paint_id_type then
+    for v_writeoffs_paint_id_type in
+      select conname
+        from pg_constraint
+       where conrelid = 'public.paints_writeoffs'::regclass
+         and pg_get_constraintdef(oid) like '%paint_id%'
+    loop
+      execute format(
+        'alter table public.paints_writeoffs drop constraint if exists %I',
+        v_writeoffs_paint_id_type
+      );
+    end loop;
+
+    execute format(
+      'alter table public.paints_writeoffs add column if not exists paint_id_migrated %s',
+      v_paint_id_type
+    );
+    execute 'alter table public.paints_writeoffs add column if not exists paint_id_text_legacy text';
+
+    execute $sql$
+      update public.paints_writeoffs w
+         set paint_id_migrated = public.safe_paint_id(w.paint_id::text)
+       where w.paint_id is not null
+         and public.safe_paint_id(w.paint_id::text) is not null
+         and exists (
+           select 1
+             from public.paints p
+            where p.id = public.safe_paint_id(w.paint_id::text)
+         )
+    $sql$;
+
+    execute $sql$
+      update public.paints_writeoffs w
+         set paint_id_text_legacy = nullif(trim(w.paint_id::text), '')
+       where w.paint_id is not null
+         and (
+           public.safe_paint_id(w.paint_id::text) is null
+           or not exists (
+             select 1
+               from public.paints p
+              where p.id = public.safe_paint_id(w.paint_id::text)
+           )
+         )
+    $sql$;
+
+    execute $sql$
+      select count(*)
+        from public.paints_writeoffs w
+       where w.paint_id is not null
+         and (
+           public.safe_paint_id(w.paint_id::text) is null
+           or not exists (
+             select 1
+               from public.paints p
+              where p.id = public.safe_paint_id(w.paint_id::text)
+           )
+         )
+    $sql$ into v_invalid_count;
+    if v_invalid_count > 0 then
+      raise warning 'paints_writeoffs.paint_id contains % legacy value(s) that cannot be cast to %. They were preserved in paint_id_text_legacy and migrated to null paint_id.',
+        v_invalid_count, v_paint_id_type;
+    end if;
+
+    drop index if exists public.paints_writeoffs_paint_id_idx;
+
+    alter table public.paints_writeoffs rename column paint_id to paint_id_raw_before_type_alignment;
+    alter table public.paints_writeoffs rename column paint_id_migrated to paint_id;
+
+    alter table public.paints_writeoffs
+      add constraint paints_writeoffs_paint_id_fkey
+      foreign key (paint_id) references public.paints(id);
+  end if;
+
+  select format_type(a.atttypid, a.atttypmod)
+    into v_writeoffs_paint_id_type
+    from pg_attribute a
+    join pg_class c on c.oid = a.attrelid
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public'
+     and c.relname = 'paints_writeoffs'
+     and a.attname = 'paint_id'
+     and a.attnum > 0
+     and not a.attisdropped;
+
+  if v_writeoffs_paint_id_type <> v_paint_id_type then
+    raise exception 'public.paints_writeoffs.paint_id type (%) does not match public.paints.id type (%)',
+      v_writeoffs_paint_id_type, v_paint_id_type;
+  end if;
+
+  for v_writeoffs_paint_id_type in
+    select table_name || '.paint_id has type ' || column_type
+      from (
+        select c.relname as table_name, format_type(a.atttypid, a.atttypmod) as column_type
+          from pg_attribute a
+          join pg_class c on c.oid = a.attrelid
+          join pg_namespace n on n.oid = c.relnamespace
+         where n.nspname = 'public'
+           and c.relname in (
+             'order_paint_reservations',
+             'order_paint_pending_writeoffs',
+             'paints_writeoffs'
+           )
+           and a.attname = 'paint_id'
+           and a.attnum > 0
+           and not a.attisdropped
+      ) typed_paint_ids
+     where column_type <> v_paint_id_type
+  loop
+    raise exception 'public.% does not match public.paints.id type %',
+      v_writeoffs_paint_id_type, v_paint_id_type;
+  end loop;
+end $$;
+
+create index if not exists paints_writeoffs_paint_id_idx
+  on public.paints_writeoffs(paint_id)
+  where paint_id is not null;


### PR DESCRIPTION
### Motivation
- Ensure all paint identifier comparisons and write-offs use the same canonical DB type by aligning `paints_writeoffs.paint_id` with `public.paints.id` and preventing mismatched types from causing incorrect lookups or partial updates.
- Send only valid UUID strings in RPC `paint_id` parameters and use a `paint_name` fallback for legacy/name-only values to avoid passing invalid identifiers to server RPCs.
- Preserve the existing task finalization semantics so an RPC failure does not mark a task as completed or partially decrement paint stock.

### Description
- Added a Supabase migration `supabase/migrations/20260518_align_paints_writeoffs_paint_id_type.sql` that aligns `paints_writeoffs.paint_id` to the type of `public.paints.id`, preserves incompatible legacy text values in `paint_id_text_legacy`, migrates castable values into a typed `paint_id`, and creates the necessary FK and index.  
- The migration recreates `public.safe_paint_id` appropriate to the canonical `paints.id` type and verifies that `order_paint_reservations.paint_id`, `order_paint_pending_writeoffs.paint_id` and `paints_writeoffs.paint_id` match `public.paints.id` to prevent cross-table type mismatches.  
- Updated `lib/modules/orders/orders_repository.dart::_paintQueueRpcRow` to extract a `rawPaintId`, validate it with a new `_isUuidString` helper, populate `paint_id` only when the string is a valid UUID, and route non-UUID name-only values into `paint_name`.  
- Verified that task finalization flow in `lib/modules/tasks/tasks_screen.dart` still awaits the `completeFlexPrintingStage` RPC and only performs cache/refresh/closing work on the successful path so failures do not change `tasks.status` to `completed` or apply partial stock changes.

### Testing
- Ran a Python-based static check confirming the RPC payload logic and the presence of the new SQL migration assertions, and the check succeeded.  
- Ran `git diff --check` and repository-side validations which reported no whitespace/merge errors.  
- Attempted to run `dart format` on `lib/modules/orders/orders_repository.dart` but `dart` was not available in the environment so formatting could not be executed.  
- Attempted to run `flutter test test/tasks_grams_input_test.dart` but `flutter` was not available in the environment so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad4d0a990832fa1ad93bfdaea208c)