### PR TITLE
Fix workplace queue sort isolation by workplace-specific semantic key

### DIFF
--- a/lib/modules/production/production_queue_provider.dart
+++ b/lib/modules/production/production_queue_provider.dart
@@ -117,6 +117,16 @@ class WorkplaceQueuePositionPlanner {
       for (final position in existing)
         if (position.workplaceId.trim() == normalizedWorkplace) position.queueKey,
     };
+    final existingSemanticKeys = {
+      for (final position in existing)
+        if (position.workplaceId.trim() == normalizedWorkplace)
+          ProductionQueueProvider.queueSemanticKeyFor(
+            workplaceId: position.workplaceId,
+            orderId: position.orderId,
+            stageId: position.stageId,
+            stageGroupKey: position.stageGroupKey,
+          ),
+    };
     final missing = <WorkplaceQueueEntry>[];
     final seen = <String>{};
     for (final entry in entries) {
@@ -125,6 +135,13 @@ class WorkplaceQueuePositionPlanner {
         continue;
       }
       if (existingKeys.contains(entry.queueKey)) continue;
+      final semanticKey = ProductionQueueProvider.queueSemanticKeyFor(
+        workplaceId: entry.workplaceId,
+        orderId: entry.orderId,
+        stageId: entry.stageId,
+        stageGroupKey: entry.stageGroupKey,
+      );
+      if (existingSemanticKeys.contains(semanticKey)) continue;
       if (!seen.add(entry.queueKey)) continue;
       missing.add(entry);
     }
@@ -314,6 +331,16 @@ class ProductionQueueProvider with ChangeNotifier {
     final task = taskId?.trim() ?? '';
     if (task.isNotEmpty) return '$workplace::task::$task';
     return '$workplace::order::${orderId.trim()}::stage::${stageId.trim()}::group::${(stageGroupKey ?? '').trim()}';
+  }
+
+  static String queueSemanticKeyFor({
+    required String workplaceId,
+    required String orderId,
+    required String stageId,
+    String? stageGroupKey,
+  }) {
+    return '${
+        workplaceId.trim()}::order::${orderId.trim()}::stage::${stageId.trim()}::group::${(stageGroupKey ?? '').trim()}';
   }
 
   void _startPollingFallback() {
@@ -571,7 +598,28 @@ class ProductionQueueProvider with ChangeNotifier {
   int priorityOfEntry(WorkplaceQueueEntry entry) {
     final workplaceId = _normalizeWorkplaceId(entry.workplaceId);
     if (workplaceId.isEmpty) return 1 << 30;
-    return _positionsByWorkplace[workplaceId]?[entry.queueKey]?.queuePosition ?? (1 << 30);
+    final workplaceMap = _positionsByWorkplace[workplaceId];
+    if (workplaceMap == null || workplaceMap.isEmpty) return 1 << 30;
+    final exact = workplaceMap[entry.queueKey];
+    if (exact != null) return exact.queuePosition;
+    final semanticKey = queueSemanticKeyFor(
+      workplaceId: workplaceId,
+      orderId: entry.orderId,
+      stageId: entry.stageId,
+      stageGroupKey: entry.stageGroupKey,
+    );
+    for (final position in workplaceMap.values) {
+      if (queueSemanticKeyFor(
+            workplaceId: position.workplaceId,
+            orderId: position.orderId,
+            stageId: position.stageId,
+            stageGroupKey: position.stageGroupKey,
+          ) ==
+          semanticKey) {
+        return position.queuePosition;
+      }
+    }
+    return 1 << 30;
   }
 
   List<T> getSortedByWorkplaceQueue<T>(


### PR DESCRIPTION
## Summary
- fixed queue-priority lookup in `ProductionQueueProvider` so workplace tabs resolve saved positions by a stable workplace+order+stage(+group) semantic key when exact task-key lookup misses
- kept existing global production list behavior unchanged
- prevented false "missing entry" detection that could append duplicates when task identity changes but stage/workplace identity is the same

## Root cause
Queue records in `workplace_queue_positions` can be keyed by either task-based key or order/stage-based key. In workplace tabs, sort priority previously relied on exact key match only. If a visible entry had a different key shape (e.g. task id changed/absent), it lost its persisted position and fell back to source order (newest first), which surfaced new orders at the top across workplaces.

## Fix details
- added `queueSemanticKeyFor(...)` to represent stable per-workplace queue identity
- `priorityOfEntry(...)` now:
  1. tries exact queue key match
  2. falls back to semantic-key match within the same workplace map
- `WorkplaceQueuePositionPlanner.missingEntries(...)` now also checks semantic-key presence to avoid inserting duplicate queue rows for the same workplace-stage queue slot

## Scope safety
- no changes to stage status transitions, material write-off/reservations, employee logic, or order launch business flow
- no change to "all production jobs" list sorting (new orders remain on top there)

## Manual verification
1. Create an order with multiple stages/workplaces and launch it.
2. Confirm **main production list** still shows new launched order at top.
3. Open each workplace tab and confirm the new order appears at the **end** of that workplace queue.
4. Reorder that order to top in one workplace tab.
5. Verify other workplace tabs keep their own order unchanged.
6. Restart app and confirm workplace queue order persists.
7. Launch another new order; verify it is appended to the end in each affected workplace queue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c073e4b98832faf5b2b97eae34b07)