### PR TITLE
Handle `setup_resume` as setup start when computing setup state

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -7154,7 +7154,7 @@ bool _hasRealStartConflict({
     int totalMs = 0;
 
     for (final c in list) {
-      if (c.type == 'setup_start') {
+      if (c.type == 'setup_start' || c.type == 'setup_resume') {
         if (active == 0) activeStart = _normTs(c.timestamp);
         active++;
       } else if (c.type == 'setup_done') {
@@ -7243,7 +7243,7 @@ bool _hasRealStartConflict({
     final Set<String> seenDone = {};
     for (final t in related) {
       for (final c in t.comments) {
-        if (c.type == 'setup_start') {
+        if (c.type == 'setup_start' || c.type == 'setup_resume') {
           final key = '${c.timestamp}-${c.type}';
           if (seenStart.add(key)) {
             final ts = _normTs(c.timestamp);
@@ -7469,7 +7469,7 @@ bool _hasRealStartConflict({
     for (final c in task.comments) {
       final uid = c.userId;
       if (uid.isEmpty) continue;
-      if (c.type == 'setup_start') {
+      if (c.type == 'setup_start' || c.type == 'setup_resume') {
         final prev = lastStartByUser[uid] ?? 0;
         if (c.timestamp > prev) lastStartByUser[uid] = c.timestamp;
       } else if (c.type == 'setup_done') {


### PR DESCRIPTION
### Motivation
- Fix a bug where resumed setup sessions (`setup_resume`) were not treated as setup starts, causing employees who resumed setup or reported a problem during resumed setup to be blocked from starting production. 

### Description
- Treat `setup_resume` the same as `setup_start` in aggregated setup interval calculation in `_setupElapsedAgg` so resumed sessions contribute to total setup time. 
- Include `setup_resume` when computing earliest/last setup bounds across related tasks in `_setupElapsedStage` to avoid missing resumed starts. 
- Consider `setup_resume` as a start event in `_hasPendingSetupForStage` so pending/resumed setup prevents false blocking logic before production. 

### Testing
- Attempted to run unit tests with `flutter test test/task_model_started_at_test.dart`, but the environment lacks the Flutter SDK and the command failed with `/bin/bash: line 1: flutter: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8f00d304832fb69f5b5b1d29c6b8)