### PR TITLE
Extract queue validity helpers and unify queue-actual checks

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -18,6 +18,7 @@ import 'orders_provider.dart';
 import 'order_stage_filter.dart';
 import 'stage_queue_builder.dart';
 import 'order_queue_service.dart';
+import 'order_queue_validity.dart';
 import 'orders_repository.dart';
 import 'order_model.dart';
 import 'order_form_rules.dart';
@@ -1148,30 +1149,16 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
 
   Map<String, dynamic> _currentQueueSignature() {
     final mainMaterial = _mainMaterialForStageQueue();
-    final paperIds = _collectSelectedPapers()
-        .map((paper) => {
-              'id': (paper.id ?? '').trim(),
-              'name': paper.name.trim(),
-              'format': (paper.format ?? '').trim(),
-              'grammage': (paper.grammage ?? '').trim(),
-              'quantity': paper.quantity,
-            })
-        .toList(growable: false);
-    return <String, dynamic>{
-      'product_type_id': _product.type.trim(),
-      'product_quantity': _product.quantity,
-      'product_width': _product.width,
-      'product_height': _product.height,
-      'product_depth': _product.depth,
-      'product_width_b': _product.widthB,
-      'material_width': parseMaterialWidth(mainMaterial),
-      'paper_materials': paperIds,
-      'has_paint': _hasAnyPaints(),
-      'has_trimming': _trimming,
-      'has_cardboard': _cardboardChecked,
-      'handle': _selectedHandleDescription.trim(),
-      'stage_template_id': _stageTemplateId,
-    };
+    return buildQueueSignature(
+      product: _product,
+      paperMaterials: _collectSelectedPapers(),
+      materialWidth: parseMaterialWidth(mainMaterial),
+      hasPaint: _hasAnyPaints(),
+      hasTrimming: _trimming,
+      hasCardboard: _cardboardChecked,
+      handle: _selectedHandleDescription,
+      templateId: _stageTemplateId,
+    );
   }
 
   bool _sameQueueSignature(
@@ -1739,7 +1726,12 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
         QueueBuildStatus.built) {
       return false;
     }
-    return _sameQueueSignature(_queueSignature, _currentQueueSignature()) ||
+    return isQueueActual(
+          currentSignature: _currentQueueSignature(),
+          storedSignature: _queueSignature,
+          queueBuildStatus: _queueBuildStatus,
+          stages: _stagePreviewStages,
+        ) ||
         widget.order!.assignmentCreated;
   }
 
@@ -6070,13 +6062,22 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
   Widget _buildProductionSection(BuildContext context,
       {bool wrapWithCard = true, bool includeMakeready = true}) {
     final children = <Widget>[];
+    final queueActual = isQueueActual(
+      currentSignature: _currentQueueSignature(),
+      storedSignature: _queueSignature,
+      queueBuildStatus: _queueBuildStatus,
+      stages: _stagePreviewStages,
+    );
     children.add(
       Padding(
         padding: const EdgeInsets.only(bottom: 8),
         child: FilledButton.icon(
+          style: FilledButton.styleFrom(
+            backgroundColor: queueActual ? Colors.green : null,
+          ),
           onPressed: _buildStageQueue,
           icon: const Icon(Icons.auto_fix_high),
-          label: const Text('Собрать очередь'),
+          label: Text(queueActual ? 'Очередь собрана' : 'Собрать очередь'),
         ),
       ),
     );

--- a/lib/modules/orders/order_queue_validity.dart
+++ b/lib/modules/orders/order_queue_validity.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'material_model.dart';
+import 'order_model.dart';
+import 'product_model.dart';
+
+Map<String, dynamic> buildQueueSignature({
+  required ProductModel product,
+  required List<MaterialModel> paperMaterials,
+  required double? materialWidth,
+  required bool hasPaint,
+  required bool hasTrimming,
+  required bool hasCardboard,
+  required String handle,
+  required String? templateId,
+}) {
+  final normalizedPapers = paperMaterials
+      .map((paper) => <String, dynamic>{
+            'id': (paper.id ?? '').trim(),
+            'name': paper.name.trim(),
+            'format': (paper.format ?? '').trim(),
+            'grammage': (paper.grammage ?? '').trim(),
+            'quantity': paper.quantity,
+          })
+      .toList(growable: false);
+
+  return <String, dynamic>{
+    'product_type_id': product.type.trim(),
+    'product_quantity': product.quantity,
+    'product_width': product.width,
+    'product_height': product.height,
+    'product_depth': product.depth,
+    'product_width_b': product.widthB,
+    'material_width': materialWidth,
+    'paper_materials': normalizedPapers,
+    'has_paint': hasPaint,
+    'has_trimming': hasTrimming,
+    'has_cardboard': hasCardboard,
+    'handle': handle.trim(),
+    'stage_template_id': templateId,
+  };
+}
+
+bool isQueueActual({
+  required Map<String, dynamic> currentSignature,
+  required Map<String, dynamic>? storedSignature,
+  required String queueBuildStatus,
+  required List<Map<String, dynamic>> stages,
+}) {
+  if (stages.isEmpty) return false;
+  if (QueueBuildStatus.normalize(queueBuildStatus) != QueueBuildStatus.built) {
+    return false;
+  }
+  if (storedSignature == null) return false;
+  return jsonEncode(storedSignature) == jsonEncode(currentSignature);
+}

--- a/test/order_queue_status_test.dart
+++ b/test/order_queue_status_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheet_clone/modules/orders/order_model.dart';
+import 'package:sheet_clone/modules/orders/order_queue_validity.dart';
+import 'package:sheet_clone/modules/orders/product_model.dart';
+
+void main() {
+  Map<String, dynamic> _signature() => buildQueueSignature(
+        product: ProductModel(
+          id: 'p1',
+          type: 'П-пакет',
+          quantity: 100,
+          width: 10,
+          height: 20,
+          depth: 5,
+          parameters: '',
+        ),
+        paperMaterials: const [],
+        materialWidth: 100,
+        hasPaint: true,
+        hasTrimming: false,
+        hasCardboard: false,
+        handle: '-',
+        templateId: 'tpl-1',
+      );
+
+  test('built + matching signature => actual queue', () {
+    final signature = _signature();
+    final actual = isQueueActual(
+      currentSignature: signature,
+      storedSignature: signature,
+      queueBuildStatus: QueueBuildStatus.built,
+      stages: const [
+        {'stageId': 'print'}
+      ],
+    );
+
+    expect(actual, isTrue);
+  });
+
+  test('built + mismatching signature => outdated queue', () {
+    final current = _signature();
+    final stored = _signature()..['has_paint'] = false;
+    final actual = isQueueActual(
+      currentSignature: current,
+      storedSignature: stored,
+      queueBuildStatus: QueueBuildStatus.built,
+      stages: const [
+        {'stageId': 'print'}
+      ],
+    );
+
+    expect(actual, isFalse);
+  });
+
+  test('empty queue is never actual', () {
+    final signature = _signature();
+    final actual = isQueueActual(
+      currentSignature: signature,
+      storedSignature: signature,
+      queueBuildStatus: QueueBuildStatus.built,
+      stages: const [],
+    );
+
+    expect(actual, isFalse);
+  });
+}


### PR DESCRIPTION
### Motivation
- Централизовать логику формирования и сравнения подписи очереди, чтобы UI и сервисы использовали один и тот же канонический алгоритм для определения актуальности очереди.
- Обеспечить, чтобы экран редактирования использовал эту логику при принятии решений (повторное использование сохранённой очереди, цвет/текст кнопки «Собрать очередь» и пометка очереди как устаревшей).
- Добавить автотесты на базовые сценарии состояния очереди (built+match, built+mismatch, пустая очередь).

### Description
- Добавлен новый модуль `lib/modules/orders/order_queue_validity.dart` с функциями `buildQueueSignature(...)` и `isQueueActual(...)` для создания канонической подписи и проверки актуальности очереди.
- В `lib/modules/orders/edit_order_screen.dart` текущая реализация `_currentQueueSignature()` заменена на вызов `buildQueueSignature(...)`, проверка возможности повторного использования сохранённой превью-очереди (`_shouldKeepSavedStagePreview`) теперь использует `isQueueActual(...)`, и UI-кнопка «Собрать очередь» вычисляет цвет/текст через `isQueueActual(...)`.
- Добавлен тест `test/order_queue_status_test.dart` с кейсами: `built + matching signature => actual`, `built + mismatching signature => not actual`, `empty queue => not actual`.
- Ничего не менялось в схеме хранения полей очереди: поля `queueBuildStatus` и `queueSignature` продолжают читаться/писаться через существующие `OrderModel`/провайдеры и остаются каноническим источником состояния.

### Testing
- Добавленный тест `test/order_queue_status_test.dart` покрывает три сценария описанных выше but был не выполнен в CI локально из-за отсутствия окружения: попытка запустить `dart format` завершилась с `/bin/bash: dart: command not found` и попытка `flutter test` завершилась с `/bin/bash: flutter: command not found`, поэтому автоматические тесты не были выполнены здесь.
- Статическая/форматная проверка не выполнялась по той же причине (отсутствуют `dart`/`flutter` в окружении).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4095ab30832f98630d8f32e0981e)