### PR TITLE
Add in-app media preview for order comment attachments

### DIFF
--- a/lib/modules/orders/order_comments_timeline.dart
+++ b/lib/modules/orders/order_comments_timeline.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../tasks/task_model.dart';
 import 'order_comment_attachment.dart';
 import 'order_comments_repository.dart';
+import '../../utils/media_viewer.dart';
 
 class OrderCommentsSection extends StatefulWidget {
   const OrderCommentsSection({
@@ -146,32 +147,37 @@ class OrderCommentItem extends StatelessWidget {
 class AttachmentPreview extends StatelessWidget {
   const AttachmentPreview({super.key, required this.attachment});
   final OrderCommentAttachment attachment;
+
+  IconData _iconForAttachment() {
+    final mime = attachment.mimeType.toLowerCase();
+    if (mime.startsWith('image/')) return Icons.image_outlined;
+    if (mime.startsWith('video/')) return Icons.videocam_outlined;
+    if (mime == 'application/pdf') return Icons.picture_as_pdf_outlined;
+    return Icons.attach_file;
+  }
+
   @override
   Widget build(BuildContext context) {
     return ActionChip(
-      avatar: const Icon(Icons.attach_file, size: 16),
+      avatar: Icon(_iconForAttachment(), size: 16),
       label: Text(attachment.fileName),
-      onPressed: () {
-        Navigator.of(context).push(MaterialPageRoute(
-          builder: (_) => AttachmentViewerScreen(attachment: attachment),
-        ));
-      },
-    );
-  }
-}
+      onPressed: () async {
+        final url = (attachment.fileUrl ?? '').trim();
+        if (url.isEmpty) {
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Файл недоступен для просмотра')),
+          );
+          return;
+        }
 
-class AttachmentViewerScreen extends StatelessWidget {
-  const AttachmentViewerScreen({super.key, required this.attachment});
-  final OrderCommentAttachment attachment;
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(attachment.fileName)),
-      body: Center(
-        child: Text((attachment.fileUrl ?? '').isEmpty
-            ? 'Нет URL для просмотра'
-            : attachment.fileUrl!),
-      ),
+        await showMediaPreview(
+          context,
+          url: url,
+          mime: attachment.mimeType,
+          title: attachment.fileName,
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Allow users to open photos, videos and PDFs attached to order comments directly inside the app using a dedicated viewer window. 
- Bring order comment attachment UX in line with existing chat behavior that already uses the shared media viewer. 

### Description
- Import the shared viewer with `import '../../utils/media_viewer.dart';` and call `showMediaPreview` when an attachment is tapped. 
- Replace the placeholder `AttachmentViewerScreen` flow with an inline `ActionChip` handler that opens images, videos and PDFs using the shared viewer. 
- Add `_iconForAttachment()` to pick an icon by MIME type (image / video / PDF / generic file) and show it on the chip. 
- Show a user-facing `SnackBar` when the attachment `fileUrl` is missing instead of navigating to an empty page. 

### Testing
- Attempted to run `dart format lib/modules/orders/order_comments_timeline.dart`, but the `dart` executable was not available in the environment so formatting could not be verified. 
- `flutter analyze` / other Flutter SDK checks were not run because the Flutter/Dart SDK tools were not available in PATH in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d64b04dac832fad86b92115ab4060)