### PR TITLE
Fix restarted-order history navigation inside workspace comments

### DIFF
--- a/lib/modules/orders/archive_orders_screen.dart
+++ b/lib/modules/orders/archive_orders_screen.dart
@@ -7,7 +7,6 @@ import 'product_model.dart';
 import 'edit_order_screen.dart';
 import 'id_format.dart';
 import 'order_timeline_dialog.dart';
-import 'order_comments_timeline.dart';
 
 /// Экран архива заказов. Показывает завершённые заказы с поиском и
 /// возможностью переключения вида (список/карточки). Из архива можно
@@ -89,17 +88,6 @@ class _ArchiveOrdersScreenState extends State<ArchiveOrdersScreen> {
 
 
 
-  Future<void> _showComments(BuildContext context, OrderModel o) async {
-    await showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (_) => SizedBox(
-        height: MediaQuery.of(context).size.height * 0.6,
-        child: OrderCommentsSection(orderId: o.id, legacyText: o.comments),
-      ),
-    );
-  }
-
   Widget _buildCard(BuildContext context, OrderModel o) {
     final product = o.product;
     final displayId = orderDisplayId(o);
@@ -135,11 +123,6 @@ class _ArchiveOrdersScreenState extends State<ArchiveOrdersScreen> {
                   },
                   icon: const Icon(Icons.history),
                   label: const Text('История'),
-                ),
-                TextButton.icon(
-                  onPressed: () => _showComments(context, o),
-                  icon: const Icon(Icons.comment),
-                  label: const Text('Комментарии'),
                 ),
                 TextButton.icon(
                   onPressed: () => _resumeOrder(context, o),
@@ -226,20 +209,12 @@ class _ArchiveOrdersScreenState extends State<ArchiveOrdersScreen> {
                                 );
                                 return;
                               }
-                              if (value == 'comments') {
-                                await _showComments(context, o);
-                                return;
-                              }
                               _resumeOrder(context, o);
                             },
                             itemBuilder: (_) => const [
                               PopupMenuItem(
                                 value: 'history',
                                 child: Text('История'),
-                              ),
-                              PopupMenuItem(
-                                value: 'comments',
-                                child: Text('Комментарии'),
                               ),
                               PopupMenuItem(
                                 value: 'resume',

--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -683,6 +683,15 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
     }
   }
 
+  String _restartOrderChipLabel(OrderRestartHistoryEntry entry) {
+    final index = _restartAncestors.indexWhere((e) => e.id == entry.id);
+    final orderLabel = index == -1 ? 'Заказ' : 'Заказ ${index + 1}';
+    final finishedAt = entry.timelineAt;
+    if (finishedAt == null) return orderLabel;
+    final when = DateFormat('dd.MM HH:mm').format(finishedAt.toLocal());
+    return '$orderLabel · завершён $when';
+  }
+
   Color _stageStatusColor(TaskStatus? status) {
     switch (status) {
       case TaskStatus.completed:
@@ -758,13 +767,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
                     Padding(
                       padding: const EdgeInsets.only(right: 8),
                       child: ChoiceChip(
-                        label: Text(
-                          ancestor.timelineAt == null
-                              ? ancestor.id
-                              : DateFormat('dd.MM.yyyy').format(
-                                  ancestor.timelineAt!.toLocal(),
-                                ),
-                        ),
+                        label: Text(_restartOrderChipLabel(ancestor)),
                         selected: _selectedCommentsOrderId == ancestor.id,
                         onSelected: (_) => setState(
                           () => _selectedCommentsOrderId = ancestor.id,


### PR DESCRIPTION
## Summary
- removed the extra `Комментарии` action from archive orders UI (both card and table menu)
- removed archive bottom-sheet comments viewer entrypoint entirely
- kept history browsing in the existing workspace `Комментарии` block on production details
- improved restart-history chips to use user-facing labels like `Заказ N · завершён DD.MM HH:mm`
- preserved existing read-only behavior for historical orders and current-order-only write flow

## Why
The required UX is to view previous restarted-order histories only through the existing comments/history block in the employee workspace, not through a separate archive comments action.

## Scope
- `lib/modules/orders/archive_orders_screen.dart`
- `lib/modules/production/production_details_screen.dart`

## Notes
- No data model changes were introduced.
- No comment/history duplication logic was added; selection stays isolated per order id as already implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7b6c679c832fa7329d14dcb12248)