### PR TITLE
Persist orders.completed_at on completion and use it as restart-history timeline

### DIFF
--- a/lib/modules/orders/order_restart_history_repository.dart
+++ b/lib/modules/orders/order_restart_history_repository.dart
@@ -15,7 +15,9 @@ class OrderRestartHistoryEntry {
     this.updatedAt,
   });
 
-  DateTime? get finishedAt => completedAt ?? archivedAt ?? updatedAt;
+  DateTime? get timelineAt => completedAt ?? archivedAt ?? updatedAt;
+
+  DateTime? get finishedAt => timelineAt;
 
   factory OrderRestartHistoryEntry.fromMap(Map<String, dynamic> row) {
     DateTime? parseTs(dynamic v) {

--- a/lib/modules/orders/orders_provider.dart
+++ b/lib/modules/orders/orders_provider.dart
@@ -1155,7 +1155,7 @@ class OrdersProvider with ChangeNotifier {
       rethrow;
     }
 
-    final DateTime now = DateTime.now();
+    final DateTime now = DateTime.now().toUtc();
     final previous = _orders[index];
     final updated = orderData.copyWith(
       status: OrderStatus.completed.name,
@@ -1168,10 +1168,9 @@ class OrdersProvider with ChangeNotifier {
     notifyListeners();
 
     try {
-      await _supabase
-          .from('orders')
-          .update(updated.toMap()..remove('id'))
-          .eq('id', order.id);
+      final orderUpdate = updated.toMap()..remove('id');
+      orderUpdate['completed_at'] = now.toIso8601String();
+      await _supabase.from('orders').update(orderUpdate).eq('id', order.id);
       if (actualQtyForPens != null && actualQtyForPens > 0) {
         await _logPensCompletionWriteoff(
           order: orderData,

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -723,7 +723,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
         .where((e) => e.id == _selectedCommentsOrderId)
         .cast<OrderRestartHistoryEntry?>()
         .firstWhere((_) => true, orElse: () => null);
-    final selectedFinishedAt = selectedEntry?.finishedAt;
+    final selectedFinishedAt = selectedEntry?.timelineAt;
     final selectedDate = selectedFinishedAt == null
         ? _selectedCommentsOrderId
         : DateFormat('dd.MM.yyyy HH:mm').format(selectedFinishedAt.toLocal());
@@ -759,10 +759,10 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                       padding: const EdgeInsets.only(right: 8),
                       child: ChoiceChip(
                         label: Text(
-                          ancestor.finishedAt == null
+                          ancestor.timelineAt == null
                               ? ancestor.id
                               : DateFormat('dd.MM.yyyy').format(
-                                  ancestor.finishedAt!.toLocal(),
+                                  ancestor.timelineAt!.toLocal(),
                                 ),
                         ),
                         selected: _selectedCommentsOrderId == ancestor.id,

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -1201,7 +1201,10 @@ class TaskProvider with ChangeNotifier {
         if (isOrderFinallyCompleted(list)) {
           await _supabase
               .from('orders')
-              .update({'status': OrderStatus.completed.name}).eq('id', orderId);
+              .update({
+                  'status': OrderStatus.completed.name,
+                  'completed_at': DateTime.now().toUtc().toIso8601String(),
+                }).eq('id', orderId);
         }
       } catch (_) {}
     }

--- a/supabase/migrations/20260520_add_orders_completed_at.sql
+++ b/supabase/migrations/20260520_add_orders_completed_at.sql
@@ -1,0 +1,10 @@
+alter table if exists public.orders
+  add column if not exists completed_at timestamptz null;
+
+create index if not exists orders_completed_at_idx
+  on public.orders(completed_at);
+
+update public.orders
+set completed_at = coalesce(completed_at, shipped_at, archived_at, updated_at)
+where status = 'completed'
+  and completed_at is null;


### PR DESCRIPTION
### Motivation
- Ensure newly completed orders get a deterministic UTC ISO `completed_at` timestamp written at the moment of completion. 
- Use `completed_at` as the primary timeline time for restart/history chips while preserving existing fallback values for older data. 
- Provide a migration/backfill so older completed orders have `completed_at` where possible. 

### Description
- Added migration `supabase/migrations/20260520_add_orders_completed_at.sql` to add `orders.completed_at`, create an index, and backfill existing `completed` rows using `coalesce(completed_at, shipped_at, archived_at, updated_at)`. 
- Persist `completed_at` (UTC ISO) when an order is marked completed from the task workflow in `lib/modules/tasks/task_provider.dart`. 
- Persist `completed_at` (UTC ISO) when an order is shipped/completed in `lib/modules/orders/orders_provider.dart`, and ensure `now` is computed in UTC. 
- Introduced `timelineAt` (priority: `completed_at` then `archived_at` then `updated_at`) in `lib/modules/orders/order_restart_history_repository.dart` and switched the production UI (`lib/modules/production/production_details_screen.dart`) to use the timeline field for history chips, preserving fallback semantics. 

### Testing
- Ran `dart format` on the modified files via `dart format lib/modules/tasks/task_provider.dart lib/modules/orders/orders_provider.dart lib/modules/orders/order_restart_history_repository.dart lib/modules/production/production_details_screen.dart`, which failed because the `dart` tool was not available in the environment. 
- No unit or integration tests were executed in this rollout; changes are limited to migration and code paths that will be exercised at runtime after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d72877ffc832f894a96b8058e6686)