### PR TITLE
Fix paint reservation details loading

### DIFF
--- a/lib/modules/warehouse/warehouse_provider.dart
+++ b/lib/modules/warehouse/warehouse_provider.dart
@@ -2369,12 +2369,12 @@ class WarehouseProvider with ChangeNotifier {
     try {
       final rows = await _sb
           .from('order_paint_reservations')
-          .select(
-              'order_id, reserved_qty, used_qty, released_qty, orders(id, customer, new_form_no, form_code)')
+          .select('order_id, reserved_qty, used_qty, released_qty, created_at')
           .eq('paint_id', normalizedId)
           .order('created_at');
       if (rows is! List) return const [];
-      return rows
+
+      final reservationRows = rows
           .whereType<Map>()
           .map((raw) {
             final row = Map<String, dynamic>.from(raw as Map);
@@ -2385,6 +2385,39 @@ class WarehouseProvider with ChangeNotifier {
           })
           .where((row) => _toDouble(row['active_reserved_qty']) > 0)
           .toList(growable: false);
+      if (reservationRows.isEmpty) return const [];
+
+      final orderIds = reservationRows
+          .map((row) => (row['order_id'] ?? '').toString().trim())
+          .where((id) => id.isNotEmpty)
+          .toSet()
+          .toList(growable: false);
+      if (orderIds.isEmpty) return reservationRows;
+
+      final ordersById = <String, Map<String, dynamic>>{};
+      try {
+        final orderRows = await _sb
+            .from('orders')
+            .select('id, customer, new_form_no, form_code')
+            .inFilter('id', orderIds);
+        if (orderRows is List) {
+          for (final raw in orderRows.whereType<Map>()) {
+            final order = Map<String, dynamic>.from(raw as Map);
+            final orderId = (order['id'] ?? '').toString().trim();
+            if (orderId.isNotEmpty) ordersById[orderId] = order;
+          }
+        }
+      } catch (e) {
+        debugPrint('⚠️ paint reservation orders load failed: $e');
+      }
+
+      return reservationRows.map((row) {
+        final next = Map<String, dynamic>.from(row);
+        final orderId = (next['order_id'] ?? '').toString().trim();
+        final order = ordersById[orderId];
+        if (order != null) next['orders'] = order;
+        return next;
+      }).toList(growable: false);
     } catch (e) {
       debugPrint('⚠️ paint reservations details failed: $e');
       return const [];

--- a/supabase/migrations/20260518_add_order_paint_reservations_order_fk.sql
+++ b/supabase/migrations/20260518_add_order_paint_reservations_order_fk.sql
@@ -1,0 +1,24 @@
+-- Ensure PostgREST can resolve order_paint_reservations -> orders embeds
+-- even when the reservations table was created before the FK existed.
+
+do $$
+begin
+  if to_regclass('public.order_paint_reservations') is not null
+     and to_regclass('public.orders') is not null
+     and not exists (
+       select 1
+         from pg_constraint c
+        where c.conrelid = 'public.order_paint_reservations'::regclass
+          and c.confrelid = 'public.orders'::regclass
+          and c.contype = 'f'
+     ) then
+    alter table public.order_paint_reservations
+      add constraint order_paint_reservations_order_id_fkey
+      foreign key (order_id)
+      references public.orders(id)
+      on delete cascade
+      not valid;
+  end if;
+end $$;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- PostgREST returned `PGRST200` when trying to embed `orders(...)` from `order_paint_reservations` because the schema-cache relationship was not always present. 
- The UI depended on PostgREST relationship discovery which made the reserve details fragile across databases with differing schema histories. 
- Provide a resilient client-side implementation and a migration to ensure PostgREST can resolve the FK when possible. 

### Description
- Change `getPaintReservationsByPaint` in `lib/modules/warehouse/warehouse_provider.dart` to stop using the embedded `orders(...)` select and instead select reservation rows (`order_id, reserved_qty, used_qty, released_qty, created_at`), compute `active_reserved_qty` locally, then load related `orders` in a separate `_sb.from('orders')` query and attach them to the reservation rows. 
- Return only reservations with a positive active quantity and gracefully handle missing/empty order ids. 
- Add a Supabase migration `supabase/migrations/20260518_add_order_paint_reservations_order_fk.sql` that adds a not-valid FK `order_paint_reservations(order_id) -> orders(id)` if missing and issues `notify pgrst, 'reload schema'` to prompt PostgREST to refresh the schema cache. 
- Files changed: `lib/modules/warehouse/warehouse_provider.dart` and new migration `supabase/migrations/20260518_add_order_paint_reservations_order_fk.sql`. 

### Testing
- Ran `git diff --check` which returned no whitespace or diff-check errors. 
- Ran `git diff --cached --check` and `git status --short` to validate index and staged changes, both succeeded. 
- Attempted `dart format lib/modules/warehouse/warehouse_provider.dart` but the environment lacked `dart`, so formatting could not be executed automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b07edb5ac832fbf71aa41978f0c0a)