### PR TITLE
Reorder ink-stage finalization flow in tasks_screen

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5050,6 +5050,9 @@ class _TasksScreenState extends State<TasksScreen>
     return raw;
   }
 
+  /// For ink-confirmation stages, finalization must run in strict order:
+  /// quantity input -> ink adjustment -> completion RPC. Any cancel/close
+  /// on intermediate steps exits early without completing the stage.
   Future<void> _finalizeTask(
     TaskModel task, {
     _QuantityInput? initialQtyInput,
@@ -5058,6 +5061,40 @@ class _TasksScreenState extends State<TasksScreen>
         _workplaceUnit(context.read<PersonnelProvider>(), task.stageId);
     List<Map<String, dynamic>> paints = const <Map<String, dynamic>>[];
     _QuantityInput? qtyInput = initialQtyInput;
+    final stageMode = _execModeForUser(task, widget.employeeId);
+    final isSeparateFinalizeWithoutPrefilledQty =
+        stageMode == ExecutionMode.separate && qtyInput == null;
+
+    if (!isSeparateFinalizeWithoutPrefilledQty) {
+      while (qtyInput == null) {
+        final result = await _askQuantity(
+          context,
+          unit: unitLabel,
+          allowPaperEdit: true,
+          initialQuantity: _initialMeterQuantityForTask(task, unitLabel),
+          order: _orderById(task.orderId),
+          task: task,
+        );
+        if (result == null) return;
+        if (!result.openPaperEditor) {
+          qtyInput = result;
+          break;
+        }
+        final order = _orderById(task.orderId);
+        if (order == null) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Не удалось найти заказ для редактирования бумаги.'),
+              ),
+            );
+          }
+          return;
+        }
+        await _openPaperEditDialog(order);
+      }
+    }
+
     if (_isInkConfirmationStage(task)) {
       final repo = OrdersRepository();
       List<Map<String, dynamic>> initialPaints = const <Map<String, dynamic>>[];
@@ -5134,11 +5171,13 @@ class _TasksScreenState extends State<TasksScreen>
             .map((pending) => pending.orderId.trim())
             .where((id) => id.isNotEmpty)
             .toSet();
-        final pendingOrderLabels = await _loadReadableOrderLabelsByIds(pendingOrderIds);
+        final pendingOrderLabels =
+            await _loadReadableOrderLabelsByIds(pendingOrderIds);
         final pendingPaints = pendingWriteoffs.map((pending) {
           final row = pending.toMap();
-          final readableOrderLabel = pendingOrderLabels[pending.orderId.trim()] ??
-              _buildReadableOrderLabel(row, fallbackId: pending.orderId);
+          final readableOrderLabel =
+              pendingOrderLabels[pending.orderId.trim()] ??
+                  _buildReadableOrderLabel(row, fallbackId: pending.orderId);
           return row
             ..addAll({
               'source': 'pending',
@@ -5178,7 +5217,8 @@ class _TasksScreenState extends State<TasksScreen>
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(
-                  content: Text('Не удалось найти заказ для редактирования красок.'),
+                  content:
+                      Text('Не удалось найти заказ для редактирования красок.'),
                 ),
               );
             }
@@ -5197,7 +5237,8 @@ class _TasksScreenState extends State<TasksScreen>
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(
-                  content: Text('Не удалось найти заказ для редактирования бумаги.'),
+                  content:
+                      Text('Не удалось найти заказ для редактирования бумаги.'),
                 ),
               );
             }
@@ -5209,40 +5250,6 @@ class _TasksScreenState extends State<TasksScreen>
         mutablePaints = dialogResult.paints;
         paints = mutablePaints;
         break;
-      }
-    }
-
-    final stageMode = _execModeForUser(task, widget.employeeId);
-    final isSeparateFinalizeWithoutPrefilledQty =
-        stageMode == ExecutionMode.separate && qtyInput == null;
-
-    if (!isSeparateFinalizeWithoutPrefilledQty) {
-      while (qtyInput == null) {
-        final result = await _askQuantity(
-          context,
-          unit: unitLabel,
-          allowPaperEdit: true,
-          initialQuantity: _initialMeterQuantityForTask(task, unitLabel),
-          order: _orderById(task.orderId),
-          task: task,
-        );
-        if (result == null) return;
-        if (!result.openPaperEditor) {
-          qtyInput = result;
-          break;
-        }
-        final order = _orderById(task.orderId);
-        if (order == null) {
-          if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('Не удалось найти заказ для редактирования бумаги.'),
-              ),
-            );
-          }
-          return;
-        }
-        await _openPaperEditDialog(order);
       }
     }
 


### PR DESCRIPTION
### Motivation
- Обеспечить строгое требование порядка шагов при финализации ink-confirmation этапа: сначала ввод количества, затем диалог корректировки краски, и только потом вызов RPC завершения.
- Сохранить атомарность операции: при отмене/закрытии любого шага не совершать завершение стадии и не менять статус задачи.
- Убедиться, что передаваемое в RPC `quantityDone` приходит из реально введённого значения.

### Description
- Перемещён блок запроса количества (`_askQuantity`) в начало `_finalizeTask` для ink-этапов, чтобы ввод количества выполнялся до показа `_showInkAdjustDialog`.
- Сохранена логика ранних выходов: если `_askQuantity` или `_showInkAdjustDialog` вернутое значение `null` (отмена/закрытие), функция делает `return` и не вызывает `OrdersRepository.completeFlexPrintingStage`.
- `quantityDone` по-прежнему передаётся в `OrdersRepository.completeFlexPrintingStage` из `qtyInput?.commentText`, то есть из введённого пользователем значения после перестановки шагов.
- Добавлен/обновлён док-комментарий у `_finalizeTask`, явно документирующий обязательный порядок: quantity -> ink adjustment -> completion RPC.

### Testing
- Выполнена проверка изменений с помощью `git diff -- lib/modules/tasks/tasks_screen.dart` (успешно).
- Выполнена попытка автоформатирования `dart format lib/modules/tasks/tasks_screen.dart`, которая завершилась ошибкой из-за отсутствия `dart` в окружении (`/bin/bash: line 1: dart: command not found`).
- Изменения зафиксированы коммитом (`git commit`) успешно.
- Замечание: автотесты/юнит-тесты проекта не запускались в этом PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4b0ea268832f96d228840a891969)