### PR TITLE
Improve order label fallbacks and display logic in tasks screen

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4553,16 +4553,21 @@ class _TasksScreenState extends State<TasksScreen>
         label.contains('flexo');
   }
 
+  String _fallbackOrderLabelById(String orderId) {
+    final normalizedId = orderId.trim();
+    if (normalizedId.isEmpty) return 'Заказ';
+    final shortId = normalizedId.length > 8
+        ? normalizedId.substring(0, 8).toUpperCase()
+        : normalizedId.toUpperCase();
+    return 'Заказ №$shortId';
+  }
+
   String _orderDisplayNameForWriteoff(OrderModel order) {
     final customer = order.customer.trim();
-    if (customer.isNotEmpty && !_looksLikeOrderCode(customer)) {
+    if (customer.isNotEmpty) {
       return customer;
     }
-    final productName = order.product.type.trim();
-    if (productName.isNotEmpty && !_looksLikeOrderCode(productName)) {
-      return productName;
-    }
-    return 'Без названия';
+    return _fallbackOrderLabelById(order.id);
   }
 
   String _orderReferenceForWriteoff(OrderModel order) {
@@ -4575,17 +4580,22 @@ class _TasksScreenState extends State<TasksScreen>
     final orderName = pick(const ['order_name', 'title', 'name']);
     final orderNumber = pick(const ['order_number', 'number', 'order_no']);
 
-    if (orderNumber.isNotEmpty && customer.isNotEmpty) {
-      return '№$orderNumber — $customer';
-    }
+    if (customer.isNotEmpty) return customer;
     if (orderNumber.isNotEmpty && orderName.isNotEmpty) {
       return '№$orderNumber — $orderName';
     }
-    if (customer.isNotEmpty) return customer;
-    if (orderName.isNotEmpty) return orderName;
     if (orderNumber.isNotEmpty) return '№$orderNumber';
 
-    return 'Заказ без указанного клиента';
+    final fallback = (fallbackId ?? '').trim();
+    if (fallback.isNotEmpty) {
+      final localOrder = _orderById(fallback);
+      if (localOrder != null) {
+        return _orderReferenceForWriteoff(localOrder);
+      }
+      return _fallbackOrderLabelById(fallback);
+    }
+
+    return 'Заказ';
   }
 
   Future<Map<String, String>> _loadReadableOrderLabelsByIds(
@@ -4746,7 +4756,11 @@ class _TasksScreenState extends State<TasksScreen>
               row,
               const ['order_label', 'orderLabel', 'order_name'],
             )
-          : 'Заказ без указанного клиента',
+          : (() {
+              final localOrder = _orderById(orderId);
+              if (localOrder != null) return _orderReferenceForWriteoff(localOrder);
+              return _fallbackOrderLabelById(orderId);
+            })(),
       paintId: _stringFromRow(row, const ['paint_id', 'material_id', 'paintId']),
       paintName:
           _stringFromRow(row, const ['paint_name', 'name', 'paintName']).isEmpty


### PR DESCRIPTION
### Motivation
- Provide consistent, user-friendly order labels when customer/order name fields are missing or contain order codes. 
- Avoid showing ambiguous placeholders like `Заказ без указанного клиента` and generate compact readable identifiers from order IDs. 
- Simplify display name selection by removing brittle checks against order-code-like strings in some cases. 

### Description
- Added helper `String _fallbackOrderLabelById(String orderId)` to produce localized fallback labels such as `Заказ` or `Заказ №<SHORT_ID>`.  
- Changed `_orderDisplayNameForWriteoff` to immediately prefer non-empty `customer` and otherwise use `_fallbackOrderLabelById(order.id)`.  
- Reworked `_buildReadableOrderLabel` to prioritize `customer`, then `№<order_number> — <order_name>`, then `№<order_number>`, and finally resolve a `fallbackId` by looking up a local order via `_orderById` or using `_fallbackOrderLabelById`.  
- Updated construction of `FlexPaintWriteoffRow` so that missing `order_label` falls back to a local order reference via `_orderReferenceForWriteoff` or `_fallbackOrderLabelById(orderId)` instead of the previous static placeholder.  

### Testing
- Ran `flutter analyze` to ensure no static analysis issues; analysis passed.  
- Executed the existing Flutter/Dart test suite (`flutter test`) and existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4f71844c832f9b5bca0f7edfc89d)