### PR TITLE
Fix UUID/text comparisons in paint RPCs, guard mounted context, and restore production queue reordering

### DIFF
--- a/lib/modules/production/production_queue_provider.dart
+++ b/lib/modules/production/production_queue_provider.dart
@@ -867,17 +867,65 @@ class ProductionQueueProvider with ChangeNotifier {
     final byKey = {
       for (final position in current) position.queueKey: position,
     };
-    for (var i = 0; i < nextKeys.length; i++) {
-      final position = byKey[nextKeys[i]];
-      if (position == null) continue;
-      final nextPosition = i + 1;
-      if (position.queuePosition == nextPosition) continue;
-      await _sb.from(_positionsTable).update({
-        'queue_position': nextPosition,
-        'updated_at': DateTime.now().toUtc().toIso8601String(),
-      }).eq('id', position.id);
+
+    // Apply the new order in memory before the network roundtrip. Without this
+    // optimistic update the next build can re-render the old queue and make a
+    // successful drag look like it was ignored until realtime/polling catches up.
+    _applyLocalVisibleReorder(
+      workplaceId: normalized,
+      nextKeys: nextKeys,
+      byKey: byKey,
+    );
+
+    try {
+      for (var i = 0; i < nextKeys.length; i++) {
+        final position = byKey[nextKeys[i]];
+        if (position == null) continue;
+        final nextPosition = i + 1;
+        if (position.queuePosition == nextPosition) continue;
+        await _sb.from(_positionsTable).update({
+          'queue_position': nextPosition,
+          'updated_at': DateTime.now().toUtc().toIso8601String(),
+        }).eq('id', position.id);
+      }
+    } catch (_) {
+      await loadPositionsForWorkplace(normalized);
+      rethrow;
     }
     await loadPositionsForWorkplace(normalized);
+  }
+
+  void _applyLocalVisibleReorder({
+    required String workplaceId,
+    required List<String> nextKeys,
+    required Map<String, WorkplaceQueuePosition> byKey,
+  }) {
+    final currentMap = _positionsByWorkplace[workplaceId];
+    if (currentMap == null || currentMap.isEmpty) return;
+    var changed = false;
+    final updated = Map<String, WorkplaceQueuePosition>.from(currentMap);
+    for (var i = 0; i < nextKeys.length; i++) {
+      final key = nextKeys[i];
+      final position = byKey[key];
+      if (position == null) continue;
+      final nextPosition = i + 1;
+      if (position.queuePosition == nextPosition && position.hasQueuePosition) {
+        continue;
+      }
+      updated[key] = WorkplaceQueuePosition(
+        id: position.id,
+        workplaceId: position.workplaceId,
+        taskId: position.taskId,
+        orderId: position.orderId,
+        stageId: position.stageId,
+        stageGroupKey: position.stageGroupKey,
+        queuePosition: nextPosition,
+      );
+      changed = true;
+    }
+    if (!changed) return;
+    _positionsByWorkplace[workplaceId] = updated;
+    notifyListeners();
   }
 
   /// Legacy/fallback order sync. Manual workplace ordering must use

--- a/lib/modules/production/production_screen.dart
+++ b/lib/modules/production/production_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -1383,18 +1385,29 @@ class _ProductionTabState extends State<_ProductionTab> {
                   final updated = List.of(ordered);
                   final item = updated.removeAt(oldIndex);
                   updated.insert(newIndex, item);
-                  queue.applyVisibleTaskReorder(
-                    workplaceId: tab.id,
-                    orderedKeys: updated
-                        .map((order) => WorkplaceQueueItemKey.fromEntry(
-                              _queueEntryForOrder(
-                                order,
-                                groupingByOrder[order.id]!,
-                                tab.id,
-                              ),
-                            ))
-                        .toList(growable: false),
-                  );
+                  unawaited(() async {
+                    try {
+                      await queue.applyVisibleTaskReorder(
+                        workplaceId: tab.id,
+                        orderedKeys: updated
+                            .map((order) => WorkplaceQueueItemKey.fromEntry(
+                                  _queueEntryForOrder(
+                                    order,
+                                    groupingByOrder[order.id]!,
+                                    tab.id,
+                                  ),
+                                ))
+                            .toList(growable: false),
+                      );
+                    } catch (e) {
+                      if (!context.mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Не удалось сохранить очередь: $e'),
+                        ),
+                      );
+                    }
+                  }());
                 },
                 itemBuilder: (context, index) {
                   final order = ordered[index];

--- a/lib/modules/warehouse/type_table_tabs_screen.dart
+++ b/lib/modules/warehouse/type_table_tabs_screen.dart
@@ -386,6 +386,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       final t = widget.type.toLowerCase();
       context.read<WarehouseProvider>().setStationeryKey(
             (t.startsWith('руч') || t.startsWith('pens'))
@@ -410,6 +411,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
       required List<TmcModel> items,
       WarehouseLogsBundle? bundle,
     }) {
+      if (!mounted) return;
       final writeoffs =
           bundle == null ? _writeoffs : _mapBundleLogs(bundle.writeoffs);
       final inventories =

--- a/supabase/migrations/20260514_add_order_paint_reservations.sql
+++ b/supabase/migrations/20260514_add_order_paint_reservations.sql
@@ -244,7 +244,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = rec.paint_id
-       and r.order_id <> p_order_id;
+       and r.order_id::text <> p_order_id;
 
     v_available := rec.total_qty - v_reserved_other;
     if v_available < rec.qty then
@@ -259,7 +259,7 @@ begin
   v_touched := v_touched || array(
     select distinct paint_id
       from order_paint_reservations
-     where order_id = p_order_id and paint_id is not null
+     where order_id::text = p_order_id and paint_id is not null
   );
 
   for rec in
@@ -299,7 +299,7 @@ begin
   loop
     if rec.qty <= 0 then
       delete from order_paint_reservations
-       where order_id = p_order_id and paint_id = rec.paint_id;
+       where order_id::text = p_order_id and paint_id = rec.paint_id;
     else
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
       values (p_order_id, rec.paint_id, rec.paint_name, rec.qty, 0, 0)
@@ -314,7 +314,7 @@ begin
   end loop;
 
   delete from order_paint_reservations r
-   where r.order_id = p_order_id
+   where r.order_id::text = p_order_id
      and not exists (
        with requested as (
          select public.safe_paint_id(coalesce(value->>'paint_id', value->>'material_id')) as paint_id,
@@ -370,12 +370,12 @@ begin
 
   select array_agg(distinct paint_id) into v_touched
     from order_paint_reservations
-   where order_id = p_order_id and paint_id is not null;
+   where order_id::text = p_order_id and paint_id is not null;
 
   update order_paint_reservations
      set released_qty = greatest(reserved_qty - used_qty, 0),
          updated_at = now()
-   where order_id = p_order_id;
+   where order_id::text = p_order_id;
 
   perform recalculate_paint_reserved_qty(v_touched);
 end;
@@ -413,7 +413,7 @@ begin
   if coalesce(trim(p_order_id), '') = '' then raise exception 'order_id is required'; end if;
   if p_paint_usages is null then p_paint_usages := '[]'::jsonb; end if;
 
-  perform 1 from tasks where id = p_task_id and order_id = p_order_id for update;
+  perform 1 from tasks where id::text = p_task_id and order_id::text = p_order_id for update;
   if not found then
     raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
   end if;
@@ -472,7 +472,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = rec.paint_id
-       and r.order_id <> p_order_id;
+       and r.order_id::text <> p_order_id;
 
     v_available := rec.total_qty - v_reserved_other;
     if v_available < rec.qty then
@@ -498,7 +498,7 @@ begin
            released_qty = greatest(reserved_qty - rec.qty, 0),
            paint_name = coalesce(paint_name, rec.paint_name, rec.stock_name),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rec.paint_id;
+     where order_id::text = p_order_id and paint_id = rec.paint_id;
 
     if not found then
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
@@ -515,14 +515,14 @@ begin
   for rel in
     select paint_id
       from order_paint_reservations
-     where order_id = p_order_id
+     where order_id::text = p_order_id
        and greatest(reserved_qty - used_qty - released_qty, 0) > 0
      for update
   loop
     update order_paint_reservations
        set released_qty = greatest(reserved_qty - used_qty, 0),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rel.paint_id;
+     where order_id::text = p_order_id and paint_id = rel.paint_id;
     v_touched := array_append(v_touched, rel.paint_id);
   end loop;
 
@@ -530,7 +530,7 @@ begin
 
   select coalesce(comments::jsonb, '[]'::jsonb) into v_comments
     from tasks
-   where id = p_task_id
+   where id::text = p_task_id
    for update;
 
   if p_quantity_done is not null and trim(p_quantity_done) <> '' then
@@ -557,13 +557,13 @@ begin
      set status = 'completed',
          started_at = null,
          comments = v_comments
-   where id = p_task_id;
+   where id::text = p_task_id;
 
   update tasks
      set status = 'completed', started_at = null
-   where order_id = p_order_id
-     and stage_id = p_stage_id
-     and id <> p_task_id
+   where order_id::text = p_order_id
+     and stage_id::text = p_stage_id
+     and id::text <> p_task_id
      and status <> 'completed';
 end;
 $$;

--- a/supabase/migrations/20260514_complete_task_stage_rpc.sql
+++ b/supabase/migrations/20260514_complete_task_stage_rpc.sql
@@ -82,14 +82,14 @@ begin
        set status = 'completed',
            started_at = null,
            completed_at = v_now_ms
-     where order_id = p_order_id
+     where order_id::text = p_order_id
        and coalesce(nullif(stage_group_key, ''), stage_id) = v_group_key
        and status <> 'completed';
   else
     update tasks
        set status = 'completed',
            started_at = null
-     where order_id = p_order_id
+     where order_id::text = p_order_id
        and coalesce(nullif(stage_group_key, ''), stage_id) = v_group_key
        and status <> 'completed';
   end if;
@@ -97,7 +97,7 @@ begin
   if to_regclass('public.prod_plans') is not null and to_regclass('public.prod_plan_stages') is not null then
     select id::text into v_plan_id
       from public.prod_plans
-     where order_id = p_order_id
+     where order_id::text = p_order_id
      limit 1;
 
     if v_plan_id is not null then
@@ -140,14 +140,14 @@ begin
   select bool_and(status = 'completed')
     into v_completed_all_stage
     from tasks
-   where order_id = p_order_id
-     and stage_id = p_stage_id;
+   where order_id::text = p_order_id
+     and stage_id::text = p_stage_id;
 
   if coalesce(v_completed_all_stage, false) then
     select exists(
       select 1 from tasks
-       where order_id = p_order_id
-         and stage_id <> p_stage_id
+       where order_id::text = p_order_id
+         and stage_id::text <> p_stage_id
          and status <> 'completed'
     ) into v_has_pending_after;
 
@@ -172,24 +172,24 @@ begin
             )
           end as qty
           from tasks
-          where order_id = p_order_id and stage_id = p_stage_id
+          where order_id::text = p_order_id and stage_id::text = p_stage_id
         ) s;
 
       update orders
          set actual_qty = v_actual_qty
-       where id = p_order_id;
+       where id::text = p_order_id;
     end if;
   end if;
 
   select bool_and(status = 'completed')
     into v_order_completed
     from tasks
-   where order_id = p_order_id;
+   where order_id::text = p_order_id;
 
   if coalesce(v_order_completed, false) then
     update orders
        set status = 'completed'
-     where id = p_order_id;
+     where id::text = p_order_id;
 
     if to_regprocedure('public.finalize_order_paper_reservations(text,text)') is not null then
       perform public.finalize_order_paper_reservations(p_order_id, p_actor);
@@ -229,7 +229,7 @@ begin
 
   select * into v_task
     from tasks
-   where id = p_task_id and order_id = p_order_id and stage_id = p_stage_id
+   where id::text = p_task_id and order_id::text = p_order_id and stage_id::text = p_stage_id
    for update;
   if not found then
     raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
@@ -320,7 +320,7 @@ begin
      set comments = v_comments,
          status = 'completed',
          started_at = null
-   where id = p_task_id;
+   where id::text = p_task_id;
 
   perform public.advance_order_after_task_completion(
     p_order_id,
@@ -369,7 +369,7 @@ begin
 
   select * into v_task
     from tasks
-   where id = p_task_id and order_id = p_order_id and stage_id = p_stage_id
+   where id::text = p_task_id and order_id::text = p_order_id and stage_id::text = p_stage_id
    for update;
   if not found then
     raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
@@ -438,7 +438,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = rec.paint_id
-       and r.order_id <> p_order_id;
+       and r.order_id::text <> p_order_id;
 
     v_available := rec.total_qty - v_reserved_other;
     if v_available < rec.qty then
@@ -464,7 +464,7 @@ begin
            released_qty = greatest(reserved_qty - rec.qty, 0),
            paint_name = coalesce(paint_name, rec.paint_name, rec.stock_name),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rec.paint_id;
+     where order_id::text = p_order_id and paint_id = rec.paint_id;
 
     if not found then
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
@@ -481,14 +481,14 @@ begin
   for rel in
     select paint_id
       from order_paint_reservations
-     where order_id = p_order_id
+     where order_id::text = p_order_id
        and greatest(reserved_qty - used_qty - released_qty, 0) > 0
      for update
   loop
     update order_paint_reservations
        set released_qty = greatest(reserved_qty - used_qty, 0),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rel.paint_id;
+     where order_id::text = p_order_id and paint_id = rel.paint_id;
     v_touched := array_append(v_touched, rel.paint_id);
   end loop;
 
@@ -546,7 +546,7 @@ begin
      set status = 'completed',
          started_at = null,
          comments = v_comments
-   where id = p_task_id;
+   where id::text = p_task_id;
 
   perform public.advance_order_after_task_completion(
     p_order_id,

--- a/supabase/migrations/20260515_complete_flex_printing_stage_paint_queue.sql
+++ b/supabase/migrations/20260515_complete_flex_printing_stage_paint_queue.sql
@@ -56,7 +56,7 @@ begin
 
   select * into v_task
     from tasks
-   where id = p_task_id and order_id = p_order_id and stage_id = p_stage_id
+   where id::text = p_task_id and order_id::text = p_order_id and stage_id::text = p_stage_id
    for update;
   if not found then
     raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
@@ -233,7 +233,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = v_paint_id
-       and r.order_id <> v_source_order_id;
+       and r.order_id::text <> v_source_order_id;
     v_available := v_stock_qty - v_reserved_other;
     if v_available < v_amount then
       raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
@@ -255,7 +255,7 @@ begin
            released_qty = greatest(reserved_qty - v_amount, 0),
            paint_name = coalesce(paint_name, v_paint_name, v_stock_name),
            updated_at = now()
-     where order_id = v_source_order_id and paint_id = v_paint_id;
+     where order_id::text = v_source_order_id and paint_id = v_paint_id;
     if not found then
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
       values (v_source_order_id, v_paint_id, coalesce(v_paint_name, v_stock_name), v_amount, v_amount, 0)
@@ -341,7 +341,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = v_paint_id
-       and r.order_id <> v_source_order_id;
+       and r.order_id::text <> v_source_order_id;
     v_available := v_stock_qty - v_reserved_other;
     if v_available < v_amount then
       raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
@@ -363,7 +363,7 @@ begin
            released_qty = greatest(reserved_qty - v_amount, 0),
            paint_name = coalesce(paint_name, v_paint_name, v_stock_name),
            updated_at = now()
-     where order_id = v_source_order_id and paint_id = v_paint_id;
+     where order_id::text = v_source_order_id and paint_id = v_paint_id;
     if not found then
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
       values (v_source_order_id, v_paint_id, coalesce(v_paint_name, v_stock_name), v_amount, v_amount, 0)
@@ -405,14 +405,14 @@ begin
   for rec in
     select paint_id
       from order_paint_reservations
-     where order_id = p_order_id
+     where order_id::text = p_order_id
        and greatest(reserved_qty - used_qty - released_qty, 0) > 0
      for update
   loop
     update order_paint_reservations
        set released_qty = greatest(reserved_qty - used_qty, 0),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rec.paint_id;
+     where order_id::text = p_order_id and paint_id = rec.paint_id;
     v_touched := array_append(v_touched, rec.paint_id);
   end loop;
 
@@ -528,7 +528,7 @@ begin
      set status = 'completed',
          started_at = null,
          comments = v_comments
-   where id = p_task_id;
+   where id::text = p_task_id;
 
   perform public.advance_order_after_task_completion(
     p_order_id,

--- a/supabase/migrations/20260516_migrate_order_paint_ids_to_paints_id_type.sql
+++ b/supabase/migrations/20260516_migrate_order_paint_ids_to_paints_id_type.sql
@@ -436,7 +436,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = rec.paint_id
-       and r.order_id <> p_order_id;
+       and r.order_id::text <> p_order_id;
 
     v_available := rec.total_qty - v_reserved_other;
     if v_available < rec.qty then
@@ -451,7 +451,7 @@ begin
   v_touched := v_touched || array(
     select distinct paint_id
       from order_paint_reservations
-     where order_id = p_order_id and paint_id is not null
+     where order_id::text = p_order_id and paint_id is not null
   );
 
   for rec in
@@ -491,7 +491,7 @@ begin
   loop
     if rec.qty <= 0 then
       delete from order_paint_reservations
-       where order_id = p_order_id and paint_id = rec.paint_id;
+       where order_id::text = p_order_id and paint_id = rec.paint_id;
     else
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
       values (p_order_id, rec.paint_id, rec.paint_name, rec.qty, 0, 0)
@@ -506,7 +506,7 @@ begin
   end loop;
 
   delete from order_paint_reservations r
-   where r.order_id = p_order_id
+   where r.order_id::text = p_order_id
      and not exists (
        with requested as (
          select public.safe_paint_id(coalesce(value->>'paint_id', value->>'material_id')) as paint_id,
@@ -562,12 +562,12 @@ begin
 
   select array_agg(distinct paint_id) into v_touched
     from order_paint_reservations
-   where order_id = p_order_id and paint_id is not null;
+   where order_id::text = p_order_id and paint_id is not null;
 
   update order_paint_reservations
      set released_qty = greatest(reserved_qty - used_qty, 0),
          updated_at = now()
-   where order_id = p_order_id;
+   where order_id::text = p_order_id;
 
   perform recalculate_paint_reserved_qty(v_touched);
 end;
@@ -605,7 +605,7 @@ begin
   if coalesce(trim(p_order_id), '') = '' then raise exception 'order_id is required'; end if;
   if p_paint_usages is null then p_paint_usages := '[]'::jsonb; end if;
 
-  perform 1 from tasks where id = p_task_id and order_id = p_order_id for update;
+  perform 1 from tasks where id::text = p_task_id and order_id::text = p_order_id for update;
   if not found then
     raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
   end if;
@@ -664,7 +664,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = rec.paint_id
-       and r.order_id <> p_order_id;
+       and r.order_id::text <> p_order_id;
 
     v_available := rec.total_qty - v_reserved_other;
     if v_available < rec.qty then
@@ -690,7 +690,7 @@ begin
            released_qty = greatest(reserved_qty - rec.qty, 0),
            paint_name = coalesce(paint_name, rec.paint_name, rec.stock_name),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rec.paint_id;
+     where order_id::text = p_order_id and paint_id = rec.paint_id;
 
     if not found then
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
@@ -707,14 +707,14 @@ begin
   for rel in
     select paint_id
       from order_paint_reservations
-     where order_id = p_order_id
+     where order_id::text = p_order_id
        and greatest(reserved_qty - used_qty - released_qty, 0) > 0
      for update
   loop
     update order_paint_reservations
        set released_qty = greatest(reserved_qty - used_qty, 0),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rel.paint_id;
+     where order_id::text = p_order_id and paint_id = rel.paint_id;
     v_touched := array_append(v_touched, rel.paint_id);
   end loop;
 
@@ -722,7 +722,7 @@ begin
 
   select coalesce(comments::jsonb, '[]'::jsonb) into v_comments
     from tasks
-   where id = p_task_id
+   where id::text = p_task_id
    for update;
 
   if p_quantity_done is not null and trim(p_quantity_done) <> '' then
@@ -749,13 +749,13 @@ begin
      set status = 'completed',
          started_at = null,
          comments = v_comments
-   where id = p_task_id;
+   where id::text = p_task_id;
 
   update tasks
      set status = 'completed', started_at = null
-   where order_id = p_order_id
-     and stage_id = p_stage_id
-     and id <> p_task_id
+   where order_id::text = p_order_id
+     and stage_id::text = p_stage_id
+     and id::text <> p_task_id
      and status <> 'completed';
 end;
 $$;
@@ -822,7 +822,7 @@ begin
 
   select * into v_task
     from tasks
-   where id = p_task_id and order_id = p_order_id and stage_id = p_stage_id
+   where id::text = p_task_id and order_id::text = p_order_id and stage_id::text = p_stage_id
    for update;
   if not found then
     raise exception 'Задача % не найдена для заказа %.', p_task_id, p_order_id;
@@ -999,7 +999,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = v_paint_id
-       and r.order_id <> v_source_order_id;
+       and r.order_id::text <> v_source_order_id;
     v_available := v_stock_qty - v_reserved_other;
     if v_available < v_amount then
       raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
@@ -1021,7 +1021,7 @@ begin
            released_qty = greatest(reserved_qty - v_amount, 0),
            paint_name = coalesce(paint_name, v_paint_name, v_stock_name),
            updated_at = now()
-     where order_id = v_source_order_id and paint_id = v_paint_id;
+     where order_id::text = v_source_order_id and paint_id = v_paint_id;
     if not found then
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
       values (v_source_order_id, v_paint_id, coalesce(v_paint_name, v_stock_name), v_amount, v_amount, 0)
@@ -1107,7 +1107,7 @@ begin
       into v_reserved_other
       from order_paint_reservations r
      where r.paint_id = v_paint_id
-       and r.order_id <> v_source_order_id;
+       and r.order_id::text <> v_source_order_id;
     v_available := v_stock_qty - v_reserved_other;
     if v_available < v_amount then
       raise exception 'Недостаточно краски: %. Доступно: %, требуется: %',
@@ -1129,7 +1129,7 @@ begin
            released_qty = greatest(reserved_qty - v_amount, 0),
            paint_name = coalesce(paint_name, v_paint_name, v_stock_name),
            updated_at = now()
-     where order_id = v_source_order_id and paint_id = v_paint_id;
+     where order_id::text = v_source_order_id and paint_id = v_paint_id;
     if not found then
       insert into order_paint_reservations(order_id, paint_id, paint_name, reserved_qty, used_qty, released_qty)
       values (v_source_order_id, v_paint_id, coalesce(v_paint_name, v_stock_name), v_amount, v_amount, 0)
@@ -1171,14 +1171,14 @@ begin
   for rec in
     select paint_id
       from order_paint_reservations
-     where order_id = p_order_id
+     where order_id::text = p_order_id
        and greatest(reserved_qty - used_qty - released_qty, 0) > 0
      for update
   loop
     update order_paint_reservations
        set released_qty = greatest(reserved_qty - used_qty, 0),
            updated_at = now()
-     where order_id = p_order_id and paint_id = rec.paint_id;
+     where order_id::text = p_order_id and paint_id = rec.paint_id;
     v_touched := array_append(v_touched, rec.paint_id);
   end loop;
 
@@ -1294,7 +1294,7 @@ begin
      set status = 'completed',
          started_at = null,
          comments = v_comments
-   where id = p_task_id;
+   where id::text = p_task_id;
 
   perform public.advance_order_after_task_completion(
     p_order_id,


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by comparing UUID columns to plain text parameters in Supabase RPCs (causing `operator does not exist: uuid = text`) and ensure flexo paint writeoffs + task completion remain atomic and reliable. 
- Avoid Flutter crashes from accessing `context` after widget disposal during post-frame callbacks and async snapshots. 
- Restore responsive manual reordering of the production queue so UI drag operations feel immediate and persist reliably.

### Description
- Updated Supabase RPC SQL to compare task/order/stage IDs via `::text` at RPC boundaries and to use `public.safe_paint_id(...)` for paint ids so UUID/text mismatches no longer occur while preserving typed `paints.id` behavior; changes were applied to the flex/paint reservation and completion RPCs and related migration RPCs. 
- Kept the full atomic flex printing flow (immediate writeoffs, queued writeoffs, stock updates, reservation recalculation, comments, and task completion) but fixed all places that compared uuid columns to text params by casting the columns to text for safe comparisons. 
- Guarded widget lifecycle in the warehouse screen by checking `mounted` before doing a post-frame provider read and before applying async snapshot updates to avoid using `context` after disposal. 
- Restored manual queue reordering responsiveness by applying an optimistic in-memory reorder (`_applyLocalVisibleReorder`) before issuing Supabase updates, adding rollback/load-on-failure behavior, and showing a user-facing error Snackbar when saving fails; also made the UI call asynchronous save without blocking the drag behavior. 

### Testing
- Ran a project-wide pattern scan (Python) for remaining unsafe `uuid = text` comparison patterns and found none in the touched migrations. (succeeded) 
- Executed `git diff --check` to detect whitespace/patch errors (no problems found). (succeeded) 
- Verified that SQL migration functions now use `::text` for id comparisons by inspecting the updated migration files. (inspection) 
- Dart/Flutter formatting and runtime tests were not executed in this environment because `dart`/`flutter` CLIs are not available here, so local formatting/tests should be run in a developer environment before deployment. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0adba633fc832fb2e1c24f992417d6)