### PR TITLE
Refine comments history switching for restarted orders

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -1120,6 +1120,16 @@ class _TasksScreenState extends State<TasksScreen>
     }
   }
 
+  String _formatRestartChipLabel(OrderRestartHistoryEntry entry) {
+    final order = _orderById(entry.id);
+    final rawTitle = order?.product.type.trim() ?? '';
+    final title = rawTitle.isEmpty ? 'Заказ' : rawTitle;
+    final finishedAt = (entry.finishedAt ?? entry.updatedAt)?.toLocal();
+    if (finishedAt == null) return title;
+    final when = DateFormat('dd.MM.yyyy HH:mm').format(finishedAt);
+    return '$title · $when';
+  }
+
   String _employeeDisplayName(PersonnelProvider personnel, String userId) {
     if (userId.isEmpty) return '';
     try {
@@ -4067,9 +4077,14 @@ class _TasksScreenState extends State<TasksScreen>
                     Padding(
                       padding: EdgeInsets.only(right: scale * 6),
                       child: ChoiceChip(
-                        label: Text(_formatTimestamp(
-                          (ancestor.finishedAt ?? ancestor.updatedAt)?.millisecondsSinceEpoch ?? 0,
-                        )),
+                        label: ConstrainedBox(
+                          constraints: BoxConstraints(maxWidth: scale * 190),
+                          child: Text(
+                            _formatRestartChipLabel(ancestor),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
                         selected: selectedOrderId == ancestor.id,
                         onSelected: (_) => setState(
                           () => _selectedCommentsOrderByTaskId[task.id] = ancestor.id,
@@ -4108,8 +4123,9 @@ class _TasksScreenState extends State<TasksScreen>
             _pendingAttachmentsPreview(scale, updateDialogState: setState),
             SizedBox(height: scale * 6),
           ],
-          Row(
-            children: [
+          if (!isHistoryReadOnly)
+            Row(
+              children: [
               Expanded(
                 child: TextField(
                   controller: _chatController,
@@ -4227,8 +4243,8 @@ class _TasksScreenState extends State<TasksScreen>
                   child: Icon(Icons.send, color: Colors.white, size: scale * 18),
                 ),
               ),
-            ],
-          ),
+              ],
+            ),
         ],
       ),
       scale,


### PR DESCRIPTION
### Motivation
- Allow users to view the full chain of restarted orders' comments from inside the existing `💬 Комментарии` block without adding extra buttons or moving UI elements. 
- Ensure previous-order history is strictly read-only and cannot receive new comments or attachments so history and current-order data never mix.

### Description
- Added `_formatRestartChipLabel` in `lib/modules/tasks/tasks_screen.dart` to render chip labels as `Название заказа · dd.MM.yyyy HH:mm` using ancestor order metadata. 
- Replaced the plain timestamp chip label with a constrained, ellipsized `ChoiceChip` so long names/traces do not break layout and chips scroll horizontally. 
- Hid the entire comment composer/attachment/send row when viewing a previous order by wrapping it with `if (!isHistoryReadOnly)`, enforcing read-only behavior for old orders. 
- No archive UI, management-panel placement, or comments data model changes were added; the patch only modifies `lib/modules/tasks/tasks_screen.dart` and preserves existing write-path logic targeting the current order.

### Testing
- Ran `git diff` and inspected the file-level patch for `lib/modules/tasks/tasks_screen.dart`, which succeeded. 
- Committed the change with `git commit`, which succeeded. 
- Attempted to run `dart format` but it failed in the environment because `dart` is not installed (`/bin/bash: line 1: dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8a9e9678832f825f7fc02477ac11)