### PR TITLE
Fix UUID/text mismatch in restart history lookup

### DIFF
--- a/lib/modules/orders/order_restart_history_repository.dart
+++ b/lib/modules/orders/order_restart_history_repository.dart
@@ -66,7 +66,7 @@ class SupabaseOrderRestartHistoryRepository
   @override
   Future<OrderRestartHistoryEntry?> loadOrderById(String orderId) async {
     final id = orderId.trim();
-    if (id.isEmpty) return null;
+    if (id.isEmpty || !_uuidPattern.hasMatch(id)) return null;
 
     Future<Map<String, dynamic>?> runSelect(String columns) {
       return _client.from('orders').select(columns).eq('id', id).maybeSingle();


### PR DESCRIPTION
### Motivation
- Prevent PostgREST error `operator does not exist: uuid = text (42883)` which occurs when `loadOrderById` attempts to compare a non-UUID string to the `orders.id (uuid)` column.

### Description
- Add an early UUID format check using `_uuidPattern` in `SupabaseOrderRestartHistoryRepository.loadOrderById` to return `null` for empty or non-UUID `orderId`, avoiding invalid `eq('id', id)` queries; change is in `lib/modules/orders/order_restart_history_repository.dart`.

### Testing
- Attempted to run `flutter test test/restart_history_service_test.dart`, but the command failed with `flutter: command not found` so automated tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8fe8278c832fa668f6d525b870bd)