### PR TITLE
Fix paint reservation updates and human-readable writeoff display

### DIFF
--- a/lib/modules/orders/orders_repository.dart
+++ b/lib/modules/orders/orders_repository.dart
@@ -1,5 +1,7 @@
 // lib/modules/orders/orders_repository.dart (v3.1, paints fallback + events)
 import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:uuid/uuid.dart';
 
@@ -484,25 +486,117 @@ class OrdersRepository {
         ? currentOrderRows
         : (paintUsages ?? const <Map<String, dynamic>>[]);
 
+    final currentRpcRows = effectiveCurrentRows
+        .map((row) => _paintQueueRpcRow(
+              row,
+              fallbackOrderId: orderId,
+              fallbackTaskId: taskId,
+            ))
+        .toList(growable: false);
+    final pendingRpcRows = pendingRows
+        .map((row) => _paintQueueRpcRow(row))
+        .toList(growable: false);
+
     await _sb.rpc('complete_flex_printing_stage_with_paint_queue', params: {
       'p_task_id': taskId,
       'p_order_id': orderId,
       'p_stage_id': stageId,
       'p_employee_id': employeeId,
-      'p_current_order_rows': effectiveCurrentRows
-          .map((row) => _paintQueueRpcRow(
-                row,
-                fallbackOrderId: orderId,
-                fallbackTaskId: taskId,
-              ))
-          .toList(growable: false),
-      'p_pending_rows': pendingRows
-          .map((row) => _paintQueueRpcRow(row))
-          .toList(growable: false),
+      'p_current_order_rows': currentRpcRows,
+      'p_pending_rows': pendingRpcRows,
       'p_quantity_done': quantityDone,
       'p_comment': comment,
       'p_actor': actor ?? '',
     });
+
+    await _applyPaintReservationUsage(<Map<String, dynamic>>[
+      ...currentRpcRows,
+      ...pendingRpcRows,
+    ]);
+  }
+
+  Future<void> _applyPaintReservationUsage(
+    List<Map<String, dynamic>> writeoffRows,
+  ) async {
+    final rowsToApply = writeoffRows.where((row) {
+      final writeOffNow = row['write_off_now'] == true ||
+          row['write_off_now']?.toString().toLowerCase() == 'true';
+      final qty = _readDouble(row, const ['actual_used_amount', 'used_qty']) ?? 0;
+      final sourceOrderId = _trimmedString(row, const ['source_order_id']);
+      return writeOffNow && qty > 0 && sourceOrderId.isNotEmpty;
+    }).toList(growable: false);
+    if (rowsToApply.isEmpty) return;
+
+    for (final row in rowsToApply) {
+      final sourceOrderId = _trimmedString(row, const ['source_order_id']);
+      final paintId = _trimmedString(row, const ['paint_id']);
+      final paintName = _normalizePaintNameForMatching(
+        _trimmedString(row, const ['paint_name']),
+      );
+      final usedQty =
+          _readDouble(row, const ['actual_used_amount', 'used_qty']) ?? 0;
+      if (sourceOrderId.isEmpty || usedQty <= 0) continue;
+      if (paintId.isEmpty && paintName.isEmpty) continue;
+
+      try {
+        var query = _sb
+            .from('order_paint_reservations')
+            .select('id, paint_id, paint_name, reserved_qty, used_qty, released_qty')
+            .eq('order_id', sourceOrderId);
+        if (paintId.isNotEmpty) {
+          query = query.eq('paint_id', paintId);
+        }
+        final response = await query;
+        final reservations = response is List
+            ? response
+                .whereType<Map>()
+                .map((raw) => Map<String, dynamic>.from(raw as Map))
+                .where((reservation) {
+                  if (paintId.isNotEmpty) return true;
+                  return _normalizePaintNameForMatching(
+                        (reservation['paint_name'] ?? '').toString(),
+                      ) ==
+                      paintName;
+                })
+                .toList(growable: true)
+            : <Map<String, dynamic>>[];
+        if (reservations.isEmpty) continue;
+
+        var remainingToApply = usedQty;
+        for (final reservation in reservations) {
+          if (remainingToApply <= 0) break;
+          final reserved = _readDouble(reservation, const ['reserved_qty']) ?? 0;
+          final alreadyUsed = _readDouble(reservation, const ['used_qty']) ?? 0;
+          final released = _readDouble(reservation, const ['released_qty']) ?? 0;
+          final active = reserved - alreadyUsed - released;
+          if (active <= 0) continue;
+          final applyQty = active < remainingToApply ? active : remainingToApply;
+          final nextUsed = alreadyUsed + applyQty;
+          final reservationId = _trimmedString(reservation, const ['id']);
+          var update = _sb
+              .from('order_paint_reservations')
+              .update({'used_qty': nextUsed});
+          if (reservationId.isNotEmpty) {
+            update = update.eq('id', reservationId);
+          } else {
+            update = update.eq('order_id', sourceOrderId);
+            final reservationPaintId =
+                _trimmedString(reservation, const ['paint_id']);
+            if (reservationPaintId.isNotEmpty) {
+              update = update.eq('paint_id', reservationPaintId);
+            } else {
+              update = update.eq('paint_name', reservation['paint_name']);
+            }
+          }
+          await update;
+          remainingToApply -= applyQty;
+        }
+      } catch (error) {
+        debugPrint(
+          '⚠️ Не удалось обновить резерв краски после списания: $error',
+        );
+      }
+    }
   }
 
   Map<String, dynamic> _paintQueueRpcRow(

--- a/lib/modules/warehouse/type_table_screen.dart
+++ b/lib/modules/warehouse/type_table_screen.dart
@@ -431,7 +431,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
               note: entry.note,
               format: entry.format,
               grammage: entry.grammage,
-              byName: entry.byName,
+              byName: _displayEmployeeName(entry.byName),
               sourceTable: entry.sourceTable,
             ))
         .toList();
@@ -832,6 +832,16 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
     return note.replaceFirst(orderId, label.trim());
   }
 
+  String _displayEmployeeName(String? value) {
+    final text = (value ?? '').trim();
+    if (text.isEmpty) return '';
+    final match = _uuidLikePattern.firstMatch(text);
+    if (match != null && match.group(0) == text && text.length > 8) {
+      return text.substring(0, 8);
+    }
+    return text;
+  }
+
   Future<List<Map<String, dynamic>>> _selectByIdsAny({
     required List<String> tables,
     required String fk,
@@ -959,7 +969,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         note: note,
         format: fmt,
         grammage: gram,
-        byName: by,
+        byName: _displayEmployeeName(by),
         sourceTable: e['_source_table']?.toString(),
         isCanceled: isCanceled,
       );
@@ -1060,7 +1070,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         note: note,
         format: fmt,
         grammage: gram,
-        byName: by,
+        byName: _displayEmployeeName(by),
         sourceTable: e['_source_table']?.toString(),
         isCanceled: isCanceled,
       );
@@ -1158,7 +1168,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         note: note,
         format: fmt,
         grammage: gram,
-        byName: by,
+        byName: _displayEmployeeName(by),
         sourceTable: e['_source_table']?.toString(),
         isCanceled: isCanceled,
       );

--- a/lib/modules/warehouse/type_table_tabs_screen.dart
+++ b/lib/modules/warehouse/type_table_tabs_screen.dart
@@ -485,7 +485,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
             note: entry.note,
             format: entry.format,
             grammage: entry.grammage,
-            byName: entry.byName,
+            byName: _displayEmployeeName(entry.byName),
             itemId: entry.itemId,
             sourceTable: entry.sourceTable,
             action: entry.action,
@@ -897,6 +897,16 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
     return note.replaceFirst(orderId, label.trim());
   }
 
+  String _displayEmployeeName(String? value) {
+    final text = (value ?? '').trim();
+    if (text.isEmpty) return '';
+    final match = _uuidLikePattern.firstMatch(text);
+    if (match != null && match.group(0) == text && text.length > 8) {
+      return text.substring(0, 8);
+    }
+    return text;
+  }
+
   Future<List<Map<String, dynamic>>> _selectByIdsAny({
     required List<String> tables,
     required String fk,
@@ -1019,7 +1029,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         note: note,
         format: fmt,
         grammage: gram,
-        byName: by,
+        byName: _displayEmployeeName(by),
         itemId: baseId,
         action: WarehouseLogAction.writeoff,
         canUndo: (baseId ?? '').isNotEmpty && !isCanceled,
@@ -1117,7 +1127,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         note: note,
         format: fmt,
         grammage: gram,
-        byName: by,
+        byName: _displayEmployeeName(by),
         itemId: baseId,
         action: WarehouseLogAction.inventory,
         canUndo: (baseId ?? '').isNotEmpty && !isCanceled,
@@ -1212,7 +1222,7 @@ class _TypeTableTabsScreenState extends State<TypeTableTabsScreen>
         note: note,
         format: fmt,
         grammage: gram,
-        byName: by,
+        byName: _displayEmployeeName(by),
         itemId: baseId,
         action: WarehouseLogAction.arrival,
         canUndo: (baseId ?? '').isNotEmpty && !isCanceled,

--- a/lib/modules/warehouse/warehouse_logs_repository.dart
+++ b/lib/modules/warehouse/warehouse_logs_repository.dart
@@ -456,6 +456,245 @@ class WarehouseLogsRepository {
     return null;
   }
 
+  static final RegExp _uuidLikePattern = RegExp(
+    r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+  );
+
+  static bool _isUuidLike(String value) => _uuidLikePattern.hasMatch(value.trim());
+
+  static String _firstMeaningful(Iterable<dynamic> values) {
+    for (final dynamic value in values) {
+      final String text = (value ?? '').toString().trim();
+      if (text.isEmpty) continue;
+      final String lower = text.toLowerCase();
+      if (lower == 'null' || lower == 'undefined' || lower == 'nan') continue;
+      if (text == '-' || text == '—') continue;
+      if (_isUuidLike(text)) continue;
+      return text;
+    }
+    return '';
+  }
+
+  static String _shortId(String id) {
+    final String trimmed = id.trim();
+    if (trimmed.length <= 8) return trimmed;
+    return trimmed.substring(0, 8);
+  }
+
+  static String? _extractOrderIdFromNote(String? note) {
+    final String source = (note ?? '').trim();
+    if (source.isEmpty) return null;
+    return _uuidLikePattern.firstMatch(source)?.group(0);
+  }
+
+  static Set<String> _extractOrderIdsFromWriteoffRows(
+    List<Map<String, dynamic>> rows,
+    String typeKey,
+  ) {
+    final Set<String> ids = <String>{};
+    for (final Map<String, dynamic> row in rows) {
+      final String orderId = (_pickStr(row, const <String?>[
+                'order_id',
+                'orderId',
+                'source_order_id',
+                'sourceOrderId',
+              ]) ??
+              '')
+          .trim();
+      if (orderId.isNotEmpty) ids.add(orderId);
+      final String? note = _pickStr(row, <String?>[
+        _woMap[typeKey]?['note'],
+        'note',
+        'reason',
+        'comment',
+      ]);
+      final String? noteOrderId = _extractOrderIdFromNote(note);
+      if (noteOrderId != null && noteOrderId.trim().isNotEmpty) {
+        ids.add(noteOrderId.trim());
+      }
+    }
+    return ids;
+  }
+
+  static Set<String> _extractEmployeeIdsFromWriteoffRows(
+    List<Map<String, dynamic>> rows,
+  ) {
+    final Set<String> ids = <String>{};
+    for (final Map<String, dynamic> row in rows) {
+      for (final String? key in const <String?>[
+        'employee_id',
+        'employeeId',
+        'worker_id',
+        'user_id',
+        'userId',
+        'by_id',
+        'byId',
+      ]) {
+        final String value = (_pickStr(row, <String?>[key]) ?? '').trim();
+        if (value.isNotEmpty) ids.add(value);
+      }
+      final String displayed = (_pickStr(row, const <String?>[
+                'by_name',
+                'byName',
+                'by',
+                'user_name',
+                'employee_name',
+                'employee',
+                'operator',
+                'who',
+              ]) ??
+              '')
+          .trim();
+      if (displayed.isNotEmpty && _isUuidLike(displayed)) ids.add(displayed);
+    }
+    return ids;
+  }
+
+  static Future<Map<String, String>> _loadOrderLabelsByIds(
+    Set<String> orderIds,
+  ) async {
+    if (orderIds.isEmpty) return const <String, String>{};
+    final List<Map<String, dynamic>> rows = await _selectByIdsAny(
+      tables: const <String>['orders'],
+      fk: 'id',
+      ids: orderIds.toList(growable: false),
+      selectFields:
+          'id, assignment_id, title, name, order_name, product_name, customer, new_form_no, form_code, data, product',
+      fallbackSelectFields: '*',
+    );
+    final Map<String, String> labels = <String, String>{};
+    for (final Map<String, dynamic> row in rows) {
+      final String orderId = (row['id'] ?? '').toString().trim();
+      if (orderId.isEmpty) continue;
+      final dynamic dataRaw = row['data'];
+      final Map<String, dynamic> data = dataRaw is Map
+          ? Map<String, dynamic>.from(dataRaw as Map)
+          : <String, dynamic>{};
+      final dynamic productRaw = row['product'];
+      final Map<String, dynamic> product = productRaw is Map
+          ? Map<String, dynamic>.from(productRaw as Map)
+          : <String, dynamic>{};
+      final dynamic dataProductRaw = data['product'];
+      final Map<String, dynamic> dataProduct = dataProductRaw is Map
+          ? Map<String, dynamic>.from(dataProductRaw as Map)
+          : <String, dynamic>{};
+
+      final String formNo = _firstMeaningful(<dynamic>[
+        row['new_form_no'],
+        row['form_code'],
+        data['new_form_no'],
+        data['form_code'],
+      ]);
+      final String title = _firstMeaningful(<dynamic>[
+        row['assignment_id'],
+        row['title'],
+        row['order_name'],
+        row['product_name'],
+        row['customer'],
+        data['assignment_id'],
+        data['title'],
+        data['order_name'],
+        data['product_name'],
+        data['customer'],
+        product['name'],
+        product['title'],
+        dataProduct['name'],
+        dataProduct['title'],
+        row['name'],
+        data['name'],
+      ]);
+      if (formNo.isNotEmpty && title.isNotEmpty) {
+        labels[orderId] = '№$formNo / $title';
+      } else if (formNo.isNotEmpty) {
+        labels[orderId] = '№$formNo';
+      } else if (title.isNotEmpty) {
+        labels[orderId] = title;
+      }
+    }
+    return labels;
+  }
+
+  static Future<Map<String, String>> _loadEmployeeLabelsByIds(
+    Set<String> employeeIds,
+  ) async {
+    if (employeeIds.isEmpty) return const <String, String>{};
+    final List<Map<String, dynamic>> rows = await _selectByIdsAny(
+      tables: const <String>['employees_view', 'employees'],
+      fk: 'id',
+      ids: employeeIds.toList(growable: false),
+      selectFields:
+          'id, last_name, first_name, patronymic, full_name, display_name, name, login',
+      fallbackSelectFields: '*',
+    );
+    final Map<String, String> labels = <String, String>{};
+    for (final Map<String, dynamic> row in rows) {
+      final String employeeId = (row['id'] ?? '').toString().trim();
+      if (employeeId.isEmpty) continue;
+      final String fullName = _firstMeaningful(<dynamic>[
+        row['full_name'],
+        row['display_name'],
+        row['name'],
+      ]);
+      final String composed = <String>[
+        (row['last_name'] ?? row['lastName'] ?? '').toString().trim(),
+        (row['first_name'] ?? row['firstName'] ?? '').toString().trim(),
+        (row['patronymic'] ?? '').toString().trim(),
+      ].where((String part) => part.isNotEmpty).join(' ');
+      final String login = _firstMeaningful(<dynamic>[row['login']]);
+      final String label = _firstMeaningful(<dynamic>[fullName, composed, login]);
+      if (label.isNotEmpty) labels[employeeId] = label;
+    }
+    return labels;
+  }
+
+  static String _humanizeWriteoffNote(
+    String? rawNote,
+    Map<String, String> orderLabels,
+  ) {
+    final String note = (rawNote ?? '').trim();
+    if (note.isEmpty) return '';
+    final String? orderId = _extractOrderIdFromNote(note);
+    if (orderId == null || orderId.isEmpty) return note;
+    final String? label = orderLabels[orderId];
+    if (label == null || label.trim().isEmpty) return note;
+    return note.replaceFirst(orderId, label.trim());
+  }
+
+  static String? _resolveWriteoffEmployeeName(
+    Map<String, dynamic> row,
+    Map<String, String> employeeLabels,
+  ) {
+    final String explicitId = (_pickStr(row, const <String?>[
+              'employee_id',
+              'employeeId',
+              'worker_id',
+              'user_id',
+              'userId',
+              'by_id',
+              'byId',
+            ]) ??
+            '')
+        .trim();
+    if (explicitId.isNotEmpty && employeeLabels[explicitId]?.isNotEmpty == true) {
+      return employeeLabels[explicitId];
+    }
+    final String raw = (_pickStr(row, const <String?>[
+              'by_name',
+              'byName',
+              'by',
+              'user_name',
+              'employee_name',
+              'employee',
+              'operator',
+              'who',
+            ]) ??
+            '')
+        .trim();
+    if (raw.isEmpty) return null;
+    if (_isUuidLike(raw)) return employeeLabels[raw] ?? _shortId(raw);
+    return raw;
+  }
+
   static String _resolveDescription({
     Map<String, dynamic>? baseRow,
     required Map<String, dynamic> raw,
@@ -679,6 +918,13 @@ class WarehouseLogsRepository {
       for (final Map<String, dynamic> row in baseRows) row['id'].toString(): row
     };
 
+    final Map<String, String> orderLabels = await _loadOrderLabelsByIds(
+      _extractOrderIdsFromWriteoffRows(rawLogs, typeKey),
+    );
+    final Map<String, String> employeeLabels = await _loadEmployeeLabelsByIds(
+      _extractEmployeeIdsFromWriteoffRows(rawLogs),
+    );
+
     return rawLogs.map((Map<String, dynamic> e) {
       final String? itemId = _pickId(e, fkCandidates);
       final Map<String, dynamic>? baseRow =
@@ -691,8 +937,34 @@ class WarehouseLogsRepository {
             'count',
           ]) ??
           0;
+      final Map<String, dynamic> displayRaw = Map<String, dynamic>.from(e);
+      final String? rawNote = _pickStr(displayRaw, <String?>[
+        _woMap[typeKey]?['note'],
+        'note',
+        'reason',
+        'comment',
+      ]);
+      final String noteColumn = _woMap[typeKey]?['note'] ?? 'reason';
+      final String explicitOrderId = (_pickStr(displayRaw, const <String?>[
+                'order_id',
+                'orderId',
+                'source_order_id',
+                'sourceOrderId',
+              ]) ??
+              '')
+          .trim();
+      final String humanizedNote = _humanizeWriteoffNote(rawNote, orderLabels);
+      displayRaw[noteColumn] = humanizedNote.isNotEmpty
+          ? humanizedNote
+          : (orderLabels[explicitOrderId]?.isNotEmpty == true
+              ? 'Заказ ${orderLabels[explicitOrderId]}'
+              : humanizedNote);
+      displayRaw['by_name'] = _resolveWriteoffEmployeeName(
+        displayRaw,
+        employeeLabels,
+      );
       return _mapToEntry(
-        raw: e,
+        raw: displayRaw,
         baseRow: baseRow,
         typeKey: typeKey,
         action: WarehouseLogAction.writeoff,
@@ -749,6 +1021,13 @@ class WarehouseLogsRepository {
         <String, Map<String, dynamic>>{
       for (final Map<String, dynamic> row in baseRows) row['id'].toString(): row
     };
+
+    final Map<String, String> orderLabels = await _loadOrderLabelsByIds(
+      _extractOrderIdsFromWriteoffRows(rawLogs, typeKey),
+    );
+    final Map<String, String> employeeLabels = await _loadEmployeeLabelsByIds(
+      _extractEmployeeIdsFromWriteoffRows(rawLogs),
+    );
 
     return rawLogs.map((Map<String, dynamic> e) {
       final String? itemId = _pickId(e, fkCandidates);
@@ -819,6 +1098,13 @@ class WarehouseLogsRepository {
         <String, Map<String, dynamic>>{
       for (final Map<String, dynamic> row in baseRows) row['id'].toString(): row
     };
+
+    final Map<String, String> orderLabels = await _loadOrderLabelsByIds(
+      _extractOrderIdsFromWriteoffRows(rawLogs, typeKey),
+    );
+    final Map<String, String> employeeLabels = await _loadEmployeeLabelsByIds(
+      _extractEmployeeIdsFromWriteoffRows(rawLogs),
+    );
 
     return rawLogs.map((Map<String, dynamic> e) {
       final String? itemId = _pickId(e, fkCandidates);


### PR DESCRIPTION
### Motivation
- Fix a bug where paint remained shown as reserved after it was actually written off and where writeoff tables showed raw UUIDs instead of readable order/employee names.
- Ensure that writeoffs performed when completing stages (e.g. «Флексопечать») correctly decrease or clear the reservation only for the related order and paint.

### Description
- Apply confirmed paint writeoffs back to order-specific reservations by adding `_applyPaintReservationUsage(...)` and calling it after the RPC in `completeFlexPrintingStage` so `order_paint_reservations.used_qty` is increased per `source_order_id`/paint, handling full and partial consumption (`lib/modules/orders/orders_repository.dart`).
- Resolve human-readable order labels and employee names for warehouse logs by collecting unique `order_id` and employee IDs from writeoff rows, loading corresponding `orders` and `employees` rows in bulk, and substituting labels into writeoff notes and `by_name` fields instead of showing UUIDs (`lib/modules/warehouse/warehouse_logs_repository.dart`).
- Update warehouse screens to use the enriched data and to fall back to a short ID when no readable name is available by adding `_displayEmployeeName` and using humanized notes for writeoffs so UI tables immediately show readable values (`lib/modules/warehouse/type_table_screen.dart`, `lib/modules/warehouse/type_table_tabs_screen.dart`).
- Files changed: `lib/modules/orders/orders_repository.dart`, `lib/modules/warehouse/warehouse_logs_repository.dart`, `lib/modules/warehouse/type_table_screen.dart`, `lib/modules/warehouse/type_table_tabs_screen.dart`.

### Testing
- Ran repository checks and searches to validate affected code paths (`rg`/`find`/quick grep) and confirmed diffs; `git diff --check` returned no issues.
- Attempted `dart format` and `flutter analyze`, but `dart`/`flutter` are not installed in the execution environment so automated formatting/static analysis could not be run here.  Local project build/CI should run these checks and is recommended before publishing.
- No other automated tests were available in this environment; please run the app and CI tests to verify runtime behaviour (especially scenarios: full writeoff, partial writeoff, and missing PostgREST relationships).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b052db0cc832f8d4db73fb25bb3db)