### PR TITLE
Support multiple return shortcuts and show customer name in employee workspace

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1091,21 +1091,30 @@ class _TasksScreenState extends State<TasksScreen>
     return queueOrderId;
   }
 
-  TaskModel? _activeTaskForEmployee(TaskProvider taskProvider) {
+  String _customerNameForTask(TaskModel task, OrdersProvider ordersProvider) {
+    final queueOrderId = _queueOrderIdForTask(task, ordersProvider);
+    final order = ordersProvider.orders.cast<OrderModel?>().firstWhere(
+          (candidate) => candidate?.id == queueOrderId,
+          orElse: () => null,
+        );
+    final customer = order?.customer.trim() ?? '';
+    if (customer.isNotEmpty) return customer;
+    return _orderLabelForTask(task, ordersProvider);
+  }
+
+  List<TaskModel> _activeTasksForEmployee(TaskProvider taskProvider) {
     final candidates = taskProvider.tasks.where((task) {
       if (!task.assignees.contains(widget.employeeId)) return false;
       if (_isEffectivelyCompleted(task)) return false;
       final state = _userRunState(task, widget.employeeId);
       return state == UserRunState.active;
     }).toList(growable: false);
-
-    if (candidates.isEmpty) return null;
     candidates.sort((a, b) {
       final aStarted = a.startedAt ?? 0;
       final bStarted = b.startedAt ?? 0;
       return bStarted.compareTo(aStarted);
     });
-    return candidates.first;
+    return candidates;
   }
 
 
@@ -2821,7 +2830,7 @@ class _TasksScreenState extends State<TasksScreen>
 
     final selectedOrder =
         currentTask != null ? findOrder(currentTask.orderId) : null;
-    final activeTask = _activeTaskForEmployee(taskProvider);
+    final activeTasks = _activeTasksForEmployee(taskProvider);
 
     Widget buildLeftPanel({required bool scrollable}) {
       final String workplaceLabel = _selectedWorkplaceId == null
@@ -2901,42 +2910,48 @@ class _TasksScreenState extends State<TasksScreen>
         );
       }
 
-      Widget buildActiveTaskShortcut() {
-        if (activeTask == null) return const SizedBox.shrink();
-
-        final workplace = personnel.workplaceById(activeTask.stageId);
-        final workplaceName = workplace?.name.trim().isNotEmpty == true
-            ? workplace!.name.trim()
-            : activeTask.stageId;
-        final orderLabel = _orderLabelForTask(activeTask, ordersProvider);
-
-        return Align(
-          alignment: Alignment.centerRight,
-          child: TextButton(
-            style: TextButton.styleFrom(
-              padding: EdgeInsets.zero,
-              visualDensity: VisualDensity.compact,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-            onPressed: () {
-              _persistWorkplace(activeTask.stageId);
-              _persistTask(activeTask.id);
-              setState(() {
-                _selectedWorkplaceId = activeTask.stageId;
-                _selectedTask = activeTask;
-                _selectedStatus = _sectionForTask(activeTask);
-              });
-            },
-            child: Text(
-              '↩ $workplaceName · заказ $orderLabel',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: scaled(11.5),
-                fontWeight: FontWeight.w600,
+      Widget buildActiveTaskShortcuts() {
+        if (activeTasks.isEmpty) return const SizedBox.shrink();
+        return Column(
+          children: [
+            for (final activeTask in activeTasks)
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  style: TextButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    visualDensity: VisualDensity.compact,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  onPressed: () {
+                    _persistWorkplace(activeTask.stageId);
+                    _persistTask(activeTask.id);
+                    setState(() {
+                      _selectedWorkplaceId = activeTask.stageId;
+                      _selectedTask = activeTask;
+                      _selectedStatus = _sectionForTask(activeTask);
+                    });
+                  },
+                  child: Text(
+                    () {
+                      final workplace = personnel.workplaceById(activeTask.stageId);
+                      final workplaceName = workplace?.name.trim().isNotEmpty == true
+                          ? workplace!.name.trim()
+                          : activeTask.stageId;
+                      final customerName =
+                          _customerNameForTask(activeTask, ordersProvider);
+                      return '↩ $workplaceName · заказчик $customerName';
+                    }(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: scaled(11.5),
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
               ),
-            ),
-          ),
+          ],
         );
       }
 
@@ -2972,9 +2987,9 @@ class _TasksScreenState extends State<TasksScreen>
               buildWorkplaceSelector(),
             ],
           ),
-          if (activeTask != null) ...[
+          if (activeTasks.isNotEmpty) ...[
             SizedBox(height: smallSpacing),
-            buildActiveTaskShortcut(),
+            buildActiveTaskShortcuts(),
           ],
           SizedBox(height: sectionSpacing * 0.6),
           SizedBox(height: sectionSpacing),


### PR DESCRIPTION
### Motivation
- Allow an employee who runs multiple orders simultaneously to have one return button per active order so they can jump back to each exact task.
- Show the customer name instead of the order number on the return shortcut to make it easier to identify which order to return to.

### Description
- Replaced the single-task helper ` _activeTaskForEmployee` with ` _activeTasksForEmployee` which returns a sorted list of active tasks for the employee.
- Added ` _customerNameForTask` helper that resolves `OrderModel.customer` via `OrdersProvider` and falls back to the prior order label if empty.
- Refactored the UI: replaced `buildActiveTaskShortcut` with `buildActiveTaskShortcuts` and render one `TextButton` per active task that restores workspace selection when pressed.
- Updated the shortcut label to display the customer name (prefix `заказчик`) instead of the raw order id/assignment id.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but it failed because `dart` is not available in the environment (`dart: command not found`).
- Inspected the produced diff with `git diff` to verify the intended changes to `lib/modules/tasks/tasks_screen.dart`.
- Committed the changes with `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bffcbc370832f811a826db80b63a2)