### PR TITLE
Quantity status tracking and validation for task quantities

### DIFF
--- a/lib/modules/orders/order_timeline_dialog.dart
+++ b/lib/modules/orders/order_timeline_dialog.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import '../personnel/personnel_provider.dart';
 import '../tasks/task_model.dart';
+import '../tasks/quantity_status_service.dart';
 import 'id_format.dart';
 import 'order_model.dart';
 
@@ -51,6 +52,8 @@ class OrderTimelineDialog extends StatelessWidget {
   }
 
   String _formatQuantity(String text, double? parsed) {
+    final payloadDisplay = quantityDisplayText(text);
+    if (payloadDisplay != text) return payloadDisplay;
     if (parsed != null) {
       final bool isInt = (parsed - parsed.round()).abs() < 0.0001;
       final display = isInt ? parsed.round().toString() : parsed.toStringAsFixed(2);

--- a/lib/modules/tasks/quantity_status_service.dart
+++ b/lib/modules/tasks/quantity_status_service.dart
@@ -1,0 +1,281 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import '../orders/order_model.dart';
+import '../orders/stage_queue_builder.dart' as stage_queue;
+import '../orders/material_model.dart';
+import 'task_model.dart';
+
+const String kQuantityStatusTwoSheetPackageProductId =
+    stage_queue.kTwoSheetPackageProductTypeId;
+const String kQuantityStatusSheetCutStageId = stage_queue.kSheetCutStageId;
+const Set<String> kQuantityStatusSheetCutStageAliases = <String>{
+  'листорезка',
+};
+const String kQuantityStatusWarningMessage =
+    'Введённое количество отличается от плана. Проверьте значение перед завершением этапа.';
+
+enum QuantityStatus { success, warning, danger, unknown }
+
+const Set<String> _meterUnitAliases = <String>{
+  'м',
+  'метр',
+  'метры',
+  'm',
+  'meter',
+  'meters',
+};
+
+const Set<String> _pieceUnitAliases = <String>{
+  '',
+  'шт',
+  'шт.',
+  'штука',
+  'штуки',
+  'лист',
+  'листы',
+  'экземпляр',
+  'экземпляры',
+  'pcs',
+  'pieces',
+};
+
+const Set<String> _packUnitAliases = <String>{
+  'уп',
+  'уп.',
+  'упак',
+  'упаковка',
+  'упаковки',
+  'пач',
+  'пачка',
+  'пачки',
+  'pack',
+  'packs',
+};
+
+String normalizeQuantityUnit(String? unit) =>
+    (unit ?? '').trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+
+bool isQuantityMeterUnit(String? unit) =>
+    _meterUnitAliases.contains(normalizeQuantityUnit(unit));
+
+bool isQuantityPieceUnit(String? unit) =>
+    _pieceUnitAliases.contains(normalizeQuantityUnit(unit));
+
+bool isQuantityPackUnit(String? unit) =>
+    _packUnitAliases.contains(normalizeQuantityUnit(unit));
+
+double? _number(dynamic value) {
+  if (value == null) return null;
+  if (value is num) return value.toDouble();
+  if (value is String) {
+    final normalized = value.trim().replaceAll(',', '.');
+    if (normalized.isEmpty) return null;
+    final parsed = double.tryParse(normalized);
+    if (parsed != null) return parsed;
+    return double.tryParse(normalized.replaceAll(RegExp(r'[^0-9.\-]'), ''));
+  }
+  return null;
+}
+
+double? _paperLengthFromMap(Map<String, dynamic>? map) {
+  if (map == null) return null;
+  for (final key in const <String>['lengthL', 'length_l', 'length', 'L']) {
+    final parsed = _number(map[key]);
+    if (parsed != null && parsed > 0) return parsed;
+  }
+  final paper = map['paper'];
+  if (paper is Map) {
+    final parsed = _paperLengthFromMap(Map<String, dynamic>.from(paper));
+    if (parsed != null && parsed > 0) return parsed;
+  }
+  return null;
+}
+
+double? _paperLengthFromMaterial(MaterialModel material) {
+  final extraLength = _paperLengthFromMap(material.extra);
+  if (extraLength != null && extraLength > 0) return extraLength;
+  if (material.quantity > 0) return material.quantity;
+  return null;
+}
+
+double taskPaperLengthTotalForOrder(OrderModel? order) {
+  if (order == null) return 0;
+
+  final materialTotal = order.paperMaterials.fold<double>(0, (sum, material) {
+    final length = _paperLengthFromMaterial(material);
+    return length == null || length <= 0 ? sum : sum + length;
+  });
+  if (materialTotal > 0) return materialTotal;
+
+  final productMap = order.product.toMap();
+  final productLength = _paperLengthFromMap(productMap);
+  if (productLength != null && productLength > 0) return productLength;
+
+  final directLength = order.product.length;
+  if (directLength != null && directLength > 0) return directLength;
+
+  return 0;
+}
+
+double? initialTaskMeterQuantityForOrder({
+  required String? unit,
+  required OrderModel? order,
+}) {
+  if (!isQuantityMeterUnit(unit)) return null;
+  final total = taskPaperLengthTotalForOrder(order);
+  return total > 0 ? total : null;
+}
+
+const Set<String> kQuantityStatusTwoSheetPackageProductAliases = <String>{
+  'пакет с 2х листов',
+  'пакет с 2 листов',
+  'пакет из 2х листов',
+  'пакет из 2 листов',
+};
+
+String _normalizeProductName(String value) => value
+    .trim()
+    .toLowerCase()
+    .replaceAll('ё', 'е')
+    .replaceAll(RegExp(r'[\s_\-]+'), ' ');
+
+bool _isTwoSheetPackageProduct(String productType) {
+  return stage_queue.isTwoSheetPackageProductType(productType) ||
+      kQuantityStatusTwoSheetPackageProductAliases
+          .contains(_normalizeProductName(productType));
+}
+
+bool isTwoSheetPackageSheetCutting({
+  required OrderModel order,
+  required TaskModel task,
+}) {
+  final productType = order.product.type.trim();
+  final stageId = task.stageId.trim();
+  return _isTwoSheetPackageProduct(productType) &&
+      (stageId == kQuantityStatusSheetCutStageId ||
+          kQuantityStatusSheetCutStageAliases
+              .contains(_normalizeProductName(stageId)));
+}
+
+double? getExpectedQuantity({
+  required OrderModel order,
+  required TaskModel task,
+  required String unit,
+}) {
+  if (isQuantityMeterUnit(unit)) {
+    final meters = taskPaperLengthTotalForOrder(order);
+    return meters > 0 ? meters : null;
+  }
+
+  if (isQuantityPackUnit(unit)) {
+    final packs = _number(order.product.blQuantity);
+    return packs != null && packs > 0 ? packs : null;
+  }
+
+  if (isQuantityPieceUnit(unit)) {
+    final quantity = order.product.quantity;
+    if (quantity <= 0) return null;
+    if (isTwoSheetPackageSheetCutting(order: order, task: task)) {
+      return quantity * 2;
+    }
+    return quantity.toDouble();
+  }
+
+  return null;
+}
+
+QuantityStatus getQuantityStatus({
+  required double actual,
+  required double? expected,
+}) {
+  if (expected == null || expected <= 0) return QuantityStatus.unknown;
+  final diff = (actual - expected).abs();
+  if (diff <= 0.0001) return QuantityStatus.success;
+  final deviation = diff / expected;
+  if (deviation <= 0.1) return QuantityStatus.warning;
+  return QuantityStatus.danger;
+}
+
+Color getQuantityStatusColor(QuantityStatus status) {
+  switch (status) {
+    case QuantityStatus.success:
+      return Colors.green;
+    case QuantityStatus.warning:
+      return Colors.orange;
+    case QuantityStatus.danger:
+      return Colors.red;
+    case QuantityStatus.unknown:
+      return Colors.grey;
+  }
+}
+
+String quantityStatusToJson({
+  required double actual,
+  required String unit,
+  required double? expected,
+  required QuantityStatus status,
+  required String displayText,
+}) {
+  return jsonEncode(<String, dynamic>{
+    'actual': actual,
+    'unit': unit,
+    'expected': expected,
+    'quantity_status': status.name,
+    'display': displayText,
+  });
+}
+
+Map<String, dynamic>? tryDecodeQuantityPayload(String text) {
+  final trimmed = text.trim();
+  if (!trimmed.startsWith('{')) return null;
+  try {
+    final decoded = jsonDecode(trimmed);
+    if (decoded is Map) return Map<String, dynamic>.from(decoded);
+  } catch (_) {}
+  return null;
+}
+
+double? quantityActualFromText(String text) {
+  final payload = tryDecodeQuantityPayload(text);
+  final actual = _number(payload?['actual']);
+  if (actual != null) return actual;
+
+  final normalized = text.replaceAll(',', '.').trim();
+  final totalFromFormula =
+      RegExp(r'=\s*(-?\d+(?:\.\d+)?)').firstMatch(normalized);
+  if (totalFromFormula != null) {
+    return double.tryParse(totalFromFormula.group(1) ?? '');
+  }
+  final packsMatch = RegExp(r'(-?\d+(?:\.\d+)?)\s*пач', caseSensitive: false)
+      .firstMatch(normalized);
+  final inPackMatch =
+      RegExp(r'[x×*]\s*(-?\d+(?:\.\d+)?)').firstMatch(normalized);
+  if (packsMatch != null && inPackMatch != null) {
+    final packs = double.tryParse(packsMatch.group(1) ?? '') ?? 0;
+    final inPack = double.tryParse(inPackMatch.group(1) ?? '') ?? 0;
+    return packs * inPack;
+  }
+  final parsed = double.tryParse(normalized);
+  if (parsed != null) return parsed;
+  final firstNumber = RegExp(r'-?\d+(?:\.\d+)?').firstMatch(normalized);
+  return firstNumber == null ? null : double.tryParse(firstNumber.group(0)!);
+}
+
+String quantityDisplayText(String text) {
+  final payload = tryDecodeQuantityPayload(text);
+  final display = payload?['display']?.toString().trim();
+  if (display != null && display.isNotEmpty) return display;
+  return text;
+}
+
+QuantityStatus? quantityStatusFromText(String text) {
+  final payload = tryDecodeQuantityPayload(text);
+  final raw = payload?['quantity_status']?.toString();
+  if (raw == null) return null;
+  for (final status in QuantityStatus.values) {
+    if (status.name == raw) return status;
+  }
+  return null;
+}

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -27,6 +27,7 @@ import 'task_model.dart';
 import 'task_completion_rules.dart';
 import 'task_provider.dart';
 import 'task_visibility.dart';
+import 'quantity_status_service.dart';
 import 'stage_sequence_utils.dart' as stage_sequence;
 import '../common/pdf_view_screen.dart';
 import '../../services/storage_service.dart';
@@ -34,83 +35,6 @@ import '../../services/attachment_service.dart';
 // Additional helpers for time formatting and aggregated timers
 const String kCardboardCuttingStageId =
     stage_sequence.kCardboardCuttingStageId;
-
-const Set<String> _meterUnitAliases = <String>{
-  'м',
-  'метр',
-  'метры',
-  'm',
-  'meter',
-  'meters',
-};
-
-String _normalizeTaskQuantityUnit(String? unit) =>
-    (unit ?? '').trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
-
-bool isTaskMeterUnit(String? unit) =>
-    _meterUnitAliases.contains(_normalizeTaskQuantityUnit(unit));
-
-double? _taskPaperLengthNumber(dynamic value) {
-  if (value == null) return null;
-  if (value is num) return value.toDouble();
-  if (value is String) {
-    final normalized = value.trim().replaceAll(',', '.');
-    if (normalized.isEmpty) return null;
-    final parsed = double.tryParse(normalized);
-    if (parsed != null) return parsed;
-    return double.tryParse(normalized.replaceAll(RegExp(r'[^0-9.\-]'), ''));
-  }
-  return null;
-}
-
-double? _taskPaperLengthFromMap(Map<String, dynamic>? map) {
-  if (map == null) return null;
-  for (final key in const <String>['lengthL', 'length_l', 'length', 'L']) {
-    final parsed = _taskPaperLengthNumber(map[key]);
-    if (parsed != null && parsed > 0) return parsed;
-  }
-  final paper = map['paper'];
-  if (paper is Map) {
-    final parsed = _taskPaperLengthFromMap(Map<String, dynamic>.from(paper));
-    if (parsed != null && parsed > 0) return parsed;
-  }
-  return null;
-}
-
-double? _taskPaperLengthFromMaterial(MaterialModel material) {
-  final extraLength = _taskPaperLengthFromMap(material.extra);
-  if (extraLength != null && extraLength > 0) return extraLength;
-  if (material.quantity > 0) return material.quantity;
-  return null;
-}
-
-double taskPaperLengthTotalForOrder(OrderModel? order) {
-  if (order == null) return 0;
-
-  final materialTotal = order.paperMaterials.fold<double>(0, (sum, material) {
-    final length = _taskPaperLengthFromMaterial(material);
-    return length == null || length <= 0 ? sum : sum + length;
-  });
-  if (materialTotal > 0) return materialTotal;
-
-  final productMap = order.product.toMap();
-  final productLength = _taskPaperLengthFromMap(productMap);
-  if (productLength != null && productLength > 0) return productLength;
-
-  final directLength = order.product.length;
-  if (directLength != null && directLength > 0) return directLength;
-
-  return 0;
-}
-
-double? initialTaskMeterQuantityForOrder({
-  required String? unit,
-  required OrderModel? order,
-}) {
-  if (!isTaskMeterUnit(unit)) return null;
-  final total = taskPaperLengthTotalForOrder(order);
-  return total > 0 ? total : null;
-}
 
 String formatTaskInitialQuantity(double value) {
   if (value % 1 == 0) return value.toStringAsFixed(0);
@@ -728,6 +652,9 @@ class _QuantityInput {
   final bool openPaperEditor;
   final int? packsCount;
   final int? unitsPerPack;
+  final double? expected;
+  final QuantityStatus status;
+  final String commentText;
 
   const _QuantityInput({
     required this.quantity,
@@ -735,7 +662,10 @@ class _QuantityInput {
     this.openPaperEditor = false,
     this.packsCount,
     this.unitsPerPack,
-  });
+    this.expected,
+    this.status = QuantityStatus.unknown,
+    String? commentText,
+  }) : commentText = commentText ?? displayText;
 }
 
 class _TaskSelectionState extends ChangeNotifier {
@@ -2451,7 +2381,8 @@ class _TasksScreenState extends State<TasksScreen>
   }
 
   String _formatQuantityDisplay(String raw) {
-    final trimmed = raw.trim();
+    final payloadText = quantityDisplayText(raw);
+    final trimmed = payloadText.trim();
     if (trimmed.isEmpty) return '0';
     final numeric = RegExp(r'^[0-9]+([.,][0-9]+)?$');
     if (!numeric.hasMatch(trimmed)) return trimmed;
@@ -3521,26 +3452,25 @@ class _TasksScreenState extends State<TasksScreen>
     );
   }
 
-  int _parseQuantity(String text) {
-    final totalFromFormula = RegExp(r'=\s*(\d+)').firstMatch(text);
-    if (totalFromFormula != null) {
-      return int.tryParse(totalFromFormula.group(1) ?? '') ?? 0;
-    }
-    final packMatch =
-        RegExp(r'(\d+)\s*пач', caseSensitive: false).firstMatch(text);
-    final inPackMatch = RegExp(r'[x×*]\s*(\d+)').firstMatch(text);
-    if (packMatch != null && inPackMatch != null) {
-      final packs = int.tryParse(packMatch.group(1) ?? '') ?? 0;
-      final inPack = int.tryParse(inPackMatch.group(1) ?? '') ?? 0;
-      return packs * inPack;
-    }
-    final match = RegExp(r'(\d+)').firstMatch(text);
-    if (match == null) return 0;
-    return int.tryParse(match.group(1) ?? '') ?? 0;
+  double _parseQuantity(String text) {
+    return quantityActualFromText(text) ?? 0;
   }
 
-  int _sumQuantities(TaskModel task) {
-    int total = 0;
+  QuantityStatus _quantityStatusForComment(
+    TaskComment comment,
+    OrderModel order,
+    TaskModel task,
+  ) {
+    final saved = quantityStatusFromText(comment.text);
+    if (saved != null) return saved;
+    final actual = _parseQuantity(comment.text);
+    final unit = _workplaceUnit(context.read<PersonnelProvider>(), task.stageId) ?? '';
+    final expected = getExpectedQuantity(order: order, task: task, unit: unit);
+    return getQuantityStatus(actual: actual, expected: expected);
+  }
+
+  double _sumQuantities(TaskModel task) {
+    double total = 0;
     for (final comment in task.comments) {
       if (comment.type == 'quantity_done' ||
           comment.type == 'quantity_team_total') {
@@ -3563,6 +3493,19 @@ class _TasksScreenState extends State<TasksScreen>
   Widget _buildResultPanel(OrderModel order, TaskModel task, double scale) {
     final totalQty = _sumQuantities(task);
     final lastQty = _latestQuantityLabel(task);
+    final unit = _workplaceUnit(context.read<PersonnelProvider>(), task.stageId) ?? '';
+    final expected = getExpectedQuantity(order: order, task: task, unit: unit);
+    final totalStatus = totalQty > 0
+        ? getQuantityStatus(actual: totalQty, expected: expected)
+        : QuantityStatus.unknown;
+    final lastComment = task.comments
+        .where((c) =>
+            c.type == 'quantity_done' || c.type == 'quantity_team_total')
+        .toList()
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    final lastStatus = lastComment.isEmpty
+        ? QuantityStatus.unknown
+        : _quantityStatusForComment(lastComment.last, order, task);
     return _sectionCard(
       '📊 Производственный результат',
       Column(
@@ -3571,10 +3514,20 @@ class _TasksScreenState extends State<TasksScreen>
           Text('Фактическое количество (заказ): '
               '${order.actualQty?.toStringAsFixed(0) ?? '—'}',
               style: TextStyle(fontSize: scale * 12)),
-          Text('Суммарно по исполнителям: ${totalQty > 0 ? totalQty : '—'}',
-              style: TextStyle(fontSize: scale * 12)),
-          Text('Последняя запись: $lastQty',
-              style: TextStyle(fontSize: scale * 12)),
+          Text(
+            'Суммарно по исполнителям: ${totalQty > 0 ? formatTaskInitialQuantity(totalQty) : '—'}',
+            style: TextStyle(
+              fontSize: scale * 12,
+              color: getQuantityStatusColor(totalStatus),
+            ),
+          ),
+          Text(
+            'Последняя запись: ${quantityDisplayText(lastQty)}',
+            style: TextStyle(
+              fontSize: scale * 12,
+              color: getQuantityStatusColor(lastStatus),
+            ),
+          ),
         ],
       ),
       scale,
@@ -3772,6 +3725,21 @@ class _TasksScreenState extends State<TasksScreen>
                     IconData icon = Icons.info_outline;
                     Color color = Colors.blueGrey;
                     final c = entry.comment;
+                    final quantityComment = c.type == 'quantity_done' ||
+                        c.type == 'quantity_team_total' ||
+                        c.type == 'quantity_share';
+                    if (quantityComment) {
+                      final relatedTask = taskProvider.tasks.firstWhere(
+                        (candidate) => candidate.id == entry.taskId,
+                        orElse: () => task,
+                      );
+                      final relatedOrder = _orderById(relatedTask.orderId);
+                      final status = relatedOrder == null
+                          ? (quantityStatusFromText(c.text) ?? QuantityStatus.unknown)
+                          : _quantityStatusForComment(c, relatedOrder, relatedTask);
+                      icon = Icons.check_circle_outline;
+                      color = getQuantityStatusColor(status);
+                    }
                     switch (c.type) {
                       case 'problem':
                         icon = Icons.error_outline;
@@ -3783,8 +3751,8 @@ class _TasksScreenState extends State<TasksScreen>
                         break;
                       case 'user_done':
                       case 'quantity_done':
-                        icon = Icons.check_circle_outline;
-                        color = Colors.green;
+                      case 'quantity_team_total':
+                      case 'quantity_share':
                         break;
                       case 'setup_start':
                       case 'setup_done':
@@ -3843,10 +3811,34 @@ class _TasksScreenState extends State<TasksScreen>
                                   color: Colors.grey,
                                 ),
                               ),
-                            Text(
-                              _describeComment(entry.comment),
-                              style: TextStyle(fontSize: scale * 12.5),
-                            ),
+                            Builder(builder: (_) {
+                              final quantityComment = c.type == 'quantity_done' ||
+                                  c.type == 'quantity_team_total' ||
+                                  c.type == 'quantity_share';
+                              var textColor = Colors.black87;
+                              if (quantityComment) {
+                                final relatedTask = taskProvider.tasks.firstWhere(
+                                  (candidate) => candidate.id == entry.taskId,
+                                  orElse: () => task,
+                                );
+                                final relatedOrder = _orderById(relatedTask.orderId);
+                                final status = relatedOrder == null
+                                    ? (quantityStatusFromText(c.text) ?? QuantityStatus.unknown)
+                                    : _quantityStatusForComment(
+                                        c,
+                                        relatedOrder,
+                                        relatedTask,
+                                      );
+                                textColor = getQuantityStatusColor(status);
+                              }
+                              return Text(
+                                _describeComment(entry.comment),
+                                style: TextStyle(
+                                  fontSize: scale * 12.5,
+                                  color: textColor,
+                                ),
+                              );
+                            }),
                             Builder(builder: (_) {
                               final attachments = taskProvider
                                   .attachmentsForComment(entry.comment.id);
@@ -5017,6 +5009,8 @@ class _TasksScreenState extends State<TasksScreen>
           unit: unitLabel,
           allowPaperEdit: true,
           initialQuantity: _initialMeterQuantityForTask(task, unitLabel),
+          order: _orderById(task.orderId),
+          task: task,
         );
         if (result == null) return;
         if (!result.openPaperEditor) {
@@ -5053,7 +5047,7 @@ class _TasksScreenState extends State<TasksScreen>
           pendingRows: paints
               .where(_isPendingPaintRow)
               .toList(growable: false),
-          quantityDone: qtyInput?.displayText,
+          quantityDone: qtyInput?.commentText,
           comment: note,
         );
         await tp.refresh();
@@ -5082,7 +5076,7 @@ class _TasksScreenState extends State<TasksScreen>
         orderId: task.orderId,
         stageId: task.stageId,
         employeeId: widget.employeeId,
-        quantityDone: qtyInput?.displayText,
+        quantityDone: qtyInput?.commentText,
         comment: note,
       );
       await tp.refresh();
@@ -5687,6 +5681,8 @@ class _TasksScreenState extends State<TasksScreen>
                           allowPaperEdit: true,
                           initialQuantity:
                               _initialMeterQuantityForTask(task, unitLabel),
+                          order: order,
+                          task: task,
                         );
                         if (qtyInput == null) return;
                         if (!qtyInput.openPaperEditor) break;
@@ -5704,7 +5700,7 @@ class _TasksScreenState extends State<TasksScreen>
                         await _openPaperEditDialog(order);
                       }
                       if (qtyInput == null) return;
-                      final qtyText = qtyInput.displayText;
+                      final qtyText = qtyInput.commentText;
                       final taskProvider = context.read<TaskProvider>();
                       var separateAllDone = false;
                       var jointUserIds = <String>[];
@@ -6020,6 +6016,8 @@ class _TasksScreenState extends State<TasksScreen>
                         unit: unitLabel,
                         initialQuantity:
                             _initialMeterQuantityForTask(task, unitLabel),
+                        order: _orderById(task.orderId),
+                        task: task,
                       );
                       if (qtyInput == null) return;
 
@@ -6102,6 +6100,8 @@ class _TasksScreenState extends State<TasksScreen>
                             allowPaperEdit: true,
                             initialQuantity:
                                 _initialMeterQuantityForTask(task, unitLabel),
+                            order: _orderById(task.orderId),
+                            task: task,
                           );
                           if (qtyInput == null) return;
                           if (!qtyInput.openPaperEditor) break;
@@ -6121,7 +6121,7 @@ class _TasksScreenState extends State<TasksScreen>
                           await _openPaperEditDialog(order);
                         }
                         if (qtyInput == null) return;
-                        final qtyText = qtyInput.displayText;
+                        final qtyText = qtyInput.commentText;
                         final helperIds = jointGroup != null && isMyRow
                             ? latestTask.assignees
                                 .where((id) =>
@@ -7862,6 +7862,8 @@ Future<_QuantityInput?> _askQuantity(
   String? unit,
   bool allowPaperEdit = false,
   double? initialQuantity,
+  OrderModel? order,
+  TaskModel? task,
 }) async {
   final totalController = TextEditingController(
     text: initialQuantity != null && initialQuantity > 0
@@ -7873,51 +7875,119 @@ Future<_QuantityInput?> _askQuantity(
   final v = await showDialog<_QuantityInput?>(
     context: context,
     builder: (ctx) {
-      return AlertDialog(
-        title: const Text('Количество выполнено'),
-        content: TextField(
-          controller: totalController,
-          autofocus: true,
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          decoration: InputDecoration(
-            hintText: unitLabel.isNotEmpty
-                ? 'Введите количество в $unitLabel'
-                : 'Введите количество экземпляров',
-            border: const OutlineInputBorder(),
-          ),
-        ),
-        actions: [
-          if (allowPaperEdit)
-            TextButton(
-              onPressed: () => Navigator.pop(
-                ctx,
-                const _QuantityInput(
-                  quantity: 0,
-                  displayText: paperEditValue,
-                  openPaperEditor: true,
-                ),
+      String? errorText;
+      return StatefulBuilder(
+        builder: (ctx, setState) {
+          return AlertDialog(
+            title: const Text('Количество выполнено'),
+            content: TextField(
+              controller: totalController,
+              autofocus: true,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              decoration: InputDecoration(
+                hintText: unitLabel.isNotEmpty
+                    ? 'Введите количество в $unitLabel'
+                    : 'Введите количество экземпляров',
+                border: const OutlineInputBorder(),
+                errorText: errorText,
               ),
-              child: const Text('Изменить бумагу'),
+              onChanged: (_) {
+                if (errorText != null) setState(() => errorText = null);
+              },
             ),
-          TextButton(
-              onPressed: () => Navigator.pop(ctx), child: const Text('Отмена')),
-          ElevatedButton(
-            onPressed: () {
-              final raw = totalController.text.trim();
-              final n = double.tryParse(raw.replaceAll(',', '.'));
-              if (n == null) return;
-              final displayQuantity = formatTaskInitialQuantity(n);
-              final display = unitLabel.isNotEmpty
-                  ? '$displayQuantity $unitLabel'
-                  : displayQuantity;
-              Navigator.pop(
-                ctx,
-                _QuantityInput(quantity: n, displayText: display),
-              );
-            },
-            child: const Text('OK'),
-          ),
-        ],
+            actions: [
+              if (allowPaperEdit)
+                TextButton(
+                  onPressed: () => Navigator.pop(
+                    ctx,
+                    const _QuantityInput(
+                      quantity: 0,
+                      displayText: paperEditValue,
+                      openPaperEditor: true,
+                    ),
+                  ),
+                  child: const Text('Изменить бумагу'),
+                ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Отмена'),
+              ),
+              ElevatedButton(
+                onPressed: () async {
+                  final raw = totalController.text.trim();
+                  if (raw.isEmpty) {
+                    setState(() => errorText = 'Укажите количество.');
+                    return;
+                  }
+                  final n = double.tryParse(raw.replaceAll(',', '.'));
+                  if (n == null) {
+                    setState(() => errorText = 'Количество должно быть числом.');
+                    return;
+                  }
+                  if (n < 0) {
+                    setState(() =>
+                        errorText = 'Количество не может быть отрицательным.');
+                    return;
+                  }
+                  final expected = order != null && task != null
+                      ? getExpectedQuantity(
+                          order: order,
+                          task: task,
+                          unit: unitLabel,
+                        )
+                      : null;
+                  final status = getQuantityStatus(actual: n, expected: expected);
+                  if (status == QuantityStatus.warning ||
+                      status == QuantityStatus.danger) {
+                    final confirmed = await showDialog<bool>(
+                          context: ctx,
+                          builder: (confirmCtx) => AlertDialog(
+                            title: const Text('Проверить количество'),
+                            content: const Text(kQuantityStatusWarningMessage),
+                            actions: [
+                              TextButton(
+                                onPressed: () =>
+                                    Navigator.of(confirmCtx).pop(false),
+                                child: const Text('Отмена'),
+                              ),
+                              ElevatedButton(
+                                onPressed: () =>
+                                    Navigator.of(confirmCtx).pop(true),
+                                child: const Text('Продолжить'),
+                              ),
+                            ],
+                          ),
+                        ) ??
+                        false;
+                    if (!confirmed) return;
+                  }
+                  final displayQuantity = formatTaskInitialQuantity(n);
+                  final display = unitLabel.isNotEmpty
+                      ? '$displayQuantity $unitLabel'
+                      : displayQuantity;
+                  final payload = quantityStatusToJson(
+                    actual: n,
+                    unit: unitLabel,
+                    expected: expected,
+                    status: status,
+                    displayText: display,
+                  );
+                  Navigator.pop(
+                    ctx,
+                    _QuantityInput(
+                      quantity: n,
+                      displayText: display,
+                      expected: expected,
+                      status: status,
+                      commentText: payload,
+                    ),
+                  );
+                },
+                child: const Text('OK'),
+              ),
+            ],
+          );
+        },
       );
     },
   );


### PR DESCRIPTION
### Motivation
- Centralize quantity/status calculation and expected-quantity resolution so UI and backend payloads use a single source of truth. 
- Validate quantity input (empty/non-numeric/negative) and surface warnings when entered quantities deviate from plan. 
- Make quantity comments machine-readable (JSON) including actual/expected/status so older free-form comments remain supported while new UI can colorize and interpret status.

### Description
- Added `lib/modules/tasks/quantity_status_service.dart` implementing `QuantityStatus` enum, unit normalization, `getExpectedQuantity`, `getQuantityStatus`, `getQuantityStatusColor`, JSON payload helpers (`quantityStatusToJson`, `tryDecodeQuantityPayload`, `quantityDisplayText`, etc.), and constants/alias handling for the two-sheet-package + sheet-cutting rule. 
- Updated `lib/modules/tasks/tasks_screen.dart` to import and use the service, to enrich `_QuantityInput` with `expected`, `status`, and `commentText`, to validate input in `_askQuantity`, to ask for confirmation on `warning`/`danger` deviations, and to serialize comments as the new JSON payload when posting `quantity_done`, `quantity_team_total`, `quantity_share` and when calling RPCs that accept `quantityDone`.
- Implemented on-the-fly parsing for legacy (plain-text) quantity comments and derive status when payload is not present, and updated `_buildResultPanel` and comments panel to apply status color highlighting (success = green, warning = orange, danger = red, unknown = grey) and status-aware icons.
- Updated `lib/modules/orders/order_timeline_dialog.dart` to prefer human-readable `display` from the new JSON payload when formatting quantity entries.

### Testing
- Ran `git diff --check` to ensure no obvious whitespace/merge issues and it returned clean results. 
- Attempted `dart format` and `flutter analyze` for the modified files, but execution failed in this environment because `dart`/`flutter` executables are not available, so static formatting/analysis could not be completed here. 
- Manual code inspections and local textual transformations were applied to integrate the new service with existing parsing and comment-writing flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad70f11bc832f812fe8ed738f9536)