### PR TITLE
Validate task quantity input (disallow zero)

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -7929,6 +7929,11 @@ Future<_QuantityInput?> _askQuantity(
                         errorText = 'Количество не может быть отрицательным.');
                     return;
                   }
+                  if (n == 0) {
+                    setState(() =>
+                        errorText = 'Количество должно быть больше 0.');
+                    return;
+                  }
                   final expected = order != null && task != null
                       ? getExpectedQuantity(
                           order: order,


### PR DESCRIPTION
### Motivation
- Ensure the quantity dialog validates user input in-place and prevents closing when the value is invalid, requiring a strictly positive quantity when business logic does not allow zero.

### Description
- Add an explicit zero-value check to `Future<_QuantityInput?> _askQuantity(...)` that sets `errorText` (`InputDecoration.errorText`) and keeps the `StatefulBuilder` dialog open instead of accepting `0`, and otherwise returns the `_QuantityInput(quantity: n, displayText: display, ...)` on successful validation in `lib/modules/tasks/tasks_screen.dart`.

### Testing
- Basic repository check `git diff --check` passed; an attempt to run `dart format` was not possible because the `dart` tool is not available in the environment; no unit or widget tests were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad9560144832fb626646c55d7762b)