### PR TITLE
Require setup resume before production start after setup problem

### DIFF
--- a/lib/modules/tasks/tasks_screen.dart
+++ b/lib/modules/tasks/tasks_screen.dart
@@ -5893,11 +5893,17 @@ bool _hasRealStartConflict({
                         _hasOpenStartIntentForUser(task, currentRowUserId);
                     final bool startIntentBlocksRow =
                         hasOpenStartIntentForRowUser && !isSetupActiveForRow;
+                    final bool problemRequiresSetupResume =
+                        _hasMachineForStage(stage) &&
+                            stateRowUser == UserRunState.problem &&
+                            _hasPendingSetupForStage(task) &&
+                            !isSetupActiveForRow;
                     final bool canStartButtonRow = isMyRow &&
                         canStart &&
                         !_startingTaskIds.contains(task.id) &&
                         !requiresSetupBeforeStart &&
                         !blockedByShiftResumeLock &&
+                        !problemRequiresSetupResume &&
                         !startIntentBlocksRow &&
                         // Для отдельных исполнителей разрешаем возобновлять этап
                         // после личного завершения (до финальной кнопки


### PR DESCRIPTION
### Motivation
- Fix a flow where a user who marked a stage as `Проблема` during an unfinished machine setup could press `▶ Начать/Продолжить` and resume production without first resuming setup, causing inconsistent state.

### Description
- Introduced `problemRequiresSetupResume` in `lib/modules/tasks/tasks_screen.dart` and added it to the `canStartButtonRow` condition to block the Start/Continue button when the stage has a machine, the row user is in `UserRunState.problem`, the stage has a pending setup, and setup is not active for that user.

### Testing
- Attempted to run the formatter with `dart format lib/modules/tasks/tasks_screen.dart` but the `dart` binary was not available in the environment so formatting/check was skipped. 
- Verified the file diff and created a commit successfully using `git add` and `git commit`, and no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d91c94848832fbadb41ac27bcb45f)