### PR TITLE
Prefer order.customer in paint writeoff dialog

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4547,7 +4547,7 @@ class _TasksScreenState extends State<TasksScreen>
 
   String _orderDisplayNameForWriteoff(OrderModel order) {
     final customer = order.customer.trim();
-    if (customer.isNotEmpty && !_looksLikeOrderCode(customer)) {
+    if (customer.isNotEmpty) {
       return customer;
     }
     final productName = order.product.type.trim();


### PR DESCRIPTION
### Motivation
- Ensure the paint writeoff dialog displays the order's customer name (including numeric names like `15`) instead of erroneously treating some customer values as order codes and falling back to product text.

### Description
- Remove the `_looksLikeOrderCode` check when selecting `order.customer` in `_orderDisplayNameForWriteoff` so the function returns `order.customer` whenever it is non-empty while keeping existing fallbacks to product type and `'Без названия'`.

### Testing
- Attempted to run `flutter analyze lib/modules/tasks/tasks_screen.dart` but analysis could not be performed in this environment because `flutter` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5c03c6a8832f8658d11b0fbd15df)