### PR TITLE
Improve KPD baseline: aggregate previous months and safe fallback

### DIFF
--- a/lib/modules/analytics/calculators/kpd_calculator.dart
+++ b/lib/modules/analytics/calculators/kpd_calculator.dart
@@ -29,35 +29,42 @@ class KpdCalculator {
     return AnalyticsCalculator.speedQtyPerMinute(eventsOfMonthForWorkplace);
   }
 
-  /// Считает КПД, имея скорость текущего месяца и скорости предыдущих.
-  /// Если предыдущих скоростей нет — возвращает 100% с пометкой noBaseline.
+  /// Считает КПД, имея скорость текущего месяца и помесячные скорости
+  /// предыдущих месяцев с ненулевым полезным временем.
+  /// Если базы нет или средняя база нулевая — возвращает безопасные 100%
+  /// с пометкой noBaseline, чтобы UI не показывал NaN/Infinity.
   static KpdResult compute({
     required double currentSpeed,
     required List<double> previousMonthsSpeeds,
   }) {
-    final filtered = previousMonthsSpeeds.where((s) => s.isFinite && s > 0).toList();
+    final safeCurrentSpeed = currentSpeed.isFinite && currentSpeed > 0
+        ? currentSpeed
+        : 0.0;
+    final filtered = previousMonthsSpeeds
+        .where((speed) => speed.isFinite && speed >= 0)
+        .toList();
     if (filtered.isEmpty) {
       return KpdResult(
-        currentSpeed: currentSpeed,
+        currentSpeed: safeCurrentSpeed,
         previousAverageSpeed: 0,
         kpdPercent: 100,
         noBaseline: true,
       );
     }
     final avg = filtered.reduce((a, b) => a + b) / filtered.length;
-    if (avg <= 0) {
+    if (!avg.isFinite || avg <= 0) {
       return KpdResult(
-        currentSpeed: currentSpeed,
+        currentSpeed: safeCurrentSpeed,
         previousAverageSpeed: 0,
         kpdPercent: 100,
         noBaseline: true,
       );
     }
-    final kpd = (currentSpeed / avg) * 100;
+    final kpd = (safeCurrentSpeed / avg) * 100;
     return KpdResult(
-      currentSpeed: currentSpeed,
+      currentSpeed: safeCurrentSpeed,
       previousAverageSpeed: avg,
-      kpdPercent: kpd.isFinite ? kpd : 0,
+      kpdPercent: kpd.isFinite ? kpd : 100,
       noBaseline: false,
     );
   }

--- a/lib/modules/analytics/repositories/analytics_repository.dart
+++ b/lib/modules/analytics/repositories/analytics_repository.dart
@@ -131,7 +131,148 @@ class AnalyticsRepository {
     return events;
   }
 
-  static (DateTime, DateTime?)? _normalizeTimeRange(DateTime start, DateTime? end, DateTime reference) {
+  /// Загружает помесячную базу скоростей по рабочим местам до выбранного
+  /// месяца: учитываются только производственные события с ненулевой
+  /// длительностью и timestamp строго раньше [month.firstDay].
+  Future<Map<String, List<double>>> loadPreviousWorkplaceMonthSpeeds(
+    AnalyticsMonth month, {
+    DateTime? now,
+  }) async {
+    final monthStart = month.firstDay.toUtc();
+    final reference = (now ?? monthStart).toUtc();
+
+    final List<dynamic> rows = await _client
+        .from('comments')
+        .select(
+            'id, type, text, user_id, timestamp, task_id, tasks!inner(id, stage_id, order_id, orders(id, customer))')
+        .inFilter('type', [
+      'time_event',
+      'quantity_done',
+      'quantity_team_total',
+      'quantity_share',
+    ])
+        .lt('timestamp', monthStart.toIso8601String())
+        .order('timestamp', ascending: true);
+
+    final Map<String, List<TaskTimeEvent>> rawEventsByGroup = {};
+    final Map<String, List<_QtyRecord>> qtyRecordsByGroup = {};
+    final Map<String, _TaskJoinData> taskDataById = {};
+
+    for (final row in rows) {
+      if (row is! Map) continue;
+      final map = Map<String, dynamic>.from(row);
+      final type = (map['type'] ?? '').toString();
+      final taskId = (map['task_id'] ?? '').toString();
+      if (taskId.isEmpty) continue;
+
+      final taskMap = map['tasks'] is Map
+          ? Map<String, dynamic>.from(map['tasks'])
+          : const <String, dynamic>{};
+      final orderMap = taskMap['orders'] is Map
+          ? Map<String, dynamic>.from(taskMap['orders'])
+          : const <String, dynamic>{};
+      taskDataById[taskId] = _TaskJoinData(
+        stageId: (taskMap['stage_id'] ?? '').toString(),
+        orderId: (taskMap['order_id'] ?? '').toString(),
+        customer: orderMap['customer']?.toString(),
+      );
+
+      final timestamp =
+          DateTime.tryParse((map['timestamp'] ?? '').toString())?.toUtc();
+      if (timestamp == null) continue;
+      final commentId = (map['id'] ?? '').toString();
+      final userId = (map['user_id'] ?? '').toString();
+
+      if (type == 'time_event') {
+        final ev = TaskTimeEvent.fromPayload(
+          (map['text'] ?? '').toString(),
+          commentId,
+          timestamp.millisecondsSinceEpoch,
+          userId,
+        );
+        if (ev == null || ev.type != TaskTimeType.production) continue;
+        final normalized =
+            _normalizeTimeRange(ev.startTime, ev.endTime, reference);
+        if (normalized == null) continue;
+        final start = normalized.$1;
+        final end = normalized.$2;
+        if (!start.isBefore(monthStart) ||
+            end == null ||
+            end.isAfter(monthStart)) {
+          continue;
+        }
+        rawEventsByGroup
+            .putIfAbsent('$taskId::${ev.subjectUserId}', () => [])
+            .add(ev.copyWith(startTime: start, endTime: end));
+      } else if (type == 'quantity_done' ||
+          type == 'quantity_team_total' ||
+          type == 'quantity_share') {
+        final qty = _parseQty((map['text'] ?? '').toString());
+        if (qty <= 0) continue;
+        final groupKey = '$taskId::$userId';
+        qtyRecordsByGroup
+            .putIfAbsent(groupKey, () => [])
+            .add(_QtyRecord(timestamp: timestamp, qty: qty));
+      }
+    }
+
+    final totalsByWorkplace = <String, Map<DateTime, _MonthSpeedTotals>>{};
+
+    rawEventsByGroup.forEach((groupKey, list) {
+      final parts = groupKey.split('::');
+      final taskId = parts.first;
+      final taskData = taskDataById[taskId];
+
+      list.sort((a, b) => a.startTime.compareTo(b.startTime));
+      final qtyQueue = List<_QtyRecord>.from(
+          qtyRecordsByGroup[groupKey] ?? const <_QtyRecord>[])
+        ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+      for (final raw in list) {
+        final effectiveEnd = raw.endTime;
+        if (effectiveEnd == null) continue;
+        final minutes = effectiveEnd.difference(raw.startTime).inMinutes;
+        if (minutes <= 0) continue;
+
+        double qty = 0;
+        while (qtyQueue.isNotEmpty &&
+            !qtyQueue.first.timestamp.isAfter(effectiveEnd)) {
+          final rec = qtyQueue.removeAt(0);
+          if (!rec.timestamp.isBefore(raw.startTime)) qty += rec.qty;
+        }
+
+        final workplaceId = raw.workplaceId.isNotEmpty
+            ? raw.workplaceId
+            : (taskData?.stageId ?? '');
+        if (workplaceId.isEmpty) continue;
+        final monthKey = DateTime.utc(raw.startTime.year, raw.startTime.month);
+        final byMonth = totalsByWorkplace.putIfAbsent(
+          workplaceId,
+          () => <DateTime, _MonthSpeedTotals>{},
+        );
+        byMonth
+            .putIfAbsent(monthKey, () => _MonthSpeedTotals())
+            .add(qty: qty, minutes: minutes);
+      }
+    });
+
+    final speedsByWorkplace = <String, List<double>>{};
+    totalsByWorkplace.forEach((workplaceId, byMonth) {
+      final monthKeys = byMonth.keys.toList()..sort();
+      for (final monthKey in monthKeys) {
+        final totals = byMonth[monthKey]!;
+        if (totals.minutes <= 0) continue;
+        final speed = totals.qty / totals.minutes;
+        if (!speed.isFinite) continue;
+        speedsByWorkplace.putIfAbsent(workplaceId, () => []).add(speed);
+      }
+    });
+
+    return speedsByWorkplace;
+  }
+
+  static (DateTime, DateTime?)? _normalizeTimeRange(
+      DateTime start, DateTime? end, DateTime reference) {
     final utcStart = start.toUtc();
     DateTime? utcEnd = end?.toUtc();
     if (utcEnd == null) return (utcStart, null);
@@ -147,10 +288,60 @@ class AnalyticsRepository {
     return (utcStart, utcEnd);
   }
 
-  static AnalyticsEventType? _mapType(TaskTimeType raw) { switch (raw) { case TaskTimeType.production:return AnalyticsEventType.work; case TaskTimeType.pause:return AnalyticsEventType.pause; case TaskTimeType.problem:return AnalyticsEventType.problem; case TaskTimeType.setup:return AnalyticsEventType.setup; case TaskTimeType.shiftChange:return null; } }
-  static bool _overlapsMonth(DateTime start, DateTime? end, DateTime monthFirst, DateTime monthEnd) { final endEffective = end ?? DateTime.now().toUtc(); return start.isBefore(monthEnd) && !endEffective.isBefore(monthFirst); }
-  static double _parseQty(String raw) { final normalized = raw.replaceAll(',', '.').trim(); final match = RegExp(r'-?[0-9]+(?:\.[0-9]+)?').firstMatch(normalized); if (match != null) return double.tryParse(match.group(0)!) ?? 0; return double.tryParse(normalized) ?? 0; }
+  static AnalyticsEventType? _mapType(TaskTimeType raw) {
+    switch (raw) {
+      case TaskTimeType.production:
+        return AnalyticsEventType.work;
+      case TaskTimeType.pause:
+        return AnalyticsEventType.pause;
+      case TaskTimeType.problem:
+        return AnalyticsEventType.problem;
+      case TaskTimeType.setup:
+        return AnalyticsEventType.setup;
+      case TaskTimeType.shiftChange:
+        return null;
+    }
+  }
+
+  static bool _overlapsMonth(
+      DateTime start, DateTime? end, DateTime monthFirst, DateTime monthEnd) {
+    final endEffective = end ?? DateTime.now().toUtc();
+    return start.isBefore(monthEnd) && !endEffective.isBefore(monthFirst);
+  }
+
+  static double _parseQty(String raw) {
+    final normalized = raw.replaceAll(',', '.').trim();
+    final match = RegExp(r'-?[0-9]+(?:\.[0-9]+)?').firstMatch(normalized);
+    if (match != null) return double.tryParse(match.group(0)!) ?? 0;
+    return double.tryParse(normalized) ?? 0;
+  }
 }
 
-class _QtyRecord { final DateTime timestamp; final double qty; const _QtyRecord({required this.timestamp, required this.qty}); }
-class _TaskJoinData { final String stageId; final String orderId; final String? customer; const _TaskJoinData({required this.stageId, required this.orderId, this.customer}); }
+class _QtyRecord {
+  final DateTime timestamp;
+  final double qty;
+
+  const _QtyRecord({required this.timestamp, required this.qty});
+}
+
+class _MonthSpeedTotals {
+  double qty = 0;
+  int minutes = 0;
+
+  void add({required double qty, required int minutes}) {
+    this.qty += qty;
+    this.minutes += minutes;
+  }
+}
+
+class _TaskJoinData {
+  final String stageId;
+  final String orderId;
+  final String? customer;
+
+  const _TaskJoinData({
+    required this.stageId,
+    required this.orderId,
+    this.customer,
+  });
+}

--- a/lib/modules/analytics/screens/workplace_detail_screen.dart
+++ b/lib/modules/analytics/screens/workplace_detail_screen.dart
@@ -116,8 +116,9 @@ class _WorkplaceDetailScreenState extends State<WorkplaceDetailScreen> {
                       child: AnalyticsKpiCard(
                           label: 'КПД',
                           value: '${kpd.kpdPercent.round()}%',
-                          sub:
-                              'Сравнение с предыдущими месяцами'),
+                          sub: kpd.noBaseline
+                              ? 'Нет базы — показан безопасный fallback'
+                              : 'К средней базе всех прошлых месяцев'),
                     ),
                   ],
                 ),

--- a/lib/modules/analytics/services/analytics_service.dart
+++ b/lib/modules/analytics/services/analytics_service.dart
@@ -30,7 +30,7 @@ class AnalyticsState {
   final Map<String, String> employeeStatusIds;
   final Map<String, String?> employeePayTypes;
   final List<ClaimModel> claims;
-  /// Скорости рабочих мест за каждый из предыдущих месяцев (от 1 до 12).
+  /// Помесячные скорости рабочих мест за все месяцы до выбранного.
   /// Используется для расчёта КПД.
   final Map<String, List<double>> workplacePreviousSpeeds;
   final bool loading;
@@ -157,24 +157,9 @@ class AnalyticsService extends ChangeNotifier {
       final empPayTypes = await employeePayTypesFuture;
       final claims = await claimsFuture;
 
-      // 3. Скорости предыдущих месяцев — для КПД (3 предыдущих месяца).
-      final prevMonths = month.previousMonths(3);
-      final prevSpeeds = <String, List<double>>{};
-      for (final prev in prevMonths) {
-        final prevEvents = await _analyticsRepo.loadEventsForMonth(prev);
-        final byWorkplace = <String, List<AnalyticsEvent>>{};
-        for (final e in prevEvents) {
-          if (e.type != AnalyticsEventType.work) continue;
-          byWorkplace.putIfAbsent(e.workplaceId, () => []).add(e);
-        }
-        byWorkplace.forEach((wpId, list) {
-          final qty = list.fold<double>(0, (s, e) => s + e.qty);
-          final minutes = list.fold<int>(0, (s, e) => s + e.durationMinutes());
-          if (minutes <= 0) return;
-          final speed = qty / minutes;
-          prevSpeeds.putIfAbsent(wpId, () => []).add(speed);
-        });
-      }
+      // 3. Помесячная база скоростей по всем месяцам до выбранного.
+      final prevSpeeds =
+          await _analyticsRepo.loadPreviousWorkplaceMonthSpeeds(month);
 
       _state = AnalyticsState(
         month: month,

--- a/lib/modules/analytics/widgets/workplaces_table.dart
+++ b/lib/modules/analytics/widgets/workplaces_table.dart
@@ -185,7 +185,9 @@ class WorkplacesTable extends StatelessWidget {
             _cell('${r.claims}'),
             _cellLong(
               '${r.kpd.kpdPercent.round()}%',
-              r.kpd.noBaseline ? 'нет базы' : 'к предыдущим месяцам',
+              r.kpd.noBaseline
+                  ? 'нет базы — безопасный fallback'
+                  : 'к средней базе всех прошлых месяцев',
             ),
           ],
         ),


### PR DESCRIPTION
### Motivation
- Убрать жёсткую привязку к `previousMonths(3)` и вместо этого использовать полную помесячную базу прошлых скоростей для корректного расчёта КПД. 
- Избежать `NaN`/`Infinity` и неверных процентов при отсутствии или нулевой базе, показав безопасный fallback. 

### Description
- Заменён сбор базы в `AnalyticsService`: вместо фиксированных трёх месяцев теперь вызывается новый метод репозитория `loadPreviousWorkplaceMonthSpeeds(month)`. (`lib/modules/analytics/services/analytics_service.dart`).
- Добавлен агрегирующий запрос и логика агрегации по месяцам в `AnalyticsRepository`: `loadPreviousWorkplaceMonthSpeeds` собирает production-события с `timestamp < month.firstDay`, группирует по рабочему месту и месяцу, вычисляет скорость (qty / useful_minutes) для каждого месяца и возвращает помесячные скорости по workplace. (`lib/modules/analytics/repositories/analytics_repository.dart`).
- Переработан расчёт в `KpdCalculator.compute`: нормализуется текущая скорость, база фильтруется по валидным помесячным скоростям, средняя берётся по всем валидным месяцам, а при отсутствии/нулевой/ненормальной базы возвращается безопасный `kpdPercent = 100` с флагом `noBaseline = true` (без `NaN`/`Infinity`). (`lib/modules/analytics/calculators/kpd_calculator.dart`).
- Обновлён UI текст в таблице и в деталке рабочего места, чтобы отображать, когда применяется безопасный fallback или показывается средняя по всем прошлым месяцам. (`lib/modules/analytics/widgets/workplaces_table.dart`, `lib/modules/analytics/screens/workplace_detail_screen.dart`).
- В репозитории добавлены вспомогательные структуры для накопления помесячных итогов (`_MonthSpeedTotals`, `_QtyRecord`) и аккуратное форматирование/фильтрация данных по timestamp и длительности. (`lib/modules/analytics/repositories/analytics_repository.dart`).

### Testing
- Запущена проверка изменений `git diff --check`, конфликтов нет и проверка прошла успешно. 
- Попытки запустить `dart format` и `flutter test` не выполнялись в CI-окружении потому что `dart`/`flutter` не установлены в текущем окружении, поэтому форматирование и тесты не выполнялись локально здесь. 
- В репозитории выполнён коммит с описанными изменениями; нет изменений в существующих тестах и никаких автотестов не было изменено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1927d9ec24832fb422c1200a530c75)