### PR TITLE
Add local tooltip diagnostic gate

### DIFF
--- a/lib/app_ui_stability.dart
+++ b/lib/app_ui_stability.dart
@@ -3,13 +3,15 @@ import 'package:flutter/material.dart';
 
 /// Shared UI defaults that avoid transient framework assertions from visual
 /// effects whose owner widget can be removed during fast navigation/rebuilds.
+///
+/// Keep accessibility-affecting widgets (for example [Tooltip], [SnackBar],
+/// [FocusNode], and [Semantics]) enabled by default. If a specific control
+/// needs investigation, gate that control locally with an explicit diagnostic
+/// flag instead of changing global theme behavior.
 final ThemeData appTheme = ThemeData(
   splashFactory: NoSplash.splashFactory,
   splashColor: Colors.transparent,
   highlightColor: Colors.transparent,
-  tooltipTheme: const TooltipThemeData(
-    triggerMode: TooltipTriggerMode.manual,
-  ),
 );
 
 /// Some Flutter builds can still finish a paint/build pass for an ink feature

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -47,6 +47,9 @@ class EditOrderScreen extends StatefulWidget {
   State<EditOrderScreen> createState() => _EditOrderScreenState();
 }
 
+const bool _disableSwitchableStageDotTooltipDiagnostic =
+    bool.fromEnvironment('DISABLE_SWITCHABLE_STAGE_DOT_TOOLTIP_DIAGNOSTIC');
+
 class _SwitchableStageOption {
   const _SwitchableStageOption(this.stageId, this.label);
 
@@ -75,37 +78,46 @@ class _SwitchableStageDot extends StatelessWidget {
         ? colors.primary.withValues(alpha: 0.72)
         : colors.outlineVariant.withValues(alpha: 0.9);
 
-    return Tooltip(
-      message: label,
-      child: Semantics(
-        button: true,
-        selected: selected,
-        label: label,
-        child: InkResponse(
-          onTap: onTap,
-          radius: 18,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 160),
-            curve: Curves.easeOut,
-            width: 20,
-            height: 20,
-            padding: const EdgeInsets.all(4),
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: fillColor,
-              border: Border.all(color: borderColor, width: 1.5),
-            ),
-            child: selected
-                ? DecoratedBox(
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: colors.primary.withValues(alpha: 0.78),
-                    ),
-                  )
-                : null,
+    final dot = Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: InkResponse(
+        onTap: onTap,
+        radius: 18,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          curve: Curves.easeOut,
+          width: 20,
+          height: 20,
+          padding: const EdgeInsets.all(4),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: fillColor,
+            border: Border.all(color: borderColor, width: 1.5),
           ),
+          child: selected
+              ? DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colors.primary.withValues(alpha: 0.78),
+                  ),
+                )
+              : null,
         ),
       ),
+    );
+
+    // Diagnostic-only escape hatch for Windows accessibility spam checks.
+    // Keep this local to the suspected form-choice dot instead of disabling
+    // Tooltip, SnackBar, FocusNode, or Semantics globally.
+    if (_disableSwitchableStageDotTooltipDiagnostic) {
+      return dot;
+    }
+
+    return Tooltip(
+      message: label,
+      child: dot,
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Исследуется спам accessibility-сообщений на Windows, при этом нельзя массово отключать `Tooltip`, `SnackBar`, `FocusNode` или `Semantics`, поэтому нужен локальный диагностический хэндл для подозрительного виджета.

### Description
- Убрана глобальная переопределяющая тема `Tooltip` (`triggerMode: TooltipTriggerMode.manual`) из `lib/app_ui_stability.dart` чтобы не менять поведение accessibility-виджетов по всему приложению.
- Добавлен локальный diagnostic-only флаг `DISABLE_SWITCHABLE_STAGE_DOT_TOOLTIP_DIAGNOSTIC` (`const bool _disableSwitchableStageDotTooltipDiagnostic = bool.fromEnvironment('DISABLE_SWITCHABLE_STAGE_DOT_TOOLTIP_DIAGNOSTIC')`) и применён только к `Tooltip` вокруг stage/form choice dot в `lib/modules/orders/edit_order_screen.dart`, при включённом флаге возвращается внутренний `Semantics`-`dot` без `Tooltip`.
- Сохранён `Semantics` и прочие элементы без глобальных изменений и добавлены комментарии, объясняющие диагностическую цель правки.

### Testing
- Выполнены поисковые проверки по коду `rg -n "SemanticsService|\.announce\(|announce\("` чтобы убедиться в отсутствии проектных `announce` — команда успешно выполнилась.
- Проверено наличие/отсутствие `tooltipTheme` и нового флага с помощью `rg -n "tooltipTheme|TooltipThemeData|DISABLE_SWITCHABLE_STAGE_DOT_TOOLTIP_DIAGNOSTIC|_disableSwitchableStageDotTooltipDiagnostic" lib` — команда успешно выполнилась.
- Выполнен `git diff --check` и он не обнаружил проблем; запуск `flutter`/`dart` и форматирование (`flutter --version`, `dart format`) невозможны в этой среде (`flutter`/`dart` не установлены), поэтому воспроизведение Windows-проблемы и авто-форматирование не выполнялись.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad64930ec832fb8061328af65bf25)