### PR TITLE
Allow controlled early start for Packaging stage (edeb85db-...)

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -35,6 +35,7 @@ import '../../services/attachment_service.dart';
 // Additional helpers for time formatting and aggregated timers
 const String kCardboardCuttingStageId =
     stage_sequence.kCardboardCuttingStageId;
+const String kPackagingStageId = stage_sequence.kPackagingStageId;
 
 String formatTaskInitialQuantity(double value) {
   if (value % 1 == 0) return value.toStringAsFixed(0);
@@ -625,6 +626,64 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     currentStageName: _stageDisplayName(personnel, task.stageId),
     currentStageGroupKey: task.stageGroupKey,
   );
+}
+
+
+
+bool _isPackagingStageTask(TaskModel task) =>
+    task.stageId.trim() == kPackagingStageId;
+
+bool _isPackagingAvailableByEmployeeAccess(
+  PersonnelProvider personnel,
+  String employeeId,
+) {
+  EmployeeModel? employee;
+  for (final candidate in personnel.employees) {
+    if (candidate.id == employeeId) {
+      employee = candidate;
+      break;
+    }
+  }
+  if (employee == null) return false;
+  final packagingWorkplace = personnel.workplaceById(kPackagingStageId);
+  if (packagingWorkplace == null) return false;
+  return packagingWorkplace.positionIds
+      .any((p) => employee.positionIds.contains(p));
+}
+
+bool canStartPackagingEarly({
+  required TaskModel task,
+  required TaskProvider tasks,
+  required PersonnelProvider personnel,
+  required String employeeId,
+  stage_sequence.StageGroupingResolver? groupResolver,
+}) {
+  if (!_isPackagingStageTask(task)) return false;
+  if (_isEffectivelyCompleted(task)) return false;
+  if (task.status == TaskStatus.inProgress) return false;
+  if (!_isPackagingAvailableByEmployeeAccess(personnel, employeeId)) return false;
+
+  final all = tasks.tasks.where((t) => t.orderId == task.orderId).toList();
+  if (all.isEmpty) return false;
+
+  final sequence = tasks.stageSequenceForOrder(task.orderId) ?? const <String>[];
+  if (sequence.isEmpty) return false;
+
+  String g(String stageId) => groupResolver?.call(task.orderId, stageId) ?? stageId;
+  final orderedKeys = <String>[];
+  for (final id in sequence) {
+    final key = g(id);
+    if (!orderedKeys.contains(key)) orderedKeys.add(key);
+  }
+  final taskKey = g(task.stageId);
+  final index = orderedKeys.indexOf(taskKey);
+  if (index != orderedKeys.length - 1 || index <= 0) return false;
+
+  final previousKey = orderedKeys[index - 1];
+  final previousStarted = all.any((t) => g(t.stageId) == previousKey && _hasStartedForStageSequence(t));
+  if (!previousStarted) return false;
+
+  return true;
 }
 
 bool _hasWorkplaceQueueActivity(TaskModel task) {
@@ -3015,14 +3074,21 @@ class _TasksScreenState extends State<TasksScreen>
                       queue,
                       workplace,
                     );
+                    final canStartEarlyPackaging = canStartPackagingEarly(
+                      task: task,
+                      tasks: taskProvider,
+                      personnel: personnel,
+                      employeeId: widget.employeeId,
+                      groupResolver: _stageGroupKey,
+                    );
                     final readyForStage = task.status == TaskStatus.waiting &&
                         unlockedByQueue &&
-                        _isFirstPendingStage(
+                        (_isFirstPendingStage(
                           taskProvider,
                           personnel,
                           task,
                           groupResolver: _stageGroupKey,
-                        );
+                        ) || canStartEarlyPackaging);
                     const canOpen = true;
                     return _TaskCard(
                       task: task,
@@ -5388,7 +5454,14 @@ class _TasksScreenState extends State<TasksScreen>
         (_canRunOutOfStageSequence(task) ||
             _isFirstPendingStage(context.read<TaskProvider>(),
                 context.read<PersonnelProvider>(), task,
-                groupResolver: _stageGroupKey)) &&
+                groupResolver: _stageGroupKey) ||
+            canStartPackagingEarly(
+              task: task,
+              tasks: context.read<TaskProvider>(),
+              personnel: context.read<PersonnelProvider>(),
+              employeeId: widget.employeeId,
+              groupResolver: _stageGroupKey,
+            )) &&
         stageModeAllowsJoin &&
         !shiftPaused &&
         !groupLocked &&
@@ -5642,10 +5715,18 @@ class _TasksScreenState extends State<TasksScreen>
                         final taskProvider = context.read<TaskProvider>();
                         final personnelProvider = personnel;
                         // Sequential stage guard
+                        final canStartEarlyPackaging = canStartPackagingEarly(
+                          task: task,
+                          tasks: taskProvider,
+                          personnel: personnelProvider,
+                          employeeId: widget.employeeId,
+                          groupResolver: _stageGroupKey,
+                        );
                         if (!_canRunOutOfStageSequence(task) &&
                             !_isFirstPendingStage(
                                 taskProvider, personnelProvider, task,
-                                groupResolver: _stageGroupKey)) {
+                                groupResolver: _stageGroupKey) &&
+                            !canStartEarlyPackaging) {
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                                 content: Text(


### PR DESCRIPTION
### Motivation
- Реализовать специальную бизнес-логику для этапа «Упаковка» (ID `edeb85db-c7a3-4a24-8f33-70ccdd4aaae1`), чтобы его можно было запускать раньше в ограниченных случаях без изменения очереди и порядка этапов.

### Description
- Добавлена константа `kPackagingStageId` и новая функция `canStartPackagingEarly(...)`, которая проверяет: что этап — упаковка, что он не завершён/не в работе, что упаковка последняя в последовательности заказа, что предыдущий этап уже начат, и что сотрудник имеет доступ к рабочему месту упаковки.
- Интегрировано правило в отображение задач: `readyForStage` теперь учитывает `canStartPackagingEarly(...)`, чтобы упаковка отображалась как доступная при соблюдении условий, не ломая старую логику для остальных этапов.
- Защита на уровне старта повторно проверяет условие раннего старта в `onStart`, чтобы кнопка UI не могла инициировать некорректный запуск при гонках/расхождениях.
- Обновлён критерий `canStart` (контрольной панели), чтобы учесть допустимый ранний старт упаковки только при выполнении общей проверки; схема БД не изменялась.
- Изменён файл: `lib/modules/tasks/tasks_screen.dart` — добавлена функция и её встраивание в UI/логики запуска.

### Testing
- Попытка автоматического форматирования: `dart format lib/modules/tasks/tasks_screen.dart` завершилась ошибкой в среде сборки с сообщением `dart: command not found` и не была выполнена.
- Локальные статические проверки (поиск/замены и просмотр диффа) выполнены, изменения скомпонованы и проверены на предмет целостности кода вставки; компиляция полного проекта не запускалась в этой среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1342f8b8832fa3e5c3dbcf3fa509)