### PR TITLE
Allow early start of Packaging when previous stage has started

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -627,6 +627,39 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
   );
 }
 
+bool canStartPackagingEarly({
+  required TaskModel task,
+  required TaskProvider tasks,
+  required PersonnelProvider personnel,
+  required String employeeId,
+  required stage_sequence.StageGroupingResolver groupResolver,
+}) {
+  final stageId = task.stageId.trim();
+  if (stageId != stage_sequence.kPackagingStageId) return false;
+  if (task.status == TaskStatus.completed) return false;
+  if (task.status == TaskStatus.inProgress &&
+      !task.assignees.contains(employeeId)) {
+    return false;
+  }
+
+  if (personnel.workplaceById(stageId) == null) return false;
+
+  final all = tasks.tasks.where((t) => t.orderId == task.orderId).toList();
+  if (all.isEmpty) return false;
+  final sequence = tasks.stageSequenceForOrder(task.orderId) ?? const <String>[];
+  if (sequence.length < 2 ||
+      sequence.last.trim() != stage_sequence.kPackagingStageId) {
+    return false;
+  }
+
+  final prevGroupKey =
+      groupResolver(task.orderId, sequence[sequence.length - 2]);
+  final prevGroupTasks =
+      all.where((t) => groupResolver(t.orderId, t.stageId) == prevGroupKey);
+  if (prevGroupTasks.isEmpty) return false;
+  return prevGroupTasks.any(_hasStartedForStageSequence);
+}
+
 bool _hasWorkplaceQueueActivity(TaskModel task) {
   if (task.status != TaskStatus.waiting) return true;
   return task.comments.any(
@@ -3017,12 +3050,19 @@ class _TasksScreenState extends State<TasksScreen>
                     );
                     final readyForStage = task.status == TaskStatus.waiting &&
                         unlockedByQueue &&
-                        _isFirstPendingStage(
-                          taskProvider,
-                          personnel,
-                          task,
-                          groupResolver: _stageGroupKey,
-                        );
+                        (_isFirstPendingStage(
+                              taskProvider,
+                              personnel,
+                              task,
+                              groupResolver: _stageGroupKey,
+                            ) ||
+                            canStartPackagingEarly(
+                              task: task,
+                              tasks: taskProvider,
+                              personnel: personnel,
+                              employeeId: widget.employeeId,
+                              groupResolver: _stageGroupKey,
+                            ));
                     const canOpen = true;
                     return _TaskCard(
                       task: task,
@@ -5388,7 +5428,14 @@ class _TasksScreenState extends State<TasksScreen>
         (_canRunOutOfStageSequence(task) ||
             _isFirstPendingStage(context.read<TaskProvider>(),
                 context.read<PersonnelProvider>(), task,
-                groupResolver: _stageGroupKey)) &&
+                groupResolver: _stageGroupKey) ||
+            canStartPackagingEarly(
+              task: task,
+              tasks: context.read<TaskProvider>(),
+              personnel: context.read<PersonnelProvider>(),
+              employeeId: widget.employeeId,
+              groupResolver: _stageGroupKey,
+            )) &&
         stageModeAllowsJoin &&
         !shiftPaused &&
         !groupLocked &&
@@ -5642,10 +5689,19 @@ class _TasksScreenState extends State<TasksScreen>
                         final taskProvider = context.read<TaskProvider>();
                         final personnelProvider = personnel;
                         // Sequential stage guard
+                        final canStartPackagingOutOfOrder =
+                            canStartPackagingEarly(
+                          task: task,
+                          tasks: taskProvider,
+                          personnel: personnelProvider,
+                          employeeId: widget.employeeId,
+                          groupResolver: _stageGroupKey,
+                        );
                         if (!_canRunOutOfStageSequence(task) &&
                             !_isFirstPendingStage(
                                 taskProvider, personnelProvider, task,
-                                groupResolver: _stageGroupKey)) {
+                                groupResolver: _stageGroupKey) &&
+                            !canStartPackagingOutOfOrder) {
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                                 content: Text(
@@ -7593,7 +7649,7 @@ class _TaskCard extends StatelessWidget {
     final double statusSize = scaled(11.5);
     final String? stageHint = showStageHint
         ? (readyForStage
-            ? 'Можно начинать: предыдущий этап начат'
+            ? 'Доступно, так как предыдущий этап уже начат'
             : 'Ожидает начала предыдущего этапа')
         : null;
     final Color readyColor = Colors.green.shade600;


### PR DESCRIPTION
### Motivation
- Packaging (stage id `edeb85db-c7a3-4a24-8f33-70ccdd4aaae1`) must be allowed to start earlier than strict queue order when the previous stage is already started, and the performer has access to packaging. 
- This must not change queue ordering, DB schema, or automatic stage transitions, and must preserve existing protections against duplicate/unauthorized starts.

### Description
- Added a single predicate `canStartPackagingEarly(...)` in `lib/modules/tasks/tasks_screen.dart` that returns true when the checked task is the packaging stage (`stage_sequence.kPackagingStageId` / `edeb85db-c7a3-4a24-8f33-70ccdd4aaae1`), packaging is the last stage in the order sequence, the previous stage group already has a started task, packaging is not completed, and any in-progress ownership rules are respected. 
- Integrated the predicate into three places so behavior is consistent: task-card readiness (`readyForStage`), the `canStart` eligibility check in the control panel, and the pre-start guard executed before calling the status update; this ensures UI affordance matches server-side protections at start time. 
- Updated the task card hint text to `Доступно, так как предыдущий этап уже начат` to clarify why packaging may appear available. 
- Changed files: `lib/modules/tasks/tasks_screen.dart` (new `canStartPackagingEarly` and its integrations into readiness, start-guard and UI hint).

### Testing
- Ran static analysis attempt `flutter analyze lib/modules/tasks/tasks_screen.dart`, which could not be executed in this environment because the Flutter SDK is not installed (`flutter: command not found`), so no analyzer results are available. 
- No automated unit/integration tests were executed in this environment after the change due to missing SDK/runtime.
- Basic local repository checks (search/inspection) were used to verify the new predicate is referenced in readiness display, start guards, and control-panel checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1342f8b8832fa3e5c3dbcf3fa509)