### PR TITLE
Add unified order comments repository and shared timeline widgets

### DIFF
--- a/lib/modules/orders/archive_orders_screen.dart
+++ b/lib/modules/orders/archive_orders_screen.dart
@@ -7,6 +7,8 @@ import 'product_model.dart';
 import 'edit_order_screen.dart';
 import 'id_format.dart';
 import 'order_timeline_dialog.dart';
+import 'order_comments_timeline.dart';
+import '../tasks/task_model.dart';
 
 /// Экран архива заказов. Показывает завершённые заказы с поиском и
 /// возможностью переключения вида (список/карточки). Из архива можно
@@ -83,6 +85,30 @@ class _ArchiveOrdersScreenState extends State<ArchiveOrdersScreen> {
     );
   }
 
+
+
+  Future<void> _showComments(BuildContext context, OrderModel o) async {
+    final legacy = o.comments.trim();
+    final comments = legacy.isEmpty
+        ? const <TaskComment>[]
+        : [
+            TaskComment(
+              id: 'legacy-${o.id}',
+              userId: '',
+              text: legacy,
+              timestamp: o.orderDate,
+            ),
+          ];
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => SizedBox(
+        height: MediaQuery.of(context).size.height * 0.6,
+        child: OrderCommentsTimeline(comments: comments, attachmentsByComment: const {}),
+      ),
+    );
+  }
+
   Widget _buildCard(BuildContext context, OrderModel o) {
     final product = o.product;
     final displayId = orderDisplayId(o);
@@ -118,6 +144,11 @@ class _ArchiveOrdersScreenState extends State<ArchiveOrdersScreen> {
                   },
                   icon: const Icon(Icons.history),
                   label: const Text('История'),
+                ),
+                TextButton.icon(
+                  onPressed: () => _showComments(context, o),
+                  icon: const Icon(Icons.comment),
+                  label: const Text('Комментарии'),
                 ),
                 TextButton.icon(
                   onPressed: () => _resumeOrder(context, o),
@@ -204,12 +235,20 @@ class _ArchiveOrdersScreenState extends State<ArchiveOrdersScreen> {
                                 );
                                 return;
                               }
+                              if (value == 'comments') {
+                                await _showComments(context, o);
+                                return;
+                              }
                               _resumeOrder(context, o);
                             },
                             itemBuilder: (_) => const [
                               PopupMenuItem(
                                 value: 'history',
                                 child: Text('История'),
+                              ),
+                              PopupMenuItem(
+                                value: 'comments',
+                                child: Text('Комментарии'),
                               ),
                               PopupMenuItem(
                                 value: 'resume',

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -35,6 +35,8 @@ import '../personnel/personnel_provider.dart';
 import '../common/pdf_view_screen.dart';
 import '../../utils/media_viewer.dart';
 import '../../utils/enter_key_behavior.dart';
+import 'order_comments_timeline.dart';
+import '../tasks/task_model.dart';
 
 /// Экран редактирования или создания заказа.
 /// Если [order] передан, экран открывается для редактирования существующего заказа.
@@ -3688,6 +3690,36 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
             ? 'Редактирование заказа ${(widget.order!.assignmentId ?? widget.order!.id)}'
             : 'Новый заказ'),
         actions: [
+          if (widget.order != null)
+            IconButton(
+              icon: const Icon(Icons.comment_outlined),
+              tooltip: 'Комментарии',
+              onPressed: () async {
+                final order = widget.order!;
+                final legacy = order.comments.trim();
+                final comments = legacy.isEmpty
+                    ? const <TaskComment>[]
+                    : [
+                        TaskComment(
+                          id: 'legacy-${order.id}',
+                          userId: '',
+                          text: legacy,
+                          timestamp: order.orderDate,
+                        )
+                      ];
+                await showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (_) => SizedBox(
+                    height: MediaQuery.of(context).size.height * 0.6,
+                    child: OrderCommentsTimeline(
+                      comments: comments,
+                      attachmentsByComment: const {},
+                    ),
+                  ),
+                );
+              },
+            ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 8),
             child: FilledButton.tonalIcon(
@@ -3719,6 +3751,36 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                         content: const Text(
                             'Вы действительно хотите удалить этот заказ? Это действие невозможно отменить.'),
                         actions: [
+          if (widget.order != null)
+            IconButton(
+              icon: const Icon(Icons.comment_outlined),
+              tooltip: 'Комментарии',
+              onPressed: () async {
+                final order = widget.order!;
+                final legacy = order.comments.trim();
+                final comments = legacy.isEmpty
+                    ? const <TaskComment>[]
+                    : [
+                        TaskComment(
+                          id: 'legacy-${order.id}',
+                          userId: '',
+                          text: legacy,
+                          timestamp: order.orderDate,
+                        )
+                      ];
+                await showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (_) => SizedBox(
+                    height: MediaQuery.of(context).size.height * 0.6,
+                    child: OrderCommentsTimeline(
+                      comments: comments,
+                      attachmentsByComment: const {},
+                    ),
+                  ),
+                );
+              },
+            ),
                           TextButton(
                             onPressed: () => Navigator.pop(ctx, false),
                             child: const Text('Отмена'),

--- a/lib/modules/orders/order_comments_repository.dart
+++ b/lib/modules/orders/order_comments_repository.dart
@@ -1,0 +1,74 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import '../tasks/task_model.dart';
+import 'order_comment_attachment.dart';
+
+class OrderCommentsRepository {
+  OrderCommentsRepository({SupabaseClient? supabase})
+      : _supabase = supabase ?? Supabase.instance.client;
+
+  final SupabaseClient _supabase;
+  static const _uuid = Uuid();
+
+  Future<List<TaskComment>> loadComments(String orderId) async {
+    final rows = await _supabase
+        .from('tasks')
+        .select('comments')
+        .eq('order_id', orderId);
+    final result = <TaskComment>[];
+    for (final row in rows as List<dynamic>) {
+      final comments = row['comments'];
+      if (comments is! Map) continue;
+      comments.forEach((key, value) {
+        if (value is Map<String, dynamic>) {
+          result.add(TaskComment.fromMap(value, key.toString()));
+        } else if (value is Map) {
+          result.add(TaskComment.fromMap(Map<String, dynamic>.from(value), key.toString()));
+        }
+      });
+    }
+    result.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return result;
+  }
+
+  Future<List<OrderCommentAttachment>> loadAttachmentsByCommentIds(List<String> commentIds) async {
+    if (commentIds.isEmpty) return const [];
+    final rows = await _supabase
+        .from('task_comment_attachments')
+        .select('*')
+        .inFilter('comment_id', commentIds);
+    return (rows as List<dynamic>)
+        .map((e) => OrderCommentAttachment.fromMap(Map<String, dynamic>.from(e as Map)))
+        .toList();
+  }
+
+  Future<TaskComment> sendComment({
+    required String taskId,
+    required String userId,
+    required String text,
+    String type = 'comment',
+  }) async {
+    final task = await _supabase.from('tasks').select('comments').eq('id', taskId).single();
+    final commentsRaw = task['comments'];
+    final Map<String, dynamic> comments = commentsRaw is Map
+        ? Map<String, dynamic>.from(commentsRaw)
+        : <String, dynamic>{};
+    final commentId = _uuid.v4();
+    final comment = TaskComment(
+      id: commentId,
+      userId: userId,
+      text: text,
+      timestamp: DateTime.now(),
+      type: type,
+    );
+    comments[commentId] = comment.toMap();
+    await _supabase.from('tasks').update({'comments': comments}).eq('id', taskId);
+    return comment;
+  }
+
+  Future<void> attachFiles(List<Map<String, dynamic>> rows) async {
+    if (rows.isEmpty) return;
+    await _supabase.from('task_comment_attachments').insert(rows);
+  }
+}

--- a/lib/modules/orders/order_comments_timeline.dart
+++ b/lib/modules/orders/order_comments_timeline.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../tasks/task_model.dart';
+import 'order_comment_attachment.dart';
+
+class OrderCommentsTimeline extends StatelessWidget {
+  const OrderCommentsTimeline({super.key, required this.comments, required this.attachmentsByComment});
+
+  final List<TaskComment> comments;
+  final Map<String, List<OrderCommentAttachment>> attachmentsByComment;
+
+  @override
+  Widget build(BuildContext context) {
+    if (comments.isEmpty) return const Center(child: Text('Комментариев пока нет'));
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: comments.length,
+      itemBuilder: (_, i) {
+        final c = comments[i];
+        return OrderCommentItem(
+          comment: c,
+          attachments: attachmentsByComment[c.id] ?? const [],
+        );
+      },
+    );
+  }
+}
+
+class OrderCommentItem extends StatelessWidget {
+  const OrderCommentItem({super.key, required this.comment, required this.attachments});
+  final TaskComment comment;
+  final List<OrderCommentAttachment> attachments;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = comment.text.trim();
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(text.isEmpty ? '—' : text),
+          if (attachments.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: attachments.map((a) => AttachmentPreview(attachment: a)).toList(),
+            ),
+          ]
+        ]),
+      ),
+    );
+  }
+}
+
+class AttachmentPreview extends StatelessWidget {
+  const AttachmentPreview({super.key, required this.attachment});
+  final OrderCommentAttachment attachment;
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(
+      avatar: const Icon(Icons.attach_file, size: 16),
+      label: Text(attachment.fileName),
+      onPressed: () {
+        Navigator.of(context).push(MaterialPageRoute(
+          builder: (_) => AttachmentViewerScreen(attachment: attachment),
+        ));
+      },
+    );
+  }
+}
+
+class AttachmentViewerScreen extends StatelessWidget {
+  const AttachmentViewerScreen({super.key, required this.attachment});
+  final OrderCommentAttachment attachment;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(attachment.fileName)),
+      body: Center(
+        child: Text((attachment.fileUrl ?? '').isEmpty
+            ? 'Нет URL для просмотра'
+            : attachment.fileUrl!),
+      ),
+    );
+  }
+}

--- a/test/modules/orders/order_comments_timeline_integration_test.dart
+++ b/test/modules/orders/order_comments_timeline_integration_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:app/modules/orders/order_comment_attachment.dart';
+import 'package:app/modules/orders/order_comments_timeline.dart';
+import 'package:app/modules/tasks/task_model.dart';
+
+void main() {
+  final comment = TaskComment(
+    id: 'c1',
+    userId: 'u1',
+    text: 'Тестовый комментарий',
+    timestamp: DateTime(2026, 1, 1),
+  );
+  final attachment = OrderCommentAttachment(
+    id: 'a1',
+    orderId: 'o1',
+    commentId: 'c1',
+    fileName: 'spec.pdf',
+    storagePath: 'path/spec.pdf',
+    mimeType: 'application/pdf',
+    sizeBytes: 100,
+    attachmentType: 'file',
+    uploadedBy: 'u1',
+    createdAt: DateTime(2026, 1, 1),
+  );
+
+  Widget host(String title) => MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: Text(title)),
+          body: OrderCommentsTimeline(
+            comments: [comment],
+            attachmentsByComment: {
+              'c1': [attachment],
+            },
+          ),
+        ),
+      );
+
+  testWidgets('рендерится одинаково на экране архива', (tester) async {
+    await tester.pumpWidget(host('Архив'));
+    expect(find.text('Тестовый комментарий'), findsOneWidget);
+    expect(find.text('spec.pdf'), findsOneWidget);
+  });
+
+  testWidgets('рендерится одинаково на экране редактирования', (tester) async {
+    await tester.pumpWidget(host('Редактирование'));
+    expect(find.text('Тестовый комментарий'), findsOneWidget);
+    expect(find.text('spec.pdf'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Создать единый data-source для комментариев и вложений заказа и общие UI-компоненты, чтобы разные экраны рендерили комментарии консистентно и можно было централизовать логику загрузки/передачи attachments. 
- Обеспечить обратную совместимость для старых комментариев без attachments и избежать удаления storage-объектов при переносе в архив. 
- Зафиксировать поведение через integration-style widget tests, чтобы предотвратить рассинхронизацию UI между экранами.

### Description
- Добавлен репозиторий `OrderCommentsRepository` в `lib/modules/orders/order_comments_repository.dart` с методами `loadComments(orderId)`, `loadAttachmentsByCommentIds(...)`, `sendComment(...)` и `attachFiles(...)` для работы с комментариями и таблицей `task_comment_attachments`. 
- Добавлены общие виджеты в `lib/modules/orders/order_comments_timeline.dart`: `OrderCommentsTimeline`, `OrderCommentItem`, `AttachmentPreview` и `AttachmentViewerScreen` для единообразного рендера комментариев и превью вложений. 
- Подключён общий timeline в экран архива заказов (`archive_orders_screen.dart`) и в экран редактирования/создания заказа (`edit_order_screen.dart`) через модальные листы, при этом legacy-текстовые комментарии рендерятся как обычные `TaskComment` (без attachments) для обратной совместимости. 
- Добавлен тест `test/modules/orders/order_comments_timeline_integration_test.dart`, который проверяет рендер одного комментария с вложением на двух «хост»-экранах (архив и редактирование) чтобы зафиксировать визуальное поведение.

### Testing
- Добавлены integration-style widget tests `test/modules/orders/order_comments_timeline_integration_test.dart` (созданы, но не исполнялись в CI здесь). 
- Попытки выполнить `dart format` и `flutter test` в этой среде завершились ошибкой из-за отсутствия SDK (`dart: command not found`, `flutter: command not found`). 
- Компоненты и тесты добавлены в репозиторий и готовы к запуску в среде с установленным Flutter/Dart; форматирование и тестовый прогон следует выполнить в CI/локально.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c42b7b72c832f8d124a959d853e01)