### PR TITLE
Fix disposed TextEditingController reuse in reason dialog

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -4115,6 +4115,7 @@ class _TasksScreenState extends State<TasksScreen>
                               userId: widget.employeeId,
                               attachments: attachments,
                             );
+                        if (!mounted) return;
                         _chatController.clear();
                         setState(() => _pendingCommentAttachments.clear());
                       }
@@ -7194,7 +7195,7 @@ bool _hasRealStartConflict({
     final previousPending = List<AttachmentDraft>.from(_pendingCommentAttachments);
     _pendingCommentAttachments.clear();
     try {
-      return showDialog<_CommentDraft?>(
+      return await showDialog<_CommentDraft?>(
         context: context,
         builder: (ctx) => StatefulBuilder(
           builder: (ctx, setDialogState) => AlertDialog(


### PR DESCRIPTION
### Motivation
- Исправить рассинхрон жизненного цикла `TextEditingController` в диалоге с полем `hintText: "Укажите причину"`, из‑за которого контроллер мог быть `dispose()` до закрытия диалога и приводил к ошибке "A TextEditingController was used after being disposed.".

### Description
- Изменил возврат диалога в `_askCommentDraft` на `return await showDialog(...)`, чтобы `controller.dispose()` в `finally` выполнялся только после закрытия окна, и добавил `if (!mounted) return;` после асинхронной отправки комментария перед вызовами `_chatController.clear()`/`setState(...)` для защиты от обновления уже удалённого `State`.

### Testing
- Пытался запустить статический анализ `flutter analyze lib/modules/tasks/tasks_screen.dart`, но он не выполнился в CI/окружении (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5e635850832fb97fca49137ae14b)