### PR TITLE
Add order-comment attachments support to AttachmentService and model

### DIFF
--- a/lib/modules/orders/order_comment_attachment.dart
+++ b/lib/modules/orders/order_comment_attachment.dart
@@ -1,0 +1,72 @@
+class OrderCommentAttachment {
+  final String id;
+  final String orderId;
+  final String commentId;
+  final String fileName;
+  final String storagePath;
+  final String mimeType;
+  final int sizeBytes;
+  final String attachmentType;
+  final String uploadedBy;
+  final DateTime createdAt;
+  final String? fileUrl;
+
+  const OrderCommentAttachment({
+    required this.id,
+    required this.orderId,
+    required this.commentId,
+    required this.fileName,
+    required this.storagePath,
+    required this.mimeType,
+    required this.sizeBytes,
+    required this.attachmentType,
+    required this.uploadedBy,
+    required this.createdAt,
+    this.fileUrl,
+  });
+
+  factory OrderCommentAttachment.fromMap(Map<String, dynamic> map) {
+    int parseSize(dynamic value) {
+      if (value is int) return value;
+      if (value is num) return value.toInt();
+      if (value is String) return int.tryParse(value) ?? 0;
+      return 0;
+    }
+
+    DateTime parseCreatedAt(dynamic value) {
+      if (value is DateTime) return value;
+      if (value is String) return DateTime.tryParse(value) ?? DateTime.now();
+      return DateTime.now();
+    }
+
+    return OrderCommentAttachment(
+      id: (map['id'] ?? '').toString(),
+      orderId: (map['order_id'] ?? map['orderId'] ?? '').toString(),
+      commentId: (map['comment_id'] ?? map['commentId'] ?? '').toString(),
+      fileName: (map['file_name'] ?? map['fileName'] ?? 'attachment').toString(),
+      storagePath: (map['storage_path'] ?? map['storagePath'] ?? '').toString(),
+      mimeType: (map['mime_type'] ?? map['mimeType'] ?? 'application/octet-stream').toString(),
+      sizeBytes: parseSize(map['size_bytes'] ?? map['sizeBytes']),
+      attachmentType: (map['attachment_type'] ?? map['attachmentType'] ?? 'file').toString(),
+      uploadedBy: (map['uploaded_by'] ?? map['uploadedBy'] ?? '').toString(),
+      createdAt: parseCreatedAt(map['created_at'] ?? map['createdAt']),
+      fileUrl: (map['file_url'] ?? map['fileUrl'])?.toString(),
+    );
+  }
+
+  OrderCommentAttachment copyWith({String? fileUrl}) {
+    return OrderCommentAttachment(
+      id: id,
+      orderId: orderId,
+      commentId: commentId,
+      fileName: fileName,
+      storagePath: storagePath,
+      mimeType: mimeType,
+      sizeBytes: sizeBytes,
+      attachmentType: attachmentType,
+      uploadedBy: uploadedBy,
+      createdAt: createdAt,
+      fileUrl: fileUrl ?? this.fileUrl,
+    );
+  }
+}

--- a/lib/services/attachment_service.dart
+++ b/lib/services/attachment_service.dart
@@ -11,9 +11,12 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:uuid/uuid.dart';
 
 import '../modules/tasks/task_model.dart';
+import '../modules/orders/order_comment_attachment.dart';
 
 const String kTaskCommentAttachmentsBucket = 'task-comment-attachments';
 const String kTaskCommentAttachmentsTable = 'task_comment_attachments';
+const String kOrderCommentAttachmentsBucket = 'order-comment-attachments';
+const String kOrderCommentAttachmentsTable = 'order_comment_attachments';
 
 class AttachmentDraft {
   final Uint8List bytes;
@@ -159,11 +162,11 @@ class AttachmentService {
       ext.isEmpty ? attachmentId : '$attachmentId$ext',
     ].join('/');
 
-    final storage = _supabase.storage.from(kTaskCommentAttachmentsBucket);
-    await storage.uploadBinary(
-      storagePath,
-      draft.bytes,
-      fileOptions: FileOptions(contentType: draft.mimeType, upsert: false),
+    await _uploadBinary(
+      bucket: kTaskCommentAttachmentsBucket,
+      storagePath: storagePath,
+      bytes: draft.bytes,
+      mimeType: draft.mimeType,
     );
 
     try {
@@ -189,10 +192,60 @@ class AttachmentService {
           .single();
       return _withSignedUrl(
         TaskCommentAttachment.fromMap(Map<String, dynamic>.from(row)),
-        signedUrlTtl,
+        bucket: kTaskCommentAttachmentsBucket,
+        signedUrlTtl: signedUrlTtl,
       );
     } catch (_) {
       await removeStorageObject(storagePath);
+      rethrow;
+    }
+  }
+
+  Future<OrderCommentAttachment> uploadOrderCommentAttachment({
+    required AttachmentDraft draft,
+    required String orderId,
+    required String commentId,
+    required String userId,
+    String attachmentType = 'file',
+    Duration signedUrlTtl = const Duration(hours: 12),
+  }) async {
+    final attachmentId = _uuid.v4();
+    final safeName = _sanitizeFileName(draft.fileName);
+    final ext = p.extension(safeName);
+    final storagePath = [
+      orderId,
+      commentId,
+      ext.isEmpty ? attachmentId : '$attachmentId$ext',
+    ].join('/');
+
+    await _uploadBinary(
+      bucket: kOrderCommentAttachmentsBucket,
+      storagePath: storagePath,
+      bytes: draft.bytes,
+      mimeType: draft.mimeType,
+    );
+
+    try {
+      final now = DateTime.now().toUtc();
+      final row = await _supabase.from(kOrderCommentAttachmentsTable).insert({
+        'id': attachmentId,
+        'order_id': orderId,
+        'comment_id': commentId,
+        'file_name': safeName,
+        'storage_path': storagePath,
+        'mime_type': draft.mimeType,
+        'size_bytes': draft.sizeBytes,
+        'attachment_type': attachmentType,
+        'uploaded_by': userId,
+        'created_at': now.toIso8601String(),
+      }).select().single();
+      return _withSignedUrl(
+        OrderCommentAttachment.fromMap(Map<String, dynamic>.from(row)),
+        bucket: kOrderCommentAttachmentsBucket,
+        signedUrlTtl: signedUrlTtl,
+      );
+    } catch (_) {
+      await removeStorageObject(storagePath, bucket: kOrderCommentAttachmentsBucket);
       rethrow;
     }
   }
@@ -228,7 +281,36 @@ class AttachmentService {
         final map = Map<String, dynamic>.from(raw as Map);
         attachments.add(await _withSignedUrl(
           TaskCommentAttachment.fromMap(map),
-          signedUrlTtl,
+          bucket: kTaskCommentAttachmentsBucket,
+          signedUrlTtl: signedUrlTtl,
+        ));
+      }
+    }
+    return attachments;
+  }
+
+  Future<List<OrderCommentAttachment>> loadOrderCommentAttachments({
+    required String orderId,
+    Iterable<String>? commentIds,
+    Duration signedUrlTtl = const Duration(hours: 12),
+  }) async {
+    dynamic query = _supabase
+        .from(kOrderCommentAttachmentsTable)
+        .select()
+        .eq('order_id', orderId.trim());
+    final ids = (commentIds ?? const <String>[])
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toList(growable: false);
+    if (ids.isNotEmpty) query = query.inFilter('comment_id', ids);
+    final rows = await query.order('created_at');
+    final attachments = <OrderCommentAttachment>[];
+    if (rows is List) {
+      for (final raw in rows) {
+        attachments.add(await _withSignedUrl(
+          OrderCommentAttachment.fromMap(Map<String, dynamic>.from(raw as Map)),
+          bucket: kOrderCommentAttachmentsBucket,
+          signedUrlTtl: signedUrlTtl,
         ));
       }
     }
@@ -243,7 +325,19 @@ class AttachmentService {
       return attachment.fileUrl!.trim();
     }
     return _supabase.storage
-        .from(kTaskCommentAttachmentsBucket)
+      .from(kTaskCommentAttachmentsBucket)
+      .createSignedUrl(attachment.storagePath, signedUrlTtl.inSeconds);
+  }
+
+  Future<String> getOrderAttachmentUrl(
+    OrderCommentAttachment attachment, {
+    Duration signedUrlTtl = const Duration(hours: 12),
+  }) async {
+    if ((attachment.fileUrl ?? '').trim().isNotEmpty) {
+      return attachment.fileUrl!.trim();
+    }
+    return _supabase.storage
+        .from(kOrderCommentAttachmentsBucket)
         .createSignedUrl(attachment.storagePath, signedUrlTtl.inSeconds);
   }
 
@@ -255,23 +349,51 @@ class AttachmentService {
         .eq('id', attachment.id);
   }
 
-  Future<void> removeStorageObject(String storagePath) async {
+  Future<void> removeStorageObject(
+    String storagePath, {
+    String bucket = kTaskCommentAttachmentsBucket,
+  }) async {
     try {
       await _supabase
           .storage
-          .from(kTaskCommentAttachmentsBucket)
+          .from(bucket)
           .remove([storagePath]);
     } catch (_) {
       // Best-effort rollback cleanup. The original DB/storage error is more important.
     }
   }
 
-  Future<TaskCommentAttachment> _withSignedUrl(
-    TaskCommentAttachment attachment,
-    Duration signedUrlTtl,
-  ) async {
-    final url = await getUrl(attachment, signedUrlTtl: signedUrlTtl);
-    return attachment.copyWith(fileUrl: url);
+  Future<T> _withSignedUrl<T>(
+    T attachment, {
+    required String bucket,
+    required Duration signedUrlTtl,
+  }) async {
+    if (attachment is TaskCommentAttachment) {
+      final url = await _supabase.storage
+          .from(bucket)
+          .createSignedUrl(attachment.storagePath, signedUrlTtl.inSeconds);
+      return attachment.copyWith(fileUrl: url) as T;
+    }
+    if (attachment is OrderCommentAttachment) {
+      final url = await _supabase.storage
+          .from(bucket)
+          .createSignedUrl(attachment.storagePath, signedUrlTtl.inSeconds);
+      return attachment.copyWith(fileUrl: url) as T;
+    }
+    throw ArgumentError('Unsupported attachment type: ${attachment.runtimeType}');
+  }
+
+  Future<void> _uploadBinary({
+    required String bucket,
+    required String storagePath,
+    required Uint8List bytes,
+    required String mimeType,
+  }) {
+    return _supabase.storage.from(bucket).uploadBinary(
+          storagePath,
+          bytes,
+          fileOptions: FileOptions(contentType: mimeType, upsert: false),
+        );
   }
 
   String _sanitizeFileName(String value) {


### PR DESCRIPTION
### Motivation
- Provide server/storage support for order-level comment attachments and avoid duplicating upload/sign logic between task and order comment flows. 
- Prepare a clear service/model boundary so UI integration (preview, progress, in-app viewers and retry/error UX) can be implemented in follow-up changes.

### Description
- Introduced `OrderCommentAttachment` model with fields `id, order_id, comment_id, file_name, storage_path, mime_type, size_bytes, attachment_type, uploaded_by, created_at` and `fileUrl` parsing/copy helpers in `lib/modules/orders/order_comment_attachment.dart`.
- Added order attachment constants `kOrderCommentAttachmentsBucket` and `kOrderCommentAttachmentsTable` and new service APIs in `lib/services/attachment_service.dart`: `uploadOrderCommentAttachment`, `loadOrderCommentAttachments`, and `getOrderAttachmentUrl`.
- Refactored `AttachmentService` to extract shared internals: `_uploadBinary(...)` for binary uploads and a generic `_withSignedUrl<T>(...)` to attach signed URLs, and updated task-comment flows to reuse these helpers.
- Changed `removeStorageObject(...)` to accept an optional `bucket` parameter and updated task-comment upload/load to call the unified helpers to avoid logic duplication.

### Testing
- Committed changes to git: adding `lib/modules/orders/order_comment_attachment.dart` and updating `lib/services/attachment_service.dart` (commit succeeded).
- Attempted to run `dart format lib/services/attachment_service.dart lib/modules/orders/order_comment_attachment.dart`, but formatting could not be executed because `dart` is not available in the environment (`/bin/bash: dart: command not found`).
- Checked `flutter --version` which was not available in the environment (`/bin/bash: flutter: command not found`).
- No automated unit/integration tests were run in this environment; service-level behavior should be covered by integration tests against Supabase/storage in CI or a local dev environment with `dart`/`flutter` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c416e0ca0832f8892b1a1d116ab8f)