### PR TITLE
Fix nullable employee access in packaging permission check

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -645,10 +645,11 @@ bool _isPackagingAvailableByEmployeeAccess(
     }
   }
   if (employee == null) return false;
+  final emp = employee;
   final packagingWorkplace = personnel.workplaceById(kPackagingStageId);
   if (packagingWorkplace == null) return false;
   return packagingWorkplace.positionIds
-      .any((p) => employee.positionIds.contains(p));
+      .any((p) => emp.positionIds.contains(p));
 }
 
 bool canStartPackagingEarly({


### PR DESCRIPTION
### Motivation
- Fix a null-safety compile error where `employee.positionIds` was accessed on a nullable `EmployeeModel?` during the packaging access check, which caused the Windows build to fail.

### Description
- In `_isPackagingAvailableByEmployeeAccess` introduce a non-null local `emp` immediately after `if (employee == null) return false;` and use `emp.positionIds` in the closure to avoid capturing a nullable reference.

### Testing
- Attempted `dart analyze lib/modules/tasks/tasks_screen.dart` but it failed in this environment with `dart: command not found`, so static analysis could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c16e09ca8832f9e63c21869c536d8)