### PR TITLE
Unify order comments data-source and timeline UI across order screens

### DIFF
--- a/lib/modules/orders/archive_orders_screen.dart
+++ b/lib/modules/orders/archive_orders_screen.dart
@@ -8,7 +8,6 @@ import 'edit_order_screen.dart';
 import 'id_format.dart';
 import 'order_timeline_dialog.dart';
 import 'order_comments_timeline.dart';
-import '../tasks/task_model.dart';
 
 /// Экран архива заказов. Показывает завершённые заказы с поиском и
 /// возможностью переключения вида (список/карточки). Из архива можно
@@ -88,23 +87,12 @@ class _ArchiveOrdersScreenState extends State<ArchiveOrdersScreen> {
 
 
   Future<void> _showComments(BuildContext context, OrderModel o) async {
-    final legacy = o.comments.trim();
-    final comments = legacy.isEmpty
-        ? const <TaskComment>[]
-        : [
-            TaskComment(
-              id: 'legacy-${o.id}',
-              userId: '',
-              text: legacy,
-              timestamp: o.orderDate,
-            ),
-          ];
     await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       builder: (_) => SizedBox(
         height: MediaQuery.of(context).size.height * 0.6,
-        child: OrderCommentsTimeline(comments: comments, attachmentsByComment: const {}),
+        child: OrderCommentsSection(orderId: o.id, legacyText: o.comments),
       ),
     );
   }

--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -36,7 +36,6 @@ import '../common/pdf_view_screen.dart';
 import '../../utils/media_viewer.dart';
 import '../../utils/enter_key_behavior.dart';
 import 'order_comments_timeline.dart';
-import '../tasks/task_model.dart';
 
 /// Экран редактирования или создания заказа.
 /// Если [order] передан, экран открывается для редактирования существующего заказа.
@@ -3712,10 +3711,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                   isScrollControlled: true,
                   builder: (_) => SizedBox(
                     height: MediaQuery.of(context).size.height * 0.6,
-                    child: OrderCommentsTimeline(
-                      comments: comments,
-                      attachmentsByComment: const {},
-                    ),
+                    child: OrderCommentsSection(orderId: order.id, legacyText: order.comments),
                   ),
                 );
               },
@@ -3773,10 +3769,7 @@ class _EditOrderScreenState extends State<EditOrderScreen> {
                   isScrollControlled: true,
                   builder: (_) => SizedBox(
                     height: MediaQuery.of(context).size.height * 0.6,
-                    child: OrderCommentsTimeline(
-                      comments: comments,
-                      attachmentsByComment: const {},
-                    ),
+                    child: OrderCommentsSection(orderId: order.id, legacyText: order.comments),
                   ),
                 );
               },

--- a/lib/modules/orders/order_comments_timeline.dart
+++ b/lib/modules/orders/order_comments_timeline.dart
@@ -2,6 +2,95 @@ import 'package:flutter/material.dart';
 
 import '../tasks/task_model.dart';
 import 'order_comment_attachment.dart';
+import 'order_comments_repository.dart';
+
+class OrderCommentsSection extends StatefulWidget {
+  const OrderCommentsSection({
+    super.key,
+    required this.orderId,
+    this.legacyText = '',
+    this.repository,
+    this.commentFilter,
+  });
+
+  final String orderId;
+  final String legacyText;
+  final OrderCommentsRepository? repository;
+  final bool Function(TaskComment comment)? commentFilter;
+
+  @override
+  State<OrderCommentsSection> createState() => _OrderCommentsSectionState();
+}
+
+class _OrderCommentsSectionState extends State<OrderCommentsSection> {
+  late final OrderCommentsRepository _repository;
+  late Future<_OrderCommentsBundle> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _repository = widget.repository ?? OrderCommentsRepository();
+    _future = _load();
+  }
+
+  Future<_OrderCommentsBundle> _load() async {
+    final comments = await _repository.loadComments(widget.orderId);
+    final filtered = widget.commentFilter == null
+        ? comments
+        : comments.where(widget.commentFilter!).toList();
+    final attachments = await _repository
+        .loadAttachmentsByCommentIds(filtered.map((e) => e.id).toList());
+    final byComment = <String, List<OrderCommentAttachment>>{};
+    for (final item in attachments) {
+      byComment.putIfAbsent(item.commentId, () => <OrderCommentAttachment>[]).add(item);
+    }
+    if (filtered.isNotEmpty) {
+      return _OrderCommentsBundle(filtered, byComment);
+    }
+    final legacy = widget.legacyText.trim();
+    if (legacy.isEmpty) {
+      return const _OrderCommentsBundle([], {});
+    }
+    return _OrderCommentsBundle(
+      [
+        TaskComment(
+          id: 'legacy-${widget.orderId}',
+          userId: '',
+          text: legacy,
+          timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+        ),
+      ],
+      const {},
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<_OrderCommentsBundle>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return Center(child: Text('Ошибка загрузки комментариев: ${snapshot.error}'));
+        }
+        final data = snapshot.data ?? const _OrderCommentsBundle([], {});
+        return OrderCommentsTimeline(
+          comments: data.comments,
+          attachmentsByComment: data.attachmentsByComment,
+        );
+      },
+    );
+  }
+}
+
+class _OrderCommentsBundle {
+  const _OrderCommentsBundle(this.comments, this.attachmentsByComment);
+
+  final List<TaskComment> comments;
+  final Map<String, List<OrderCommentAttachment>> attachmentsByComment;
+}
 
 class OrderCommentsTimeline extends StatelessWidget {
   const OrderCommentsTimeline({super.key, required this.comments, required this.attachmentsByComment});

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -30,6 +30,7 @@ import '../tasks/task_completion_rules.dart';
 // УДАЛЕНО: import '../production_planning/planned_stage_model.dart';
 import '../personnel/employee_model.dart';
 import '../personnel/personnel_provider.dart';
+import '../orders/order_comments_timeline.dart';
 import '../../services/app_auth.dart';
 import '../orders/order_details_card.dart';
 
@@ -699,51 +700,13 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
               style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: 6),
-            if (comments.isEmpty)
-              const Text(
-                'Нет комментариев',
-                style: TextStyle(color: Colors.grey),
-              )
-            else
-              Column(
-                children: [
-                  for (final c in comments)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 2),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Icon(
-                            c.type == 'problem'
-                                ? Icons.error_outline
-                                : c.type == 'pause'
-                                    ? Icons.pause_circle_outline
-                                    : Icons.info_outline,
-                            size: 18,
-                            color: c.type == 'problem'
-                                ? Colors.redAccent
-                                : c.type == 'pause'
-                                    ? Colors.orange
-                                    : Colors.blueGrey,
-                          ),
-                          const SizedBox(width: 4),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                _buildCommentMeta(c, personnel.employees),
-                                Text(
-                                  _renderCommentText(c, personnel.employees),
-                                  style: const TextStyle(fontSize: 14),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                ],
+            SizedBox(
+              height: 220,
+              child: OrderCommentsTimeline(
+                comments: comments,
+                attachmentsByComment: const {},
               ),
+            ),
             const Divider(height: 24),
             const Text(
               'Этапы производства',

--- a/test/modules/orders/order_comments_timeline_integration_test.dart
+++ b/test/modules/orders/order_comments_timeline_integration_test.dart
@@ -1,8 +1,24 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:app/modules/orders/order_comment_attachment.dart';
+import 'package:app/modules/orders/order_comments_repository.dart';
 import 'package:app/modules/orders/order_comments_timeline.dart';
 import 'package:app/modules/tasks/task_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeOrderCommentsRepository extends OrderCommentsRepository {
+  _FakeOrderCommentsRepository(this._comments, this._attachments);
+
+  final List<TaskComment> _comments;
+  final List<OrderCommentAttachment> _attachments;
+
+  @override
+  Future<List<TaskComment>> loadComments(String orderId) async => _comments;
+
+  @override
+  Future<List<OrderCommentAttachment>> loadAttachmentsByCommentIds(List<String> commentIds) async {
+    return _attachments.where((a) => commentIds.contains(a.commentId)).toList();
+  }
+}
 
 void main() {
   final comment = TaskComment(
@@ -27,24 +43,40 @@ void main() {
   Widget host(String title) => MaterialApp(
         home: Scaffold(
           appBar: AppBar(title: Text(title)),
-          body: OrderCommentsTimeline(
-            comments: [comment],
-            attachmentsByComment: {
-              'c1': [attachment],
-            },
+          body: OrderCommentsSection(
+            orderId: 'o1',
+            repository: _FakeOrderCommentsRepository([comment], [attachment]),
           ),
         ),
       );
 
   testWidgets('рендерится одинаково на экране архива', (tester) async {
     await tester.pumpWidget(host('Архив'));
+    await tester.pumpAndSettle();
     expect(find.text('Тестовый комментарий'), findsOneWidget);
     expect(find.text('spec.pdf'), findsOneWidget);
   });
 
   testWidgets('рендерится одинаково на экране редактирования', (tester) async {
     await tester.pumpWidget(host('Редактирование'));
+    await tester.pumpAndSettle();
     expect(find.text('Тестовый комментарий'), findsOneWidget);
     expect(find.text('spec.pdf'), findsOneWidget);
+  });
+
+  testWidgets('комментарий без вложений рендерится как текст', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OrderCommentsSection(
+            orderId: 'o2',
+            legacyText: 'Legacy-only comment',
+            repository: _FakeOrderCommentsRepository(const [], const []),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Legacy-only comment'), findsOneWidget);
   });
 }


### PR DESCRIPTION
### Motivation
- Уменьшить дублирование и рассинхрон UI/логики комментариев, предоставив единый data-source и общий рендер для комментариев и их вложений; сохранить поведение для legacy plain-text комментариев; упростить подключение в нескольких местах (архив/редактирование/производство).

### Description
- Добавлен компонент-обёртка `OrderCommentsSection` в `lib/modules/orders/order_comments_timeline.dart`, который использует `OrderCommentsRepository` для загрузки комментариев по `orderId` и загрузки вложений по `commentId`, затем рендерит их через общие виджеты `OrderCommentsTimeline`, `OrderCommentItem`, `AttachmentPreview` и `AttachmentViewerScreen`.
- Заменён ad-hoc рендер legacy-комментариев в `lib/modules/orders/archive_orders_screen.dart` и в двух местах в `lib/modules/orders/edit_order_screen.dart` на `OrderCommentsSection(orderId: ..., legacyText: ...)` для единого поведения диалога комментариев.
- В модуле производственного процесса `lib/modules/production/production_details_screen.dart` комментарии на карточке производства теперь отображаются тем же `OrderCommentsTimeline` для согласованного визуального представления.
- Добавлен/обновлён интеграционный widget-тест `test/modules/orders/order_comments_timeline_integration_test.dart`, включающий ` _FakeOrderCommentsRepository`, проверяющий рендер в нескольких контекстах и кейс legacy-комментария без вложений.

### Testing
- Новые widget-тесты добавлены в `test/modules/orders/order_comments_timeline_integration_test.dart` (they exercise rendering with a fake repository and the legacy-only case). 
- Попытки запустить форматирование и тесты (`dart format` и `flutter test`) не удались в этом окружении, так как `dart`/`flutter` CLI отсутствуют в PATH, поэтому автоматические тесты не выполнялись здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4d2983dc832f8227e5a80fb35b2e)