### PR TITLE
Adjust order label fallbacks and pending prefix in tasks writeoff UI

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4577,8 +4577,7 @@ class _TasksScreenState extends State<TasksScreen>
     if (orderName.isNotEmpty) return orderName;
     if (orderNumber.isNotEmpty) return '№$orderNumber';
 
-    final fallback = (fallbackId ?? '').trim();
-    return fallback.isEmpty ? 'Предыдущий заказ' : 'Заказ';
+    return 'Заказ без указанного клиента';
   }
 
   Future<Map<String, String>> _loadReadableOrderLabelsByIds(
@@ -4739,7 +4738,7 @@ class _TasksScreenState extends State<TasksScreen>
               row,
               const ['order_label', 'orderLabel', 'order_name'],
             )
-          : (orderId.isEmpty ? 'Текущий заказ' : orderId),
+          : 'Заказ без указанного клиента',
       paintId: _stringFromRow(row, const ['paint_id', 'material_id', 'paintId']),
       paintName:
           _stringFromRow(row, const ['paint_name', 'name', 'paintName']).isEmpty
@@ -4797,7 +4796,7 @@ class _TasksScreenState extends State<TasksScreen>
                         crossAxisAlignment: WrapCrossAlignment.center,
                         children: [
                           Text(
-                            'Заказ: ${row.orderLabel}',
+                            'Заказ: ${row.isPendingSource ? 'Предыдущий заказ: ${row.orderLabel}' : row.orderLabel}',
                             style: const TextStyle(fontWeight: FontWeight.w600),
                           ),
                           Text('Краска: ${row.paintName}'),


### PR DESCRIPTION
### Motivation
- Make user-facing order labels human-friendly and consistent by avoiding raw UUIDs, providing a clear fallback when customer/name/number are missing, and adding an explicit pending-order prefix for previous-order rows.

### Description
- Change the final fallback in ` _buildReadableOrderLabel` to return `Заказ без указанного клиента` instead of exposing `fallbackId` or a generic label.
- Stop using raw `orderId` as a fallback in `_paintWriteoffRowFromMap` so `orderLabel` no longer contains UUIDs and defaults to `Заказ без указанного клиента` when no label is present.
- Prepend the display for pending writeoff rows in `_buildPaintWriteoffSection` with the prefix `Предыдущий заказ: {label}` while keeping the unified `№{number} — {customer}` format when a number and customer are available.

### Testing
- Ran `git diff -- lib/modules/tasks/tasks_screen.dart` to verify the changes are present, which showed the intended edits.
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but it failed in this environment with `/bin/bash: dart: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4da38da4832f9266eae480d4a479)