### PR TITLE
Enable controlled early-start for Packaging stage (edeb85db...)

### DIFF
--- a/lib/modules/tasks/stage_sequence_utils.dart
+++ b/lib/modules/tasks/stage_sequence_utils.dart
@@ -212,6 +212,68 @@ bool isFirstPendingStageInOrder({
   return groupKey(currentStageId) == pendingStageIds.first;
 }
 
+
+bool canStartPackagingEarly({
+  required String orderId,
+  required String currentStageId,
+  required Iterable<PendingStageState> stageStates,
+  required Iterable<String> orderedStages,
+  required bool hasPackagingAccess,
+  StageGroupingResolver? groupResolver,
+  String? currentStageName,
+  String? currentStageType,
+  String? currentStageGroupKey,
+  bool enforceSinglePerformer = true,
+}) {
+  final currentIsPackaging = isPackagingStage(
+    stageId: currentStageId,
+    stageName: currentStageName,
+    stageType: currentStageType,
+    stageGroupKey: currentStageGroupKey,
+  );
+  if (!currentIsPackaging) return false;
+  if (!hasPackagingAccess) return false;
+
+  String groupKey(String stageId) =>
+      groupResolver?.call(orderId, stageId) ?? stageId;
+
+  final orderedList = orderedStages.toList(growable: false);
+  if (orderedList.isEmpty) return false;
+
+  final orderedKeys = <String>[];
+  for (final id in orderedList) {
+    final key = groupKey(id);
+    if (!orderedKeys.contains(key)) orderedKeys.add(key);
+  }
+
+  final currentKey = groupKey(currentStageId);
+  final currentIndex = orderedKeys.indexOf(currentKey);
+  if (currentIndex != orderedKeys.length - 1 || currentIndex <= 0) return false;
+
+  final previousKey = orderedKeys[currentIndex - 1];
+
+  bool packagingCompleted = false;
+  bool packagingAlreadyStarted = false;
+  bool previousStarted = false;
+
+  for (final state in stageStates) {
+    final key = groupKey(state.stageId);
+    if (key == currentKey) {
+      if (state.completed) packagingCompleted = true;
+      if (state.started) packagingAlreadyStarted = true;
+    }
+    if (key == previousKey && (state.started || state.completed || state.problem)) {
+      previousStarted = true;
+    }
+  }
+
+  if (packagingCompleted) return false;
+  if (!previousStarted) return false;
+  if (enforceSinglePerformer && packagingAlreadyStarted) return false;
+
+  return true;
+}
+
 bool _stageUnlocksNext(Map<String, bool>? stage) {
   if (stage == null) return false;
   return stage['started'] == true ||

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -629,10 +629,6 @@ bool _isFirstPendingStage(TaskProvider tasks, PersonnelProvider personnel,
 }
 
 
-
-bool _isPackagingStageTask(TaskModel task) =>
-    task.stageId.trim() == kPackagingStageId;
-
 bool _isPackagingAvailableByEmployeeAccess(
   PersonnelProvider personnel,
   String employeeId,
@@ -659,32 +655,31 @@ bool canStartPackagingEarly({
   required String employeeId,
   stage_sequence.StageGroupingResolver? groupResolver,
 }) {
-  if (!_isPackagingStageTask(task)) return false;
-  if (_isEffectivelyCompleted(task)) return false;
-  if (task.status == TaskStatus.inProgress) return false;
-  if (!_isPackagingAvailableByEmployeeAccess(personnel, employeeId)) return false;
-
   final all = tasks.tasks.where((t) => t.orderId == task.orderId).toList();
   if (all.isEmpty) return false;
 
-  final sequence = tasks.stageSequenceForOrder(task.orderId) ?? const <String>[];
-  if (sequence.isEmpty) return false;
-
-  String g(String stageId) => groupResolver?.call(task.orderId, stageId) ?? stageId;
-  final orderedKeys = <String>[];
-  for (final id in sequence) {
-    final key = g(id);
-    if (!orderedKeys.contains(key)) orderedKeys.add(key);
-  }
-  final taskKey = g(task.stageId);
-  final index = orderedKeys.indexOf(taskKey);
-  if (index != orderedKeys.length - 1 || index <= 0) return false;
-
-  final previousKey = orderedKeys[index - 1];
-  final previousStarted = all.any((t) => g(t.stageId) == previousKey && _hasStartedForStageSequence(t));
-  if (!previousStarted) return false;
-
-  return true;
+  return stage_sequence.canStartPackagingEarly(
+    orderId: task.orderId,
+    currentStageId: task.stageId,
+    stageStates: all.map(
+      (t) => stage_sequence.PendingStageState(
+        stageId: t.stageId,
+        stageName: _stageDisplayName(personnel, t.stageId),
+        stageGroupKey: t.stageGroupKey,
+        completed: _isEffectivelyCompleted(t),
+        problem: t.status == TaskStatus.problem ||
+            t.comments.any((c) => c.type == 'problem'),
+        started: _hasStartedForStageSequence(t),
+      ),
+    ),
+    orderedStages: tasks.stageSequenceForOrder(task.orderId) ?? const <String>[],
+    groupResolver: groupResolver,
+    currentStageName: _stageDisplayName(personnel, task.stageId),
+    currentStageGroupKey: task.stageGroupKey,
+    hasPackagingAccess:
+        _isPackagingAvailableByEmployeeAccess(personnel, employeeId),
+    enforceSinglePerformer: true,
+  );
 }
 
 bool _hasWorkplaceQueueActivity(TaskModel task) {
@@ -7711,7 +7706,7 @@ class _TaskCard extends StatelessWidget {
     final double statusSize = scaled(11.5);
     final String? stageHint = showStageHint
         ? (readyForStage
-            ? 'Можно начинать: предыдущий этап начат'
+            ? 'Доступно, так как предыдущий этап уже начат'
             : 'Ожидает начала предыдущего этапа')
         : null;
     final Color readyColor = Colors.green.shade600;

--- a/test/stage_sequence_utils_test.dart
+++ b/test/stage_sequence_utils_test.dart
@@ -201,3 +201,77 @@ void main() {
     expect(canStartPackaging, isFalse);
   });
 }
+
+test('canStartPackagingEarly allows packaging when previous stage started and access granted', () {
+  final result = canStartPackagingEarly(
+    orderId: 'order-1',
+    currentStageId: kPackagingStageId,
+    currentStageName: 'Упаковка',
+    stageStates: const [
+      PendingStageState(stageId: 'print', completed: false, started: true),
+      PendingStageState(stageId: kPackagingStageId, completed: false),
+    ],
+    orderedStages: const ['print', kPackagingStageId],
+    hasPackagingAccess: true,
+  );
+
+  expect(result, isTrue);
+});
+
+test('canStartPackagingEarly blocks packaging when previous stage not started', () {
+  final result = canStartPackagingEarly(
+    orderId: 'order-1',
+    currentStageId: kPackagingStageId,
+    currentStageName: 'Упаковка',
+    stageStates: const [
+      PendingStageState(stageId: 'print', completed: false),
+      PendingStageState(stageId: kPackagingStageId, completed: false),
+    ],
+    orderedStages: const ['print', kPackagingStageId],
+    hasPackagingAccess: true,
+  );
+
+  expect(result, isFalse);
+});
+
+test('canStartPackagingEarly blocks without packaging access', () {
+  final result = canStartPackagingEarly(
+    orderId: 'order-1',
+    currentStageId: kPackagingStageId,
+    currentStageName: 'Упаковка',
+    stageStates: const [
+      PendingStageState(stageId: 'print', completed: false, started: true),
+      PendingStageState(stageId: kPackagingStageId, completed: false),
+    ],
+    orderedStages: const ['print', kPackagingStageId],
+    hasPackagingAccess: false,
+  );
+
+  expect(result, isFalse);
+});
+
+test('canStartPackagingEarly blocks when packaging already started/completed', () {
+  final started = canStartPackagingEarly(
+    orderId: 'order-1',
+    currentStageId: kPackagingStageId,
+    stageStates: const [
+      PendingStageState(stageId: 'print', completed: false, started: true),
+      PendingStageState(stageId: kPackagingStageId, completed: false, started: true),
+    ],
+    orderedStages: const ['print', kPackagingStageId],
+    hasPackagingAccess: true,
+  );
+  final completed = canStartPackagingEarly(
+    orderId: 'order-1',
+    currentStageId: kPackagingStageId,
+    stageStates: const [
+      PendingStageState(stageId: 'print', completed: true),
+      PendingStageState(stageId: kPackagingStageId, completed: true),
+    ],
+    orderedStages: const ['print', kPackagingStageId],
+    hasPackagingAccess: true,
+  );
+
+  expect(started, isFalse);
+  expect(completed, isFalse);
+});


### PR DESCRIPTION
### Motivation
- Allow the special packaging stage (`edeb85db-c7a3-4a24-8f33-70ccdd4aaae1`) to be started earlier when the previous stage is already started while preserving the existing sequential queue for all other stages.
- Support the case where an employee working the penultimate stage (and having packaging access) may optionally start packaging in parallel without changing database order or auto-finishing stages.
- Keep existing protections against duplicates, unauthorized starts and ensure behavior is stable after app restart and sync with Supabase/Postgres.

### Description
- Added a centralized check `canStartPackagingEarly(...)` in `lib/modules/tasks/stage_sequence_utils.dart` that enforces: stage is packaging, packaging is last in sequence, previous stage is started (or completed/problem), employee has packaging access, packaging is not completed, and (when enforced) packaging is not already started by someone else.
- Replaced local ad-hoc packaging checks in `lib/modules/tasks/tasks_screen.dart` with calls to the shared `stage_sequence.canStartPackagingEarly(...)`, and kept defensive re-checks before actual start; also updated the UI hint text to `"Доступно, так как предыдущий этап уже начат"` for clarity.
- Added unit tests in `test/stage_sequence_utils_test.dart` covering allowed and blocked early-start scenarios (access granted/denied, previous stage started/not started, packaging already started/completed).
- Modified files: `lib/modules/tasks/stage_sequence_utils.dart`, `lib/modules/tasks/tasks_screen.dart`, and `test/stage_sequence_utils_test.dart`.

### Testing
- Added unit tests (`test/stage_sequence_utils_test.dart`) exercising the new `canStartPackagingEarly` logic and existing packaging availability scenarios, but tests were not executed in this environment because `flutter`/`dart` are not available (`flutter: command not found`, `dart: command not found`).
- Static change was committed and includes the tests so CI should run them; local test execution must be performed in a dev environment with Flutter/Dart installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1916a218832f9608914dccdba30e)