### PR TITLE
Allow packaging start without strict stage order

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5407,6 +5407,12 @@ bool _hasRealStartConflict({
       }
     }
 
+    final isPackagingNow = stage_sequence.isPackagingStage(
+      stageId: task.stageId,
+      stageGroupKey: task.stageGroupKey,
+      stageName: _stageDisplayName(context.read<PersonnelProvider>(), task.stageId),
+    );
+
     final canStartEarlyPackaging = canStartPackagingOutOfQueue(
       task: task,
       tasks: provider,
@@ -5414,7 +5420,8 @@ bool _hasRealStartConflict({
       employeeId: widget.employeeId,
       groupResolver: _stageGroupKey,
     );
-    if (!_canRunOutOfStageSequence(task) &&
+    if (!isPackagingNow &&
+        !_canRunOutOfStageSequence(task) &&
         !_isFirstPendingStage(
           provider,
           context.read<PersonnelProvider>(),


### PR DESCRIPTION
### Motivation
- Packaging stages must be allowed to start out of strict queue order while other stages remain subject to the existing single-active-worker rules.
- Preserve the current exception that allows an employee to run two stages simultaneously only when starting packaging for the same order while a pre-packaging stage is already active.

### Description
- Relaxed the start-conflict check in `_hasRealStartConflict` so packaging stages bypass the strict `_canRunOutOfStageSequence` / `_isFirstPendingStage` enforcement by adding an `isPackagingNow` check in `lib/modules/tasks/tasks_screen.dart`.
- Kept the existing `canPairWithPackagingInSameOrder` logic that permits one special two-stage parallel case for the same order.
- Change is a small local edit: added the `isPackagingNow` computation and updated the conditional that returns early when starts should be blocked.

### Testing
- Ran `git -C /workspace/app status --short` to verify local changes were staged and it succeeded.
- Attempted to run `dart format lib/modules/tasks/tasks_screen.dart` but the command failed because `dart` is not available in the environment (`/bin/bash: line 1: dart: command not found`).
- Committed the change with `git -C /workspace/app commit` which succeeded and produced a one-file commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5a3eb63c832facc254997ba2f95f)