### PR TITLE
Fix packaging start guard in task start handler

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5407,6 +5407,12 @@ bool _hasRealStartConflict({
       }
     }
 
+    final isPackagingNow = stage_sequence.isPackagingStage(
+      stageId: task.stageId,
+      stageGroupKey: task.stageGroupKey,
+      stageName: _stageDisplayName(context.read<PersonnelProvider>(), task.stageId),
+    );
+
     final canStartEarlyPackaging = canStartPackagingOutOfQueue(
       task: task,
       tasks: provider,
@@ -5414,7 +5420,8 @@ bool _hasRealStartConflict({
       employeeId: widget.employeeId,
       groupResolver: _stageGroupKey,
     );
-    if (!_canRunOutOfStageSequence(task) &&
+    if (!isPackagingNow &&
+        !_canRunOutOfStageSequence(task) &&
         !_isFirstPendingStage(
           provider,
           context.read<PersonnelProvider>(),
@@ -5899,7 +5906,13 @@ bool _hasRealStartConflict({
                           employeeId: widget.employeeId,
                           groupResolver: _stageGroupKey,
                         );
-                        if (!_canRunOutOfStageSequence(task) &&
+                        final isPackagingNow = stage_sequence.isPackagingStage(
+                          stageId: task.stageId,
+                          stageGroupKey: task.stageGroupKey,
+                          stageName: _stageDisplayName(personnelProvider, task.stageId),
+                        );
+                        if (!isPackagingNow &&
+                            !_canRunOutOfStageSequence(task) &&
                             !_isFirstPendingStage(
                                 taskProvider, personnelProvider, task,
                                 groupResolver: _stageGroupKey) &&


### PR DESCRIPTION
### Motivation
- The UI start handler still enforced a strict sequential-stage guard which blocked starting packaging even when a pre-packaging stage was already active.
- Packaging should be allowed to start without strict order checks while preserving single-worker and workplace-queue constraints for other stages.

### Description
- Compute `isPackagingNow` via `stage_sequence.isPackagingStage` and skip the `_canRunOutOfStageSequence`/`_isFirstPendingStage` checks when `isPackagingNow` is true in the `onStart` handler in `lib/modules/tasks/tasks_screen.dart`.
- Apply the same early-packaging exemption that exists in `_hasRealStartConflict` so UI-side and conflict validation behave consistently.
- Preserve existing constraints for non-packaging stages, including the special same-order two-stage parallel case and workplace queue locking.

### Testing
- Attempted to run the formatter with `dart format lib/modules/tasks/tasks_screen.dart`, but it failed because `dart` is not available in this environment.
- Locally inspected the modified `lib/modules/tasks/tasks_screen.dart` to confirm the `isPackagingNow` checks were added in both the conflict check and the `onStart` handler.
- No automated unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5a3eb63c832facc254997ba2f95f)