### PR TITLE
Allow early start of packaging stage when previous stage has started and employee is permitted

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -35,6 +35,7 @@ import '../../services/attachment_service.dart';
 // Additional helpers for time formatting and aggregated timers
 const String kCardboardCuttingStageId =
     stage_sequence.kCardboardCuttingStageId;
+const String kPackagingStageId = stage_sequence.kPackagingStageId;
 
 String formatTaskInitialQuantity(double value) {
   if (value % 1 == 0) return value.toStringAsFixed(0);
@@ -625,6 +626,64 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
     currentStageName: _stageDisplayName(personnel, task.stageId),
     currentStageGroupKey: task.stageGroupKey,
   );
+}
+
+
+
+bool _isPackagingStageTask(TaskModel task) =>
+    task.stageId.trim() == kPackagingStageId;
+
+bool _isPackagingAvailableByEmployeeAccess(
+  PersonnelProvider personnel,
+  String employeeId,
+) {
+  EmployeeModel? employee;
+  for (final candidate in personnel.employees) {
+    if (candidate.id == employeeId) {
+      employee = candidate;
+      break;
+    }
+  }
+  if (employee == null) return false;
+  final packagingWorkplace = personnel.workplaceById(kPackagingStageId);
+  if (packagingWorkplace == null) return false;
+  return packagingWorkplace.positionIds
+      .any((p) => employee.positionIds.contains(p));
+}
+
+bool canStartPackagingEarly({
+  required TaskModel task,
+  required TaskProvider tasks,
+  required PersonnelProvider personnel,
+  required String employeeId,
+  stage_sequence.StageGroupingResolver? groupResolver,
+}) {
+  if (!_isPackagingStageTask(task)) return false;
+  if (_isEffectivelyCompleted(task)) return false;
+  if (task.status == TaskStatus.inProgress) return false;
+  if (!_isPackagingAvailableByEmployeeAccess(personnel, employeeId)) return false;
+
+  final all = tasks.tasks.where((t) => t.orderId == task.orderId).toList();
+  if (all.isEmpty) return false;
+
+  final sequence = tasks.stageSequenceForOrder(task.orderId) ?? const <String>[];
+  if (sequence.isEmpty) return false;
+
+  String g(String stageId) => groupResolver?.call(task.orderId, stageId) ?? stageId;
+  final orderedKeys = <String>[];
+  for (final id in sequence) {
+    final key = g(id);
+    if (!orderedKeys.contains(key)) orderedKeys.add(key);
+  }
+  final taskKey = g(task.stageId);
+  final index = orderedKeys.indexOf(taskKey);
+  if (index != orderedKeys.length - 1 || index <= 0) return false;
+
+  final previousKey = orderedKeys[index - 1];
+  final previousStarted = all.any((t) => g(t.stageId) == previousKey && _hasStartedForStageSequence(t));
+  if (!previousStarted) return false;
+
+  return true;
 }
 
 bool _hasWorkplaceQueueActivity(TaskModel task) {
@@ -3015,14 +3074,21 @@ class _TasksScreenState extends State<TasksScreen>
                       queue,
                       workplace,
                     );
+                    final canStartEarlyPackaging = canStartPackagingEarly(
+                      task: task,
+                      tasks: taskProvider,
+                      personnel: personnel,
+                      employeeId: widget.employeeId,
+                      groupResolver: _stageGroupKey,
+                    );
                     final readyForStage = task.status == TaskStatus.waiting &&
                         unlockedByQueue &&
-                        _isFirstPendingStage(
+                        (_isFirstPendingStage(
                           taskProvider,
                           personnel,
                           task,
                           groupResolver: _stageGroupKey,
-                        );
+                        ) || canStartEarlyPackaging);
                     const canOpen = true;
                     return _TaskCard(
                       task: task,
@@ -5311,6 +5377,13 @@ class _TasksScreenState extends State<TasksScreen>
 
     final bool strictSequentialByPreviousCompletion =
         workplace != null && workplace.executionMode != WorkplaceExecutionMode.separate;
+    final canStartPackagingEarlyNow = canStartPackagingEarly(
+      task: task,
+      tasks: taskProvider,
+      personnel: context.read<PersonnelProvider>(),
+      employeeId: widget.employeeId,
+      groupResolver: _stageGroupKey,
+    );
 
     for (var i = 0; i < index; i++) {
       final previous = queued[i];
@@ -5318,15 +5391,23 @@ class _TasksScreenState extends State<TasksScreen>
         final bool previousCompleted = _isEffectivelyCompleted(previous);
         final bool previousInProblem = previous.status == TaskStatus.problem ||
             previous.comments.any((c) => c.type == 'problem');
+        final bool isDirectPrevious = i == index - 1;
+        final bool previousStarted = _hasStartedForStageSequence(previous);
         // Бизнес-правило для "Одиночная/Совместная": следующий заказ можно
         // стартовать только после завершения предыдущего, либо если он в "Проблеме".
-        if (!previousCompleted && !previousInProblem) {
+        // Исключение: для последнего этапа упаковки разрешаем ранний старт,
+        // когда непосредственный предыдущий этап уже начат.
+        if (!previousCompleted &&
+            !previousInProblem &&
+            !(canStartPackagingEarlyNow && isDirectPrevious && previousStarted)) {
           return false;
         }
         continue;
       }
       if (!_hasWorkplaceQueueActivity(previous)) {
-        return false;
+        if (!(canStartPackagingEarlyNow && i == index - 1 && _hasStartedForStageSequence(previous))) {
+          return false;
+        }
       }
     }
     return true;
@@ -5388,7 +5469,14 @@ class _TasksScreenState extends State<TasksScreen>
         (_canRunOutOfStageSequence(task) ||
             _isFirstPendingStage(context.read<TaskProvider>(),
                 context.read<PersonnelProvider>(), task,
-                groupResolver: _stageGroupKey)) &&
+                groupResolver: _stageGroupKey) ||
+            canStartPackagingEarly(
+              task: task,
+              tasks: context.read<TaskProvider>(),
+              personnel: context.read<PersonnelProvider>(),
+              employeeId: widget.employeeId,
+              groupResolver: _stageGroupKey,
+            )) &&
         stageModeAllowsJoin &&
         !shiftPaused &&
         !groupLocked &&
@@ -5642,10 +5730,18 @@ class _TasksScreenState extends State<TasksScreen>
                         final taskProvider = context.read<TaskProvider>();
                         final personnelProvider = personnel;
                         // Sequential stage guard
+                        final canStartEarlyPackaging = canStartPackagingEarly(
+                          task: task,
+                          tasks: taskProvider,
+                          personnel: personnelProvider,
+                          employeeId: widget.employeeId,
+                          groupResolver: _stageGroupKey,
+                        );
                         if (!_canRunOutOfStageSequence(task) &&
                             !_isFirstPendingStage(
                                 taskProvider, personnelProvider, task,
-                                groupResolver: _stageGroupKey)) {
+                                groupResolver: _stageGroupKey) &&
+                            !canStartEarlyPackaging) {
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                                 content: Text(


### PR DESCRIPTION
### Motivation

- Enable a business rule exception that allows the final packaging stage to be started early when the immediate previous stage in the order has been started and the current employee has access to the packaging workplace.

### Description

- Add `kPackagingStageId` and helper ` _isPackagingStageTask` to identify packaging tasks. 
- Add `_isPackagingAvailableByEmployeeAccess` to check employee access to the packaging workplace via positions.
- Implement `canStartPackagingEarly` which validates packaging-specific early-start rules including group resolution and ordered stage checks. 
- Integrate the early-packaging logic into readiness, queue-unlock, control-panel `canStart` checks, and the `onStart` guard so packaging tasks can bypass strict completion requirements when allowed.

### Testing

- Ran the project test suite with `flutter test`, and all tests passed. 
- Ran static analysis with `flutter analyze`, and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1342f8b8832fa3e5c3dbcf3fa509)