### PR TITLE
Измерение краски в граммах в диалоге изменения красок

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1598,6 +1598,13 @@ class _TasksScreenState extends State<TasksScreen>
     return double.tryParse((value ?? '').toString().trim().replaceAll(',', '.'));
   }
 
+
+  String _formatPaintGramsFromKg(double? valueKg) {
+    if (valueKg == null || valueKg <= 0) return '';
+    final grams = valueKg * 1000;
+    return _formatAmountForDialog(grams);
+  }
+
   String _formatPaintKg(double? value) {
     if (value == null || value <= 0) return '';
     if (value == value.roundToDouble()) return value.toStringAsFixed(0);
@@ -1686,7 +1693,7 @@ class _TasksScreenState extends State<TasksScreen>
             }
           ];
     final qtyControllers = <TextEditingController>[
-      for (final row in selected) TextEditingController(text: _formatPaintKg(_paintQtyKgFromRow(row))),
+      for (final row in selected) TextEditingController(text: _formatPaintGramsFromKg(_paintQtyKgFromRow(row))),
     ];
     final infoControllers = <TextEditingController>[
       for (final row in selected) TextEditingController(text: (row['info'] ?? '').toString()),
@@ -1775,7 +1782,7 @@ class _TasksScreenState extends State<TasksScreen>
                                 decimal: true,
                               ),
                               decoration:
-                                  const InputDecoration(labelText: 'Кол-во, кг'),
+                                  const InputDecoration(labelText: 'Кол-во, г'),
                               validator: (value) {
                                 final qty = double.tryParse((value ?? '')
                                     .trim()
@@ -1886,7 +1893,8 @@ class _TasksScreenState extends State<TasksScreen>
                           });
                           return;
                         }
-                        final qtyKg = double.parse(qtyControllers[i].text.trim().replaceAll(',', '.'));
+                        final qtyGrams = double.parse(qtyControllers[i].text.trim().replaceAll(',', '.'));
+                        final qtyKg = qtyGrams / 1000;
                         nextRows.add({
                           'order_id': latest.id,
                           'name': paintName,


### PR DESCRIPTION
### Motivation
- Изменить ввод количества краски в диалоге списания/изменения красок на граммы вместо килограммов для этапа флексопечати, сохранив совместимость с текущей моделью данных.

### Description
- Добавлен хелпер `String _formatPaintGramsFromKg(double? valueKg)` для форматирования начального значения в граммах, основанного на `qty_kg`.
- Поля ввода и контроллеры инициализируются теперь через `TextEditingController(text: _formatPaintGramsFromKg(_paintQtyKgFromRow(row)))` чтобы показывать граммы пользователю.
- Текст поля изменён с `Кол-во, кг` на `Кол-во, г` и логика валидации оставлена прежней для числового ввода.
- При сохранении значение из поля парсится как граммы и преобразуется в килограммы (`qtyKg = qtyGrams / 1000`) перед записи в ключ `qty_kg` для обратной совместимости.

### Testing
- Попытка запустить автоформатирование через `dart format` не выполнена, так как в окружении отсутствует `dart` (`/bin/bash: line 1: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4b3b401c832faa6ba38f5003964f)