### PR TITLE
Use explicit restart timestamps in production details

### DIFF
--- a/lib/modules/production/production_details_screen.dart
+++ b/lib/modules/production/production_details_screen.dart
@@ -686,7 +686,7 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
   String _restartOrderChipLabel(OrderRestartHistoryEntry entry) {
     final index = _restartAncestors.indexWhere((e) => e.id == entry.id);
     final orderLabel = index == -1 ? 'Заказ' : 'Заказ ${index + 1}';
-    final finishedAt = entry.finishedAt;
+    final finishedAt = entry.completedAt ?? entry.archivedAt ?? entry.updatedAt;
     if (finishedAt == null) return orderLabel;
     final when = DateFormat('dd.MM HH:mm').format(finishedAt.toLocal());
     return '$orderLabel · завершён $when';
@@ -732,7 +732,11 @@ class _ProductionDetailsScreenState extends State<ProductionDetailsScreen> {
         .where((e) => e.id == _selectedCommentsOrderId)
         .cast<OrderRestartHistoryEntry?>()
         .firstWhere((_) => true, orElse: () => null);
-    final selectedFinishedAt = selectedEntry?.finishedAt;
+    final selectedFinishedAt = selectedEntry == null
+        ? null
+        : (selectedEntry.completedAt ??
+            selectedEntry.archivedAt ??
+            selectedEntry.updatedAt);
     final selectedDate = selectedFinishedAt == null
         ? _selectedCommentsOrderId
         : DateFormat('dd.MM.yyyy HH:mm').format(selectedFinishedAt.toLocal());


### PR DESCRIPTION
### Motivation
- Prevent build failures from referencing a computed getter on `OrderRestartHistoryEntry` that may be unavailable in some builds by using concrete timestamp fields.

### Description
- Replace `entry.finishedAt` and `selectedEntry?.finishedAt` with the explicit fallback `completedAt ?? archivedAt ?? updatedAt` in `_restartOrderChipLabel` and the selected-order date calculation in `_buildProductionCard`.

### Testing
- Attempted `dart analyze lib/modules/production/production_details_screen.dart` but the Dart SDK was not available in the environment (`dart: command not found`), so no automated analysis completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d807ad640832fba758d0b284c49b0)