### PR TITLE
Handle non-UUID IDs in restart history RPC

### DIFF
--- a/lib/modules/orders/order_restart_history_repository.dart
+++ b/lib/modules/orders/order_restart_history_repository.dart
@@ -59,6 +59,10 @@ class SupabaseOrderRestartHistoryRepository
 
   final SupabaseClient _client;
 
+  static final RegExp _uuidPattern = RegExp(
+    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$',
+  );
+
   @override
   Future<OrderRestartHistoryEntry?> loadOrderById(String orderId) async {
     final id = orderId.trim();
@@ -89,6 +93,7 @@ class SupabaseOrderRestartHistoryRepository
   }) async {
     final id = orderId.trim();
     if (id.isEmpty || limit <= 0) return const [];
+    if (!_uuidPattern.hasMatch(id)) return const [];
 
     final rows = await _client.rpc(
       'get_order_restart_history',


### PR DESCRIPTION
### Motivation
- Prevent calling the `get_order_restart_history` RPC with non-UUID order IDs which can cause Postgres errors like `operator does not exist: uuid = text` (42883). This ensures environments that use non-UUID IDs fall back to the existing non-RPC chain loader without surfacing the DB error.

### Description
- Add a `_uuidPattern` `RegExp` to `SupabaseOrderRestartHistoryRepository` and return an empty list early from `loadRestartHistoryChainViaRpc` when the trimmed `orderId` does not match the UUID pattern. 
- Preserve existing behavior in `RestartHistoryService` so the RPC is simply skipped and the in-code chain traversal continues as a fallback.

### Testing
- Ran `flutter test test/restart_history_service_test.dart`, but the test could not be executed because the `flutter` binary is not available in the environment (`/bin/bash: flutter: command not found`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8cee2bdc832fa1d4d71a0593ec85)