### PR TITLE
Allow early start for Packaging only and prioritize it over queue order

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -655,6 +655,9 @@ bool canStartPackagingOutOfQueue({
   required String employeeId,
   stage_sequence.StageGroupingResolver? groupResolver,
 }) {
+  // Обход очереди разрешаем только для целевого этапа "Упаковка".
+  if (task.stageId != kPackagingStageId) return false;
+
   final all = tasks.tasks.where((t) => t.orderId == task.orderId).toList();
   if (all.isEmpty) return false;
 
@@ -5442,29 +5445,30 @@ class _TasksScreenState extends State<TasksScreen>
       groupResolver: _stageGroupKey,
     );
 
+    // Спец-правило упаковки имеет приоритет над строгой проверкой позиции
+    // в очереди рабочего места: если упаковку можно стартовать вне очереди,
+    // не блокируем запуск из-за того, что задача не первая.
+    if (canStartPackagingEarlyNow) {
+      return true;
+    }
+
     for (var i = 0; i < index; i++) {
       final previous = queued[i];
       if (strictSequentialByPreviousCompletion) {
         final bool previousCompleted = _isEffectivelyCompleted(previous);
         final bool previousInProblem = previous.status == TaskStatus.problem ||
             previous.comments.any((c) => c.type == 'problem');
-        final bool isDirectPrevious = i == index - 1;
-        final bool previousStarted = _hasStartedForStageSequence(previous);
         // Бизнес-правило для "Одиночная/Совместная": следующий заказ можно
         // стартовать только после завершения предыдущего, либо если он в "Проблеме".
         // Исключение: для последнего этапа упаковки разрешаем ранний старт,
         // когда непосредственный предыдущий этап уже начат.
-        if (!previousCompleted &&
-            !previousInProblem &&
-            !(canStartPackagingEarlyNow && isDirectPrevious && previousStarted)) {
+        if (!previousCompleted && !previousInProblem) {
           return false;
         }
         continue;
       }
       if (!_hasWorkplaceQueueActivity(previous)) {
-        if (!(canStartPackagingEarlyNow && i == index - 1 && _hasStartedForStageSequence(previous))) {
-          return false;
-        }
+        return false;
       }
     }
     return true;


### PR DESCRIPTION
### Motivation

- Prevent out-of-queue start checks from being applied to non-packaging stages and make packaging early-start rule take precedence over workplace queue ordering.

### Description

- Restrict `canStartPackagingOutOfQueue` so it returns `false` unless the task's `stageId` equals `kPackagingStageId`.
- Short-circuit the workplace queue check to immediately allow start when packaging early-start is permitted by calling `canStartPackagingOutOfQueue` and returning `true` before enforcing "first-in-queue" rules.
- Simplify previous-stage validation by removing per-previous-start exceptions and collapsing related conditions, so non-completed/non-problem previous stages block start unless the packaging bypass applies.

### Testing

- Ran static analysis with `flutter analyze` and the repository-wide unit tests with `flutter test`, and no failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c223d4ad8832f8935e709048d4129)