### PR TITLE
Packaging pairing and queue-unlock logic for task start

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5362,7 +5362,7 @@ class _TasksScreenState extends State<TasksScreen>
     return true;
   }
 
-  bool _hasRealStartConflict({
+bool _hasRealStartConflict({
     required TaskProvider provider,
     required TaskModel task,
     required bool shiftPaused,
@@ -5375,6 +5375,37 @@ class _TasksScreenState extends State<TasksScreen>
     }
     if (_isStageGroupLocked(provider, task)) return true;
     if (shiftPaused) return true;
+
+    final employeeActiveTasks = provider.tasks.where((candidate) {
+      if (candidate.id == task.id) return false;
+      if (!candidate.assignees.contains(widget.employeeId)) return false;
+      if (_isEffectivelyCompleted(candidate)) return false;
+      return _userRunState(candidate, widget.employeeId) == UserRunState.active;
+    }).toList(growable: false);
+
+    if (employeeActiveTasks.isNotEmpty) {
+      final startingPackaging = stage_sequence.isPackagingStage(
+        stageId: task.stageId,
+        stageGroupKey: task.stageGroupKey,
+        stageName: _stageDisplayName(context.read<PersonnelProvider>(), task.stageId),
+      );
+
+      final canPairWithPackagingInSameOrder = startingPackaging &&
+          employeeActiveTasks.length == 1 &&
+          employeeActiveTasks.first.orderId == task.orderId &&
+          !stage_sequence.isPackagingStage(
+            stageId: employeeActiveTasks.first.stageId,
+            stageGroupKey: employeeActiveTasks.first.stageGroupKey,
+            stageName: _stageDisplayName(
+              context.read<PersonnelProvider>(),
+              employeeActiveTasks.first.stageId,
+            ),
+          );
+
+      if (!canPairWithPackagingInSameOrder) {
+        return true;
+      }
+    }
 
     final canStartEarlyPackaging = canStartPackagingOutOfQueue(
       task: task,
@@ -5494,21 +5525,20 @@ class _TasksScreenState extends State<TasksScreen>
     if (index <= 0) return true;
 
     final bool strictSequentialByPreviousCompletion =
-        workplace != null && workplace.executionMode != WorkplaceExecutionMode.separate;
-    final canStartPackagingEarlyNow = canStartPackagingOutOfQueue(
-      task: task,
-      tasks: taskProvider,
-      personnel: context.read<PersonnelProvider>(),
-      employeeId: widget.employeeId,
-      groupResolver: _stageGroupKey,
+        workplace != null &&
+        workplace.executionMode != WorkplaceExecutionMode.separate;
+
+    final isPackagingNow = stage_sequence.isPackagingStage(
+      stageId: task.stageId,
+      stageGroupKey: task.stageGroupKey,
+      stageName: _stageDisplayName(context.read<PersonnelProvider>(), task.stageId),
     );
 
-    // Спец-правило упаковки имеет приоритет над строгой проверкой позиции
-    // в очереди рабочего места: если упаковку можно стартовать вне очереди,
-    // не блокируем запуск из-за того, что задача не первая.
-    if (canStartPackagingEarlyNow) {
+    if (isPackagingNow) {
       return true;
     }
+
+    // Вне очереди можно стартовать только упаковку.
 
     for (var i = 0; i < index; i++) {
       final previous = queued[i];
@@ -5518,8 +5548,8 @@ class _TasksScreenState extends State<TasksScreen>
             previous.comments.any((c) => c.type == 'problem');
         // Бизнес-правило для "Одиночная/Совместная": следующий заказ можно
         // стартовать только после завершения предыдущего, либо если он в "Проблеме".
-        // Исключение: для последнего этапа упаковки разрешаем ранний старт,
-        // когда непосредственный предыдущий этап уже начат.
+        // Вне очереди здесь не стартуем — это разрешено только для упаковки
+        // отдельным ранним выходом выше.
         if (!previousCompleted && !previousInProblem) {
           return false;
         }


### PR DESCRIPTION
### Motivation

- Prevent users from starting a task when they already have other active tasks, while allowing an explicit exception for packaging that should be able to pair with a single active non-packaging task in the same order. 
- Restrict out-of-queue starts so that only packaging stages can bypass workplace queue ordering. 
- Clarify and simplify the workplace queue unlock and start-conflict checks to match business rules around packaging and sequential execution.

### Description

- Added detection of `employeeActiveTasks` in ` _hasRealStartConflict` to block starting when the employee already has active tasks, except when starting a packaging stage that can pair with a single active non-packaging task in the same order. 
- Implemented the pairing rule by checking `stage_sequence.isPackagingStage` for the starting task and ensuring the only active task is from the same order and is not a packaging stage. 
- Reworked ` _isUnlockedByWorkplaceQueue` to use an `isPackagingNow` check and allow out-of-queue start only for packaging tasks, removing the previous generic `canStartPackagingOutOfQueue` bypass in the queue loop. 
- Cleaned up related conditionals and comments, and standardized calls to `_stageDisplayName(context.read<PersonnelProvider>(), ...)` when resolving packaging stages.

### Testing

- Ran the analyzer and static checks; no issues reported. 
- Executed the unit and widget tests covering `TasksScreen` and queue/packaging logic; all tests passed. 
- Ran the app integration smoke tests for task start flows; packaging start and queue behaviors were validated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d564b1320832fb05844814e3aff49)