### PR TITLE
Allow packaging early start by another employee

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -678,7 +678,7 @@ bool canStartPackagingEarly({
     currentStageGroupKey: task.stageGroupKey,
     hasPackagingAccess:
         _isPackagingAvailableByEmployeeAccess(personnel, employeeId),
-    enforceSinglePerformer: true,
+    enforceSinglePerformer: false,
   );
 }
 


### PR DESCRIPTION
### Motivation
- Allow packaging (`kPackagingStageId`) to be started out-of-order by a different employee with packaging access when the previous (penultimate) stage has already been started.

### Description
- In `lib/modules/tasks/tasks_screen.dart` changed the `enforceSinglePerformer` argument from `true` to `false` in the call to `stage_sequence.canStartPackagingEarly(...)`, removing the single-performer restriction for early packaging start.

### Testing
- Verified the change via `git diff` and created a commit for `lib/modules/tasks/tasks_screen.dart` which succeeded. 
- Attempted to run `dart format` but it failed due to `dart` not being available in the execution environment (formatting not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1d8efcc4832f9d32340777d912f2)