### PR TITLE
Persist order_paints via RPC with UUID casting and fix paint-dialog overflow

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -2429,13 +2429,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
     // 4) Перезаписываем таблицу order_paints
     try {
-      // удаляем старые
-      await _sb.from('order_paints').delete().eq('order_id', orderId);
-      // вставляем новые
-      if (rows.isNotEmpty) {
-        await _sb.from('order_paints').insert(rows);
-      }
-      await OrdersRepository().syncPaintReservations(
+      final repo = OrdersRepository();
+      await repo.saveOrderPaints(orderId: orderId, paints: rows);
+      await repo.syncPaintReservations(
         orderId: orderId,
         paints: rows,
         actor: AuthHelper.currentUserName ?? '',

--- a/lib/modules/orders/orders_repository.dart
+++ b/lib/modules/orders/orders_repository.dart
@@ -302,9 +302,19 @@ class OrdersRepository {
   Future<int> addPaints(String orderId, List<PaintItem> paints) async {
     if (paints.isEmpty) return 0;
     final rows = paints.map((p) => p.toRow(orderId)).toList();
-    final res = await _sb.from('order_paints').insert(rows).select('id');
-    if (res is List) return res.length;
-    return 0;
+    await saveOrderPaints(orderId: orderId, paints: rows);
+    return rows.length;
+  }
+
+  Future<void> saveOrderPaints({
+    required String orderId,
+    required List<Map<String, dynamic>> paints,
+  }) async {
+    await ensureSignedIn();
+    await _sb.rpc('save_order_paints', params: {
+      'p_order_id': orderId,
+      'p_paints': paints,
+    });
   }
 
   Future<void> syncPaintReservations({

--- a/lib/modules/production_planning/form_editor_screen.dart
+++ b/lib/modules/production_planning/form_editor_screen.dart
@@ -1231,13 +1231,9 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
     // 4) Перезаписываем таблицу order_paints
     try {
-      // удаляем старые
-      await _sb.from('order_paints').delete().eq('order_id', orderId);
-      // вставляем новые
-      if (rows.isNotEmpty) {
-        await _sb.from('order_paints').insert(rows);
-      }
-      await OrdersRepository().syncPaintReservations(
+      final repo = OrdersRepository();
+      await repo.saveOrderPaints(orderId: orderId, paints: rows);
+      await repo.syncPaintReservations(
         orderId: orderId,
         paints: rows,
         actor: AuthHelper.currentUserName ?? '',

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1660,62 +1660,95 @@ class _TasksScreenState extends State<TasksScreen>
                     for (var i = 0; i < selected.length; i++)
                       Padding(
                         padding: const EdgeInsets.only(bottom: 12),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              flex: 3,
-                              child: OutlinedButton(
-                                onPressed: saving ? null : () => choosePaint(i, setDialogState),
-                                child: Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: Text(_paintNameFromRow(selected[i]).isEmpty
+                        child: LayoutBuilder(
+                          builder: (context, constraints) {
+                            final compact = constraints.maxWidth < 640;
+                            final deleteButton = selected.length > 1
+                                ? IconButton(
+                                    tooltip: 'Удалить краску',
+                                    onPressed: saving
+                                        ? null
+                                        : () {
+                                            final removedQty = qtyControllers[i];
+                                            final removedInfo = infoControllers[i];
+                                            setDialogState(() {
+                                              selected.removeAt(i);
+                                              qtyControllers.removeAt(i);
+                                              infoControllers.removeAt(i);
+                                            });
+                                            WidgetsBinding.instance
+                                                .addPostFrameCallback((_) {
+                                              removedQty.dispose();
+                                              removedInfo.dispose();
+                                            });
+                                          },
+                                    icon: const Icon(Icons.delete_outline),
+                                  )
+                                : const SizedBox.shrink();
+                            final paintButton = OutlinedButton(
+                              onPressed: saving
+                                  ? null
+                                  : () => choosePaint(i, setDialogState),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  _paintNameFromRow(selected[i]).isEmpty
                                       ? 'Выбрать краску'
-                                      : _paintNameFromRow(selected[i])),
+                                      : _paintNameFromRow(selected[i]),
+                                  overflow: TextOverflow.ellipsis,
                                 ),
                               ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: TextFormField(
-                                controller: qtyControllers[i],
-                                keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                                decoration: const InputDecoration(labelText: 'Кол-во, кг'),
-                                validator: (value) {
-                                  final qty = double.tryParse((value ?? '').trim().replaceAll(',', '.'));
-                                  if (qty == null || qty <= 0) return 'Введите > 0';
-                                  return null;
-                                },
+                            );
+                            final qtyField = TextFormField(
+                              controller: qtyControllers[i],
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(
+                                decimal: true,
                               ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              flex: 2,
-                              child: TextFormField(
-                                controller: infoControllers[i],
-                                decoration: const InputDecoration(labelText: 'Инфо'),
-                              ),
-                            ),
-                            if (selected.length > 1)
-                              IconButton(
-                                tooltip: 'Удалить краску',
-                                onPressed: saving
-                                    ? null
-                                    : () {
-                                        final removedQty = qtyControllers[i];
-                                        final removedInfo = infoControllers[i];
-                                        setDialogState(() {
-                                          selected.removeAt(i);
-                                          qtyControllers.removeAt(i);
-                                          infoControllers.removeAt(i);
-                                        });
-                                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                                          removedQty.dispose();
-                                          removedInfo.dispose();
-                                        });
-                                      },
-                                icon: const Icon(Icons.delete_outline),
-                              ),
-                          ],
+                              decoration:
+                                  const InputDecoration(labelText: 'Кол-во, кг'),
+                              validator: (value) {
+                                final qty = double.tryParse((value ?? '')
+                                    .trim()
+                                    .replaceAll(',', '.'));
+                                if (qty == null || qty <= 0) return 'Введите > 0';
+                                return null;
+                              },
+                            );
+                            final infoField = TextFormField(
+                              controller: infoControllers[i],
+                              decoration: const InputDecoration(labelText: 'Инфо'),
+                            );
+
+                            if (compact) {
+                              return Column(
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Expanded(child: paintButton),
+                                      if (selected.length > 1) deleteButton,
+                                    ],
+                                  ),
+                                  const SizedBox(height: 8),
+                                  qtyField,
+                                  const SizedBox(height: 8),
+                                  infoField,
+                                ],
+                              );
+                            }
+
+                            return Row(
+                              children: [
+                                Expanded(flex: 3, child: paintButton),
+                                const SizedBox(width: 12),
+                                Expanded(child: qtyField),
+                                const SizedBox(width: 12),
+                                Expanded(flex: 2, child: infoField),
+                                if (selected.length > 1) deleteButton,
+                              ],
+                            );
+                          },
                         ),
                       ),
                     Align(
@@ -1793,11 +1826,10 @@ class _TasksScreenState extends State<TasksScreen>
                         });
                       }
                       try {
-                        final sb = Supabase.instance.client;
-                        await sb.from('order_paints').delete().eq('order_id', latest.id);
-                        if (nextRows.isNotEmpty) {
-                          await sb.from('order_paints').insert(nextRows);
-                        }
+                        await repo.saveOrderPaints(
+                          orderId: latest.id,
+                          paints: nextRows,
+                        );
                         await repo.syncPaintReservations(
                           orderId: latest.id,
                           paints: nextRows,
@@ -4615,46 +4647,56 @@ class _TasksScreenState extends State<TasksScreen>
                         ],
                       ),
                       const SizedBox(height: 10),
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            flex: 3,
-                            child: TextField(
-                              controller: controllers[row],
-                              keyboardType: const TextInputType.numberWithOptions(
-                                decimal: true,
+                      LayoutBuilder(
+                        builder: (context, constraints) {
+                          final compact = constraints.maxWidth < 560;
+                          final fieldWidth = compact
+                              ? constraints.maxWidth
+                              : (constraints.maxWidth - 96) / 2;
+                          return Wrap(
+                            spacing: 12,
+                            runSpacing: 8,
+                            crossAxisAlignment: WrapCrossAlignment.start,
+                            children: [
+                              SizedBox(
+                                width: fieldWidth,
+                                child: TextField(
+                                  controller: controllers[row],
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                    decimal: true,
+                                  ),
+                                  decoration: const InputDecoration(
+                                    labelText: 'Фактический расход',
+                                    border: OutlineInputBorder(),
+                                  ),
+                                  onChanged: (value) => row.actualUsedText = value,
+                                ),
                               ),
-                              decoration: const InputDecoration(
-                                labelText: 'Фактический расход',
-                                border: OutlineInputBorder(),
+                              Padding(
+                                padding: const EdgeInsets.only(top: 16),
+                                child: Text(row.unit),
                               ),
-                              onChanged: (value) => row.actualUsedText = value,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Padding(
-                            padding: const EdgeInsets.only(top: 16),
-                            child: Text(row.unit),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            flex: 3,
-                            child: CheckboxListTile(
-                              contentPadding: EdgeInsets.zero,
-                              value: row.writeOffNow,
-                              controlAffinity: ListTileControlAffinity.leading,
-                              title: const Text('Списать сейчас'),
-                              subtitle: Text(row.status),
-                              onChanged: (value) {
-                                updateDialogState(() {
-                                  row.writeOffNow = value ?? false;
-                                  row.refreshStatus();
-                                });
-                              },
-                            ),
-                          ),
-                        ],
+                              SizedBox(
+                                width: fieldWidth,
+                                child: CheckboxListTile(
+                                  contentPadding: EdgeInsets.zero,
+                                  value: row.writeOffNow,
+                                  controlAffinity:
+                                      ListTileControlAffinity.leading,
+                                  title: const Text('Списать сейчас'),
+                                  subtitle: Text(row.status),
+                                  onChanged: (value) {
+                                    updateDialogState(() {
+                                      row.writeOffNow = value ?? false;
+                                      row.refreshStatus();
+                                    });
+                                  },
+                                ),
+                              ),
+                            ],
+                          );
+                        },
                       ),
                     ],
                   ),

--- a/supabase/migrations/20260518_zz_save_order_paints_rpc.sql
+++ b/supabase/migrations/20260518_zz_save_order_paints_rpc.sql
@@ -1,0 +1,95 @@
+-- Persist order_paints through an RPC so text parameters from Flutter are cast to
+-- the database-native order_paints.order_id type before insert. This avoids
+-- Postgres 42804 on installations where order_id is uuid.
+
+create or replace function public.save_order_paints(
+  p_order_id text,
+  p_paints jsonb default '[]'::jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_order_id public.orders.id%type;
+  v_order_id_uuid uuid;
+  v_order_paints_order_id_type text;
+begin
+  if coalesce(trim(p_order_id), '') = '' then
+    raise exception 'order_id is required';
+  end if;
+
+  v_order_id := trim(p_order_id);
+
+  if p_paints is null then
+    p_paints := '[]'::jsonb;
+  end if;
+
+  select format_type(a.atttypid, a.atttypmod)
+    into v_order_paints_order_id_type
+    from pg_attribute a
+    join pg_class c on c.oid = a.attrelid
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public'
+     and c.relname = 'order_paints'
+     and a.attname = 'order_id'
+     and a.attnum > 0
+     and not a.attisdropped;
+
+  if v_order_paints_order_id_type is null then
+    raise exception 'public.order_paints.order_id column was not found';
+  end if;
+
+  if v_order_paints_order_id_type = 'uuid' then
+    v_order_id_uuid := trim(p_order_id)::uuid;
+
+    execute 'delete from public.order_paints where order_id = $1'
+      using v_order_id_uuid;
+
+    execute $sql$
+      insert into public.order_paints(order_id, name, info, qty_kg)
+      select
+        $1,
+        nullif(trim(coalesce(item->>'name', item->>'paint_name')), '') as name,
+        nullif(trim(coalesce(item->>'info', item->>'memo')), '') as info,
+        case
+          when nullif(trim(item->>'qty_kg'), '') is not null then
+            replace(trim(item->>'qty_kg'), ',', '.')::double precision
+          when nullif(trim(item->>'qtyGrams'), '') is not null then
+            replace(trim(item->>'qtyGrams'), ',', '.')::double precision / 1000
+          when nullif(trim(item->>'qty_grams'), '') is not null then
+            replace(trim(item->>'qty_grams'), ',', '.')::double precision / 1000
+          else null
+        end as qty_kg
+      from jsonb_array_elements($2) as item
+      where nullif(trim(coalesce(item->>'name', item->>'paint_name')), '') is not null
+    $sql$ using v_order_id_uuid, p_paints;
+  else
+    execute 'delete from public.order_paints where order_id = $1'
+      using trim(p_order_id);
+
+    execute $sql$
+      insert into public.order_paints(order_id, name, info, qty_kg)
+      select
+        $1,
+        nullif(trim(coalesce(item->>'name', item->>'paint_name')), '') as name,
+        nullif(trim(coalesce(item->>'info', item->>'memo')), '') as info,
+        case
+          when nullif(trim(item->>'qty_kg'), '') is not null then
+            replace(trim(item->>'qty_kg'), ',', '.')::double precision
+          when nullif(trim(item->>'qtyGrams'), '') is not null then
+            replace(trim(item->>'qtyGrams'), ',', '.')::double precision / 1000
+          when nullif(trim(item->>'qty_grams'), '') is not null then
+            replace(trim(item->>'qty_grams'), ',', '.')::double precision / 1000
+          else null
+        end as qty_kg
+      from jsonb_array_elements($2) as item
+      where nullif(trim(coalesce(item->>'name', item->>'paint_name')), '') is not null
+    $sql$ using trim(p_order_id), p_paints;
+  end if;
+end;
+$$;
+
+grant execute on function public.save_order_paints(text, jsonb)
+to authenticated, anon;


### PR DESCRIPTION
### Motivation
- Avoid Postgres 42804 errors when Flutter sends `order_id` as text but the DB `order_paints.order_id` column is `uuid`.  
- Prevent small horizontal `RenderFlex overflowed` issues in paint edit / write-off dialogs on narrow layouts.

### Description
- Add a new Supabase RPC `public.save_order_paints(text, jsonb)` that detects the actual `order_paints.order_id` type and casts the incoming text `p_order_id` to `uuid` when needed before deleting/inserting rows (file: `supabase/migrations/20260518_zz_save_order_paints_rpc.sql`).
- Add `OrdersRepository.saveOrderPaints(...)` which calls the `save_order_paints` RPC and use it from API flows to persist paints instead of issuing direct `delete/insert` with a raw text `order_id` (file: `lib/modules/orders/orders_repository.dart`).
- Replace direct `order_paints` `delete`/`insert` usages in the order edit and production planning form flows to call `saveOrderPaints` and then `syncPaintReservations` (files: `lib/modules/orders/edit_order_screen.dart`, `lib/modules/production_planning/form_editor_screen.dart`).
- Update task paint-edit flow to persist paints via `saveOrderPaints` and `syncPaintReservations` (file: `lib/modules/tasks/tasks_screen.dart`).
- Make the paint edit list and paint write-off dialog rows responsive to avoid tiny overflows by using `LayoutBuilder`, `Wrap` and `TextOverflow.ellipsis` and switching to compact vertical layout on narrow widths (file: `lib/modules/tasks/tasks_screen.dart`).

### Testing
- Ran repository pre-checks: `git diff --cached --check` (no issues found).  
- Ran `git diff --check` for whitespace/errors (no issues found).  
- Attempted `flutter analyze` but it could not run in this environment because the `flutter` tool is not available (analysis was therefore not executed here).  
- No unit/integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae4129664832faf7adddcd6ecafe9)