### PR TITLE
Fix missing DateFormat import in tasks screen

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';


### PR DESCRIPTION
### Motivation
- Fix the compilation error where `DateFormat` was undefined in `_formatRestartChipLabel` by providing the missing `intl` import.

### Description
- Added `import 'package:intl/intl.dart';` to `lib/modules/tasks/tasks_screen.dart` so `DateFormat` resolves correctly.

### Testing
- Attempted to run `flutter analyze lib/modules/tasks/tasks_screen.dart`, but it could not be executed in this environment because `flutter` is not installed (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8c21b4e8832f8872549bfb27e49f)