### PR TITLE
Fix flexo paint writeoff units and replace pending order_id with readable customer labels

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4494,6 +4494,56 @@ class _TasksScreenState extends State<TasksScreen>
     return _orderDisplayNameForWriteoff(order);
   }
 
+  String _buildReadableOrderLabel(Map<String, dynamic> row, {String? fallbackId}) {
+    String pick(List<String> keys) => _stringFromRow(row, keys);
+
+    final customer = pick(const ['customer_name', 'client_name', 'customer']);
+    final orderName = pick(const ['order_name', 'title', 'name']);
+    final orderNumber = pick(const ['order_number', 'number', 'order_no']);
+
+    if (orderNumber.isNotEmpty && customer.isNotEmpty) {
+      return '№$orderNumber — $customer';
+    }
+    if (orderNumber.isNotEmpty && orderName.isNotEmpty) {
+      return '№$orderNumber — $orderName';
+    }
+    if (customer.isNotEmpty) return customer;
+    if (orderName.isNotEmpty) return orderName;
+    if (orderNumber.isNotEmpty) return '№$orderNumber';
+
+    final fallback = (fallbackId ?? '').trim();
+    return fallback.isEmpty ? 'Предыдущий заказ' : 'Заказ';
+  }
+
+  Future<Map<String, String>> _loadReadableOrderLabelsByIds(Set<String> orderIds) async {
+    final normalizedIds = orderIds.map((id) => id.trim()).where((id) => id.isNotEmpty).toSet();
+    if (normalizedIds.isEmpty) return const <String, String>{};
+
+    final rows = await Supabase.instance.client
+        .from('orders')
+        .select('id, customer_name, client_name, customer, order_name, title, name, order_number, number, order_no')
+        .inFilter('id', normalizedIds.toList(growable: false));
+
+    final result = <String, String>{};
+    for (final dynamic item in (rows as List<dynamic>)) {
+      if (item is! Map<String, dynamic>) continue;
+      final id = _stringFromRow(item, const ['id']);
+      if (id.isEmpty) continue;
+      result[id] = _buildReadableOrderLabel(item, fallbackId: id);
+    }
+    return result;
+  }
+
+  String _normalizeInkUnit(String? unitCandidate) {
+    final normalized = (unitCandidate ?? '').trim().toLowerCase();
+    if (normalized == 'м' || normalized == 'm' || normalized == 'метры' || normalized == 'метр') {
+      return 'гр';
+    }
+    if (normalized.isEmpty) return 'гр';
+    if (normalized == 'г' || normalized == 'гр') return normalized;
+    return 'гр';
+  }
+
   bool _looksLikeOrderCode(String value) {
     final normalized = value.trim().toLowerCase();
     if (normalized.isEmpty) return true;
@@ -4608,9 +4658,11 @@ class _TasksScreenState extends State<TasksScreen>
           ? 'Краска'
           : _stringFromRow(row, const ['paint_name', 'name', 'paintName']),
       plannedAmount: plannedGrams,
-      unit: _stringFromRow(row, const ['unit']).isEmpty
-          ? ((defaultUnit ?? '').trim().isEmpty ? 'г' : defaultUnit!.trim())
-          : _stringFromRow(row, const ['unit']),
+      unit: _normalizeInkUnit(
+        _stringFromRow(row, const ['unit']).isEmpty
+            ? ((defaultUnit ?? '').trim().isEmpty ? 'гр' : defaultUnit!.trim())
+            : _stringFromRow(row, const ['unit']),
+      ),
       actualUsedText: actualUsedText,
       writeOffNow: row['write_off_now'] == true || row['writeOffNow'] == true,
     );
@@ -4753,7 +4805,7 @@ class _TasksScreenState extends State<TasksScreen>
                 const Align(
                   alignment: Alignment.centerLeft,
                   child: Text(
-                    'Проверьте расход по каждой краске и отметьте строки, которые нужно списать сейчас.',
+                    'Проверьте расход по каждой краске в гр и отметьте строки, которые нужно списать сейчас.',
                   ),
                 ),
                 const SizedBox(height: 12),
@@ -4979,8 +5031,15 @@ class _TasksScreenState extends State<TasksScreen>
           }
           return merged;
         }).toList(growable: false);
+        final pendingOrderIds = pendingWriteoffs
+            .map((pending) => pending.orderId.trim())
+            .where((id) => id.isNotEmpty)
+            .toSet();
+        final pendingOrderLabels = await _loadReadableOrderLabelsByIds(pendingOrderIds);
         final pendingPaints = pendingWriteoffs.map((pending) {
           final row = pending.toMap();
+          final readableOrderLabel = pendingOrderLabels[pending.orderId.trim()] ??
+              _buildReadableOrderLabel(row, fallbackId: pending.orderId);
           return row
             ..addAll({
               'source': 'pending',
@@ -4988,8 +5047,7 @@ class _TasksScreenState extends State<TasksScreen>
               'order_id': pending.orderId,
               'source_order_id': pending.orderId,
               'source_task_id': pending.taskId,
-              'order_label':
-                  pending.orderId.isEmpty ? 'Заказ' : pending.orderId,
+              'order_label': readableOrderLabel,
               'planned_amount': pending.plannedAmount,
               'actual_used_amount': pending.actualUsedAmount,
               'actual_used_text': pending.actualUsedAmount?.toString() ?? '',


### PR DESCRIPTION
### Motivation
- Fix incorrect unit shown in flexo paint writeoff UI (sometimes showed `м`/`М`) so paint is always displayed/entered in grams (`гр`/`г`).
- Replace technical `order_id` UUID shown for pending paint writeoffs with human-readable order/customer information to improve operator UX.
- Keep existing business logic for stage completion, partial writeoffs, reservations and actual writeoff behavior unchanged.

### Description
- Changed `lib/modules/tasks/tasks_screen.dart` to normalize paint unit and enforce grams via a new helper `_normalizeInkUnit` which is applied when building writeoff rows so meter-based units no longer appear in paint dialogs.
- Updated the top hint text in the writeoff dialog to explicitly mention grams instead of leaving it implicit. 
- Added `_buildReadableOrderLabel` to compose a human-friendly label using `order_number`, `customer_name`/`client_name`/`customer`, and fallback name fields, and added `_loadReadableOrderLabelsByIds` which performs a batched Supabase `select` (via `inFilter('id', ...)`) to fetch orders for all pending `order_id`s in one call.
- Replaced use of raw `pending.orderId` as `order_label` with resolved readable labels when mapping `pendingWriteoffs` into UI rows, preserving all original payload fields and writeoff semantics.
- Files changed: `lib/modules/tasks/tasks_screen.dart`.
- Where the wrong unit came from: paint `unit` was taken from the row or `defaultUnit` (workplace unit) and could be `м`/`М`, which is incorrect for paint; normalization now forces `гр`/`г` for paints.
- Why the ID was shown: pending writeoff rows previously set `order_label` to `pending.orderId` (UUID) when a human-readable label was not provided, exposing the technical `order_id` in the UI.
- How the customer/order name is now obtained: collect unique pending `order_id`s, query `orders` for `id, customer_name, client_name, customer, order_name, title, name, order_number, number, order_no` in one batched request, then build readable labels (priority `№<order_number> — <customer>`, then other fallbacks) and substitute them into `order_label` before showing to the user.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but `dart` is not available in the current environment so formatting could not be verified here (failed). 
- Attempted to run `flutter --version` but `flutter` is not available in the current environment so runtime checks could not be executed (failed).
- Code changes were locally committed (`git commit` succeeded) and search checks were performed to ensure affected writeoff mappings and dialog text were updated; no automated unit/integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0a6c3c68832f9608351c9a460869)