### PR TITLE
Validate pack (Уп) input against print run (тираж)

### DIFF
--- a/lib/modules/tasks/quantity_status_service.dart
+++ b/lib/modules/tasks/quantity_status_service.dart
@@ -159,6 +159,11 @@ bool isTwoSheetPackageSheetCutting({
               .contains(_normalizeProductName(stageId)));
 }
 
+double? packQuantityFromOrder(OrderModel order) {
+  final packs = _number(order.product.blQuantity);
+  return (packs != null && packs > 0) ? packs : null;
+}
+
 double? getExpectedQuantity({
   required OrderModel order,
   required TaskModel task,
@@ -170,8 +175,8 @@ double? getExpectedQuantity({
   }
 
   if (isQuantityPackUnit(unit)) {
-    final packs = _number(order.product.blQuantity);
-    return packs != null && packs > 0 ? packs : null;
+    final quantity = order.product.quantity;
+    return quantity > 0 ? quantity.toDouble() : null;
   }
 
   if (isQuantityPieceUnit(unit)) {

--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -8213,7 +8213,13 @@ Future<_QuantityInput?> _askQuantity(
                           unit: unitLabel,
                         )
                       : null;
-                  final status = getQuantityStatus(actual: n, expected: expected);
+                  final packSize = order != null && isQuantityPackUnit(unitLabel)
+                      ? packQuantityFromOrder(order)
+                      : null;
+                  final actualForValidation =
+                      packSize != null && packSize > 0 ? (n * packSize) : n;
+                  final status =
+                      getQuantityStatus(actual: actualForValidation, expected: expected);
                   if (status == QuantityStatus.warning ||
                       status == QuantityStatus.danger) {
                     final confirmed = await showDialog<bool>(
@@ -8243,7 +8249,7 @@ Future<_QuantityInput?> _askQuantity(
                       ? '$displayQuantity $unitLabel'
                       : displayQuantity;
                   final payload = quantityStatusToJson(
-                    actual: n,
+                    actual: actualForValidation,
                     unit: unitLabel,
                     expected: expected,
                     status: status,


### PR DESCRIPTION
### Motivation
- Packaging (`Уп`) input should be validated against the order print run (`тираж`) rather than the planned number of packs, while comments must still show the entered pack count. 
- The existing logic used `blQuantity` (units per pack) as the expected quantity for packs which made the check incorrect for packaging stage.

### Description
- Added helper `packQuantityFromOrder(OrderModel)` to read the package size (`blQuantity`) from an order. 
- Changed `getExpectedQuantity` for pack units to use order print run (`order.product.quantity`) as the expected value. 
- In the completion dialog (`_askQuantity` in `tasks_screen.dart`) when unit is pack, multiply entered packs by `packSize` for validation (`actualForValidation = n * packSize`), keep displayed comment text as the entered pack count, and include the recalculated `actual` in the JSON payload.
- Modified files: `lib/modules/tasks/quantity_status_service.dart` and `lib/modules/tasks/tasks_screen.dart`.

### Testing
- Attempted to run `dart format` on changed files but it failed in the environment (`/bin/bash: dart: command not found`). (failed) 
- `git status` and `git commit` were executed to stage and record the changes. (succeeded) 
- No other automated test suites were run in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c317b82dc832faf6b588a700f7465)