### PR TITLE
Исправление подписей заказов в диалоге списания красок после флексопечати

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4553,16 +4553,21 @@ class _TasksScreenState extends State<TasksScreen>
         label.contains('flexo');
   }
 
+  String _fallbackOrderLabelById(String orderId) {
+    final normalizedId = orderId.trim();
+    if (normalizedId.isEmpty) return 'Заказ';
+    final shortId = normalizedId.length > 8
+        ? normalizedId.substring(0, 8).toUpperCase()
+        : normalizedId.toUpperCase();
+    return 'Заказ №$shortId';
+  }
+
   String _orderDisplayNameForWriteoff(OrderModel order) {
     final customer = order.customer.trim();
     if (customer.isNotEmpty && !_looksLikeOrderCode(customer)) {
       return customer;
     }
-    final productName = order.product.type.trim();
-    if (productName.isNotEmpty && !_looksLikeOrderCode(productName)) {
-      return productName;
-    }
-    return 'Без названия';
+    return _fallbackOrderLabelById(order.id);
   }
 
   String _orderReferenceForWriteoff(OrderModel order) {
@@ -4582,10 +4587,18 @@ class _TasksScreenState extends State<TasksScreen>
       return '№$orderNumber — $orderName';
     }
     if (customer.isNotEmpty) return customer;
-    if (orderName.isNotEmpty) return orderName;
     if (orderNumber.isNotEmpty) return '№$orderNumber';
 
-    return 'Заказ без указанного клиента';
+    final fallback = (fallbackId ?? '').trim();
+    if (fallback.isNotEmpty) {
+      final localOrder = _orderById(fallback);
+      if (localOrder != null) {
+        return _orderReferenceForWriteoff(localOrder);
+      }
+      return _fallbackOrderLabelById(fallback);
+    }
+
+    return 'Заказ';
   }
 
   Future<Map<String, String>> _loadReadableOrderLabelsByIds(
@@ -4746,7 +4759,11 @@ class _TasksScreenState extends State<TasksScreen>
               row,
               const ['order_label', 'orderLabel', 'order_name'],
             )
-          : 'Заказ без указанного клиента',
+          : (() {
+              final localOrder = _orderById(orderId);
+              if (localOrder != null) return _orderReferenceForWriteoff(localOrder);
+              return _fallbackOrderLabelById(orderId);
+            })(),
       paintId: _stringFromRow(row, const ['paint_id', 'material_id', 'paintId']),
       paintName:
           _stringFromRow(row, const ['paint_name', 'name', 'paintName']).isEmpty


### PR DESCRIPTION
### Motivation
- В диалоге списания красок после флексопечати в UI показывались типы продукта или «Заказ без указанного клиента» вместо имени заказчика, а подписи могли «слетать» после изменения красок. 
- Нужно показать приоритетно имя клиента и обеспечить стабильный fallback, когда серверный `order_label` отсутствует, чтобы подписи не менялись после повторной загрузки.

### Description
- Добавлена функция `_fallbackOrderLabelById` для стабильного fallback-лейбла в формате `Заказ №<short-id>` по ID заказа. 
- ` _orderDisplayNameForWriteoff` теперь возвращает имя клиента при наличии и использует fallback по ID вместо `product.type` и строки «Без названия». 
- `_buildReadableOrderLabel` обновлён: при отсутствии явного `order_label` он пытается получить локальный заказ через `_orderById(fallbackId)` и в противном случае использует `_fallbackOrderLabelById`. 
- Формирование `FlexPaintWriteoffRow.orderLabel` изменено так, чтобы при отсутствии `order_label` брать локальную подпись заказа или стабильный fallback по ID, что устраняет «слетание» подписей после редактирования красок.

### Testing
- Попытка запустить `dart format lib/modules/tasks/tasks_screen.dart` завершилась ошибкой, так как `dart` отсутствует в окружении (форматирование не выполнено). 
- В ходе этого rollout автотесты не запускались и других автоматических проверок не выполнялось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4f71844c832f9b5bca0f7edfc89d)