### PR TITLE
Prefer customer name for flexo writeoff labels and hide unlabeled pending writeoffs

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4558,11 +4558,7 @@ class _TasksScreenState extends State<TasksScreen>
     if (customer.isNotEmpty && !_looksLikeOrderCode(customer)) {
       return customer;
     }
-    final productName = order.product.type.trim();
-    if (productName.isNotEmpty && !_looksLikeOrderCode(productName)) {
-      return productName;
-    }
-    return 'Без названия';
+    return 'Заказ без указанного клиента';
   }
 
   String _orderReferenceForWriteoff(OrderModel order) {
@@ -4572,19 +4568,7 @@ class _TasksScreenState extends State<TasksScreen>
     String pick(List<String> keys) => _stringFromRow(row, keys);
 
     final customer = pick(const ['customer_name', 'client_name', 'customer']);
-    final orderName = pick(const ['order_name', 'title', 'name']);
-    final orderNumber = pick(const ['order_number', 'number', 'order_no']);
-
-    if (orderNumber.isNotEmpty && customer.isNotEmpty) {
-      return '№$orderNumber — $customer';
-    }
-    if (orderNumber.isNotEmpty && orderName.isNotEmpty) {
-      return '№$orderNumber — $orderName';
-    }
     if (customer.isNotEmpty) return customer;
-    if (orderName.isNotEmpty) return orderName;
-    if (orderNumber.isNotEmpty) return '№$orderNumber';
-
     return 'Заказ без указанного клиента';
   }
 
@@ -5190,7 +5174,14 @@ class _TasksScreenState extends State<TasksScreen>
               .toSet();
           final pendingOrderLabels =
               await _loadReadableOrderLabelsByIds(pendingOrderIds);
-          return pendingWriteoffs.map((pending) {
+          return pendingWriteoffs.where((pending) {
+            final label = pendingOrderLabels[pending.orderId.trim()] ??
+                _buildReadableOrderLabel(
+                  pending.toMap(),
+                  fallbackId: pending.orderId,
+                );
+            return label != 'Заказ без указанного клиента';
+          }).map((pending) {
             final row = pending.toMap();
             final readableOrderLabel =
                 pendingOrderLabels[pending.orderId.trim()] ??


### PR DESCRIPTION
### Motivation
- The paint writeoff dialog sometimes showed product types or generic placeholders instead of the actual заказчик, which is confusing for operators. 
- Pending writeoff rows with no customer produced entries like "Заказ без указанного клиента" that should not be shown in the "Краски, ожидающие списания" section. 
- Labels could reset after reopening the paint editor; the display logic should be stable and preserve customer names after edits.

### Description
- Updated the writeoff label generation to prefer only the order `customer` and removed fallbacks to product type, order title or order number in `lib/modules/tasks/tasks_screen.dart`.  
- Made `_buildReadableOrderLabel` return the `customer` when present and otherwise return `'Заказ без указанного клиента'`, simplifying the readable label logic.  
- Filtered out pending writeoff entries whose resolved label equals `'Заказ без указанного клиента'` so that unlabeled pending rows are not included in the "pending" list used by the ink-adjust dialog.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but it failed because the environment lacks the `dart` binary.  
- Verified changes by inspecting the diff with `git diff -- lib/modules/tasks/tasks_screen.dart` which shows the applied edits.  
- Committed the change successfully with `git commit -m "Fix flexo writeoff order labels to use customer names"` and no automated unit/integration tests were executed in this environment due to missing Flutter/Dart SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4d64bff4832f8bf735c05ab53c60)