### PR TITLE
Allow concurrent packaging with one same-order active stage; bypass queue ordering

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5362,7 +5362,7 @@ class _TasksScreenState extends State<TasksScreen>
     return true;
   }
 
-  bool _hasRealStartConflict({
+bool _hasRealStartConflict({
     required TaskProvider provider,
     required TaskModel task,
     required bool shiftPaused,
@@ -5375,6 +5375,37 @@ class _TasksScreenState extends State<TasksScreen>
     }
     if (_isStageGroupLocked(provider, task)) return true;
     if (shiftPaused) return true;
+
+    final employeeActiveTasks = provider.tasks.where((candidate) {
+      if (candidate.id == task.id) return false;
+      if (!candidate.assignees.contains(widget.employeeId)) return false;
+      if (_isEffectivelyCompleted(candidate)) return false;
+      return _userRunState(candidate, widget.employeeId) == UserRunState.active;
+    }).toList(growable: false);
+
+    if (employeeActiveTasks.isNotEmpty) {
+      final startingPackaging = stage_sequence.isPackagingStage(
+        stageId: task.stageId,
+        stageGroupKey: task.stageGroupKey,
+        stageName: _stageDisplayName(context.read<PersonnelProvider>(), task.stageId),
+      );
+
+      final canPairWithPackagingInSameOrder = startingPackaging &&
+          employeeActiveTasks.length == 1 &&
+          employeeActiveTasks.first.orderId == task.orderId &&
+          !stage_sequence.isPackagingStage(
+            stageId: employeeActiveTasks.first.stageId,
+            stageGroupKey: employeeActiveTasks.first.stageGroupKey,
+            stageName: _stageDisplayName(
+              context.read<PersonnelProvider>(),
+              employeeActiveTasks.first.stageId,
+            ),
+          );
+
+      if (!canPairWithPackagingInSameOrder) {
+        return true;
+      }
+    }
 
     final canStartEarlyPackaging = canStartPackagingOutOfQueue(
       task: task,
@@ -5502,6 +5533,16 @@ class _TasksScreenState extends State<TasksScreen>
       employeeId: widget.employeeId,
       groupResolver: _stageGroupKey,
     );
+
+    final isPackagingNow = stage_sequence.isPackagingStage(
+      stageId: task.stageId,
+      stageGroupKey: task.stageGroupKey,
+      stageName: _stageDisplayName(context.read<PersonnelProvider>(), task.stageId),
+    );
+
+    if (isPackagingNow) {
+      return true;
+    }
 
     // Спец-правило упаковки имеет приоритет над строгой проверкой позиции
     // в очереди рабочего места: если упаковку можно стартовать вне очереди,


### PR DESCRIPTION
### Motivation
- Prevent starting multiple stages for the same employee by default, while providing a single exception for packaging to improve throughput for the packing step.
- Packaging should be startable without enforcing strict workplace queue ordering so packing can begin out-of-order when allowed.

### Description
- Updated `lib/modules/tasks/tasks_screen.dart` so `_hasRealStartConflict` checks for other active tasks owned by `widget.employeeId` and blocks start if any exist, with a single exception for packaging. 
- The exception allows starting packaging when the employee has exactly one active non-packaging task and that task belongs to the same order, using `stage_sequence.isPackagingStage` and `_stageDisplayName` to detect packaging.
- Modified `_isUnlockedByWorkplaceQueue` to return `true` early for packaging tasks so packaging is not blocked by workplace queue position.
- No other business logic or UI changes were touched.

### Testing
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart`, but `dart` was not available in the environment so formatting could not be executed (failed).
- No automated unit or integration tests were executed in this rollout.
- The change was committed successfully and a PR description was created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d564b1320832fb05844814e3aff49)