### PR TITLE
Fix production details build error on OrderRestartHistoryEntry getter

### DIFF
--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -686,7 +686,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
   String _restartOrderChipLabel(OrderRestartHistoryEntry entry) {
     final index = _restartAncestors.indexWhere((e) => e.id == entry.id);
     final orderLabel = index == -1 ? 'Заказ' : 'Заказ ${index + 1}';
-    final finishedAt = entry.timelineAt;
+    final finishedAt = entry.finishedAt;
     if (finishedAt == null) return orderLabel;
     final when = DateFormat('dd.MM HH:mm').format(finishedAt.toLocal());
     return '$orderLabel · завершён $when';
@@ -732,7 +732,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
         .where((e) => e.id == _selectedCommentsOrderId)
         .cast<OrderRestartHistoryEntry?>()
         .firstWhere((_) => true, orElse: () => null);
-    final selectedFinishedAt = selectedEntry?.timelineAt;
+    final selectedFinishedAt = selectedEntry?.finishedAt;
     final selectedDate = selectedFinishedAt == null
         ? _selectedCommentsOrderId
         : DateFormat('dd.MM.yyyy HH:mm').format(selectedFinishedAt.toLocal());


### PR DESCRIPTION
### Motivation
- The production details screen referenced a non-existent `timelineAt` getter on `OrderRestartHistoryEntry`, which produced a compile-time error during Flutter Windows build.

### Description
- Replaced `timelineAt` usages with the existing `finishedAt` getter in `lib/modules/production/production_details_screen.dart` for the restart-history chip label and the selected comments order date.

### Testing
- Attempted to run `dart analyze lib/modules/production/production_details_screen.dart`, but analysis could not be performed because the `dart` CLI is not available in this environment (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7f123eb8832fb0dd0e73279cdd8f)