### PR TITLE
Unify analytics tab screens and switch tabs to real screen widgets

### DIFF
--- a/lib/modules/analytics/analytics_module.dart
+++ b/lib/modules/analytics/analytics_module.dart
@@ -14,12 +14,14 @@ import 'package:flutter/material.dart';
 
 import 'screens/analytics_home_screen.dart';
 import 'services/analytics_permission_service.dart';
+import 'widgets/analytics_topbar.dart';
 
 class AnalyticsEntry extends StatelessWidget {
   const AnalyticsEntry({
     super.key,
     required this.isTechLeader,
     this.currentEmployeeId,
+    this.initialTab = AnalyticsTopTab.employees,
   });
 
   /// true если у текущего пользователя роль «Технический лидер»
@@ -30,12 +32,18 @@ class AnalyticsEntry extends StatelessWidget {
   /// сотрудник без доступа к аналитике.
   final String? currentEmployeeId;
 
+  /// Вкладка, которую нужно открыть при входе в аналитику.
+  final AnalyticsTopTab initialTab;
+
   @override
   Widget build(BuildContext context) {
     final permission = AnalyticsPermissionService(
       isTechLeader: isTechLeader,
       currentEmployeeId: currentEmployeeId,
     );
-    return AnalyticsHomeScreen(permission: permission);
+    return AnalyticsHomeScreen(
+      permission: permission,
+      initialTab: initialTab,
+    );
   }
 }

--- a/lib/modules/analytics/analytics_routes.dart
+++ b/lib/modules/analytics/analytics_routes.dart
@@ -1,22 +1,72 @@
 import 'package:flutter/material.dart';
 
 import 'analytics_module.dart';
+import 'widgets/analytics_topbar.dart';
 
 class AnalyticsRoutes {
   AnalyticsRoutes._();
 
   static const String home = '/analytics';
+  static const String employees = '/analytics/employees';
+  static const String workplaces = '/analytics/workplaces';
+  static const String schedule = '/analytics/schedule';
 
   static Route<dynamic> buildHomeRoute({
     required bool isTechLeader,
     String? currentEmployeeId,
+    AnalyticsTopTab initialTab = AnalyticsTopTab.employees,
   }) {
     return MaterialPageRoute(
-      settings: const RouteSettings(name: home),
+      settings: RouteSettings(name: routeNameForTab(initialTab)),
       builder: (_) => AnalyticsEntry(
         isTechLeader: isTechLeader,
         currentEmployeeId: currentEmployeeId,
+        initialTab: initialTab,
       ),
     );
+  }
+
+  static Route<dynamic> buildEmployeesRoute({
+    required bool isTechLeader,
+    String? currentEmployeeId,
+  }) {
+    return buildHomeRoute(
+      isTechLeader: isTechLeader,
+      currentEmployeeId: currentEmployeeId,
+      initialTab: AnalyticsTopTab.employees,
+    );
+  }
+
+  static Route<dynamic> buildWorkplacesRoute({
+    required bool isTechLeader,
+    String? currentEmployeeId,
+  }) {
+    return buildHomeRoute(
+      isTechLeader: isTechLeader,
+      currentEmployeeId: currentEmployeeId,
+      initialTab: AnalyticsTopTab.workplaces,
+    );
+  }
+
+  static Route<dynamic> buildScheduleRoute({
+    required bool isTechLeader,
+    String? currentEmployeeId,
+  }) {
+    return buildHomeRoute(
+      isTechLeader: isTechLeader,
+      currentEmployeeId: currentEmployeeId,
+      initialTab: AnalyticsTopTab.schedule,
+    );
+  }
+
+  static String routeNameForTab(AnalyticsTopTab tab) {
+    switch (tab) {
+      case AnalyticsTopTab.employees:
+        return employees;
+      case AnalyticsTopTab.workplaces:
+        return workplaces;
+      case AnalyticsTopTab.schedule:
+        return schedule;
+    }
   }
 }

--- a/lib/modules/analytics/screens/analytics_home_screen.dart
+++ b/lib/modules/analytics/screens/analytics_home_screen.dart
@@ -12,40 +12,36 @@ import '../widgets/analytics_month_picker.dart';
 import '../widgets/analytics_shell.dart';
 import '../widgets/analytics_states.dart';
 import '../widgets/analytics_topbar.dart';
-import '../widgets/employees_table.dart';
 import '../widgets/salary_settings_drawer.dart';
-import '../widgets/schedule_grid.dart';
-import '../widgets/workplaces_table.dart';
 import 'employee_detail_screen.dart';
-import 'workplace_detail_screen.dart';
+import 'employees_analytics_screen.dart';
+import 'work_schedule_screen.dart';
+import 'workplaces_analytics_screen.dart';
 
 class AnalyticsHomeScreen extends StatefulWidget {
-  const AnalyticsHomeScreen({super.key, required this.permission});
+  const AnalyticsHomeScreen({
+    super.key,
+    required this.permission,
+    this.initialTab = AnalyticsTopTab.employees,
+  });
+
   final AnalyticsPermissionService permission;
+  final AnalyticsTopTab initialTab;
 
   @override
   State<AnalyticsHomeScreen> createState() => _AnalyticsHomeScreenState();
 }
 
 class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
-  AnalyticsTopTab _tab = AnalyticsTopTab.employees;
+  late AnalyticsTopTab _tab;
   late AnalyticsService _service;
   bool _bootstrapped = false;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  // Отдельные контроллеры на каждую вкладку — чтобы Scrollbar и
-  // SingleChildScrollView всегда использовали один и тот же controller
-  // и не пытались хватать PrimaryScrollController.
-  late final ScrollController _scrollEmployees;
-  late final ScrollController _scrollWorkplaces;
-  late final ScrollController _scrollSchedule;
-
   @override
   void initState() {
     super.initState();
-    _scrollEmployees = ScrollController();
-    _scrollWorkplaces = ScrollController();
-    _scrollSchedule = ScrollController();
+    _tab = widget.initialTab;
   }
 
   @override
@@ -75,9 +71,6 @@ class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
     context.read<TaskProvider>().removeListener(_onProvidersChanged);
     context.read<OrdersProvider>().removeListener(_onProvidersChanged);
     _service.dispose();
-    _scrollEmployees.dispose();
-    _scrollWorkplaces.dispose();
-    _scrollSchedule.dispose();
     super.dispose();
   }
 
@@ -121,17 +114,7 @@ class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
                 onBack: () => Navigator.of(context).maybePop(),
               ),
               _filtersBar(state.month),
-              Expanded(
-                child: state.loading
-                    ? const AnalyticsLoadingState()
-                    : state.error != null
-                        ? AnalyticsErrorState(
-                            message:
-                                'Не удалось загрузить аналитику.\n${state.error}',
-                            onRetry: () => _service.refresh(),
-                          )
-                        : _content(state),
-              ),
+              Expanded(child: _content()),
             ],
           ),
         );
@@ -180,81 +163,24 @@ class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
     );
   }
 
-  Widget _content(state) {
-    switch (_tab) {
-      case AnalyticsTopTab.employees:
-        return _scrollable(
-          controller: _scrollEmployees,
-          child: EmployeesTable(
-            service: _service,
-            personnel: context.read<PersonnelProvider>(),
-            canViewFinance: widget.permission.canViewFinance,
-            onEmployeeTap: (id) {
-              Navigator.of(context).push(MaterialPageRoute(
-                builder: (_) => EmployeeDetailScreen(
-                  service: _service,
-                  permission: widget.permission,
-                  employeeId: id,
-                ),
-              ));
-            },
-          ),
-        );
-      case AnalyticsTopTab.workplaces:
-        return _scrollable(
-          controller: _scrollWorkplaces,
-          child: WorkplacesTable(
-            service: _service,
-            personnel: context.read<PersonnelProvider>(),
-            canEditCoefficient: widget.permission.canEdit,
-            onWorkplaceTap: (id) {
-              Navigator.of(context).push(MaterialPageRoute(
-                builder: (_) => WorkplaceDetailScreen(
-                  service: _service,
-                  permission: widget.permission,
-                  workplaceId: id,
-                ),
-              ));
-            },
-          ),
-        );
-      case AnalyticsTopTab.schedule:
-        return _scrollable(
-          controller: _scrollSchedule,
-          child: ScheduleGrid(
-            service: _service,
-            personnel: context.read<PersonnelProvider>(),
-            canEdit: widget.permission.canEdit,
-          ),
-        );
-    }
-  }
-
-  Widget _scrollable({
-    required Widget child,
-    required ScrollController controller,
-  }) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-        child: Container(
-          // Bounded height приходит сверху от Expanded -> Padding -> Container.
-          // Scrollbar и SingleChildScrollView используют ОДИН ScrollController,
-          // primary: false — чтобы не цепляться за PrimaryScrollController.
-          decoration: BoxDecoration(
-            color: AnalyticsColors.card,
-            borderRadius: BorderRadius.circular(22),
-            border: Border.all(color: AnalyticsColors.line),
-          ),
-          clipBehavior: Clip.antiAlias,
-          child: Scrollbar(
-            controller: controller,
-            thumbVisibility: true,
-            child: SingleChildScrollView(
-              controller: controller,
-              primary: false,
-              child: child,
-            ),
-          ),
+  Widget _content() {
+    return IndexedStack(
+      index: _tab.index,
+      sizing: StackFit.expand,
+      children: [
+        EmployeesAnalyticsScreen(
+          service: _service,
+          permission: widget.permission,
         ),
-      );
+        WorkplacesAnalyticsScreen(
+          service: _service,
+          permission: widget.permission,
+        ),
+        WorkScheduleScreen(
+          service: _service,
+          permission: widget.permission,
+        ),
+      ],
+    );
+  }
 }

--- a/lib/modules/analytics/screens/employees_analytics_screen.dart
+++ b/lib/modules/analytics/screens/employees_analytics_screen.dart
@@ -1,4 +1,122 @@
-// Реэкспорт виджета таблицы сотрудников и оболочки экрана.
-// Сам отдельный экран не нужен — он встроен в AnalyticsHomeScreen.
-// Файл сохранён для согласованности структуры модуля.
-export '../widgets/employees_table.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../personnel/personnel_provider.dart';
+import '../services/analytics_permission_service.dart';
+import '../services/analytics_service.dart';
+import '../utils/analytics_colors.dart';
+import '../widgets/analytics_states.dart';
+import '../widgets/employees_table.dart';
+import 'employee_detail_screen.dart';
+
+class EmployeesAnalyticsScreen extends StatefulWidget {
+  const EmployeesAnalyticsScreen({
+    super.key,
+    required this.service,
+    required this.permission,
+  });
+
+  final AnalyticsService service;
+  final AnalyticsPermissionService permission;
+
+  @override
+  State<EmployeesAnalyticsScreen> createState() =>
+      _EmployeesAnalyticsScreenState();
+}
+
+class _EmployeesAnalyticsScreenState extends State<EmployeesAnalyticsScreen> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.service,
+      builder: (context, _) {
+        final state = widget.service.state;
+        if (state.loading) {
+          return const AnalyticsLoadingState();
+        }
+        if (state.error != null) {
+          return AnalyticsErrorState(
+            message:
+                'Не удалось загрузить аналитику сотрудников.\n${state.error}',
+            onRetry: () => widget.service.refresh(),
+          );
+        }
+
+        final personnel = context.read<PersonnelProvider>();
+        final activeEmployees = personnel.employees.where((e) => !e.isFired);
+        if (activeEmployees.isEmpty) {
+          return const AnalyticsEmptyState(
+            icon: Icons.people_outline,
+            message: 'Нет активных сотрудников для выбранного месяца.',
+          );
+        }
+
+        return _AnalyticsTableCard(
+          controller: _scrollController,
+          child: EmployeesTable(
+            service: widget.service,
+            personnel: personnel,
+            canViewFinance: widget.permission.canViewFinance,
+            onEmployeeTap: (id) {
+              Navigator.of(context).push(MaterialPageRoute(
+                builder: (_) => EmployeeDetailScreen(
+                  service: widget.service,
+                  permission: widget.permission,
+                  employeeId: id,
+                ),
+              ));
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AnalyticsTableCard extends StatelessWidget {
+  const _AnalyticsTableCard({
+    required this.controller,
+    required this.child,
+  });
+
+  final ScrollController controller;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AnalyticsColors.card,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: AnalyticsColors.line),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Scrollbar(
+          controller: controller,
+          thumbVisibility: true,
+          child: SingleChildScrollView(
+            controller: controller,
+            primary: false,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/analytics/screens/work_schedule_screen.dart
+++ b/lib/modules/analytics/screens/work_schedule_screen.dart
@@ -1,2 +1,110 @@
-// Реэкспорт сетки графиков работы.
-export '../widgets/schedule_grid.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../personnel/personnel_provider.dart';
+import '../services/analytics_permission_service.dart';
+import '../services/analytics_service.dart';
+import '../utils/analytics_colors.dart';
+import '../widgets/analytics_states.dart';
+import '../widgets/schedule_grid.dart';
+
+class WorkScheduleScreen extends StatefulWidget {
+  const WorkScheduleScreen({
+    super.key,
+    required this.service,
+    required this.permission,
+  });
+
+  final AnalyticsService service;
+  final AnalyticsPermissionService permission;
+
+  @override
+  State<WorkScheduleScreen> createState() => _WorkScheduleScreenState();
+}
+
+class _WorkScheduleScreenState extends State<WorkScheduleScreen> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.service,
+      builder: (context, _) {
+        final state = widget.service.state;
+        if (state.loading) {
+          return const AnalyticsLoadingState(label: 'Загружаем график работы…');
+        }
+        if (state.error != null) {
+          return AnalyticsErrorState(
+            message: 'Не удалось загрузить график работы.\n${state.error}',
+            onRetry: () => widget.service.refresh(),
+          );
+        }
+
+        final personnel = context.read<PersonnelProvider>();
+        final activeEmployees = personnel.employees.where((e) => !e.isFired);
+        if (activeEmployees.isEmpty) {
+          return const AnalyticsEmptyState(
+            icon: Icons.calendar_month_outlined,
+            message: 'Нет активных сотрудников для графика работы.',
+          );
+        }
+
+        return _AnalyticsTableCard(
+          controller: _scrollController,
+          child: ScheduleGrid(
+            service: widget.service,
+            personnel: personnel,
+            canEdit: widget.permission.canEdit,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AnalyticsTableCard extends StatelessWidget {
+  const _AnalyticsTableCard({
+    required this.controller,
+    required this.child,
+  });
+
+  final ScrollController controller;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AnalyticsColors.card,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: AnalyticsColors.line),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Scrollbar(
+          controller: controller,
+          thumbVisibility: true,
+          child: SingleChildScrollView(
+            controller: controller,
+            primary: false,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/analytics/screens/workplaces_analytics_screen.dart
+++ b/lib/modules/analytics/screens/workplaces_analytics_screen.dart
@@ -1,2 +1,121 @@
-// Реэкспорт таблицы рабочих мест.
-export '../widgets/workplaces_table.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../personnel/personnel_provider.dart';
+import '../services/analytics_permission_service.dart';
+import '../services/analytics_service.dart';
+import '../utils/analytics_colors.dart';
+import '../widgets/analytics_states.dart';
+import '../widgets/workplaces_table.dart';
+import 'workplace_detail_screen.dart';
+
+class WorkplacesAnalyticsScreen extends StatefulWidget {
+  const WorkplacesAnalyticsScreen({
+    super.key,
+    required this.service,
+    required this.permission,
+  });
+
+  final AnalyticsService service;
+  final AnalyticsPermissionService permission;
+
+  @override
+  State<WorkplacesAnalyticsScreen> createState() =>
+      _WorkplacesAnalyticsScreenState();
+}
+
+class _WorkplacesAnalyticsScreenState extends State<WorkplacesAnalyticsScreen> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.service,
+      builder: (context, _) {
+        final state = widget.service.state;
+        if (state.loading) {
+          return const AnalyticsLoadingState();
+        }
+        if (state.error != null) {
+          return AnalyticsErrorState(
+            message:
+                'Не удалось загрузить аналитику рабочих мест.\n${state.error}',
+            onRetry: () => widget.service.refresh(),
+          );
+        }
+
+        final personnel = context.read<PersonnelProvider>();
+        if (personnel.workplaces.isEmpty) {
+          return const AnalyticsEmptyState(
+            icon: Icons.precision_manufacturing_outlined,
+            message: 'Нет рабочих мест для отображения аналитики.',
+          );
+        }
+
+        return _AnalyticsTableCard(
+          controller: _scrollController,
+          child: WorkplacesTable(
+            service: widget.service,
+            personnel: personnel,
+            canEditCoefficient: widget.permission.canEdit,
+            onWorkplaceTap: (id) {
+              Navigator.of(context).push(MaterialPageRoute(
+                builder: (_) => WorkplaceDetailScreen(
+                  service: widget.service,
+                  permission: widget.permission,
+                  workplaceId: id,
+                ),
+              ));
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AnalyticsTableCard extends StatelessWidget {
+  const _AnalyticsTableCard({
+    required this.controller,
+    required this.child,
+  });
+
+  final ScrollController controller;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AnalyticsColors.card,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: AnalyticsColors.line),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Scrollbar(
+          controller: controller,
+          thumbVisibility: true,
+          child: SingleChildScrollView(
+            controller: controller,
+            primary: false,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Make each analytics tab a standalone screen that manages its own loading/error/empty/table states and preserve selected month/filter across navigation by sharing a single `AnalyticsService` instance.
- Replace fragile re-export stubs in `screens/` with real screen widgets and allow opening analytics on a specific tab via routes/entry plumbing.

### Description
- Replaced re-export stub files with real stateful screen widgets: `EmployeesAnalyticsScreen`, `WorkplacesAnalyticsScreen` and `WorkScheduleScreen` that handle `loading`/`error`/`empty` and render the respective table/grid (files in `lib/modules/analytics/screens/`).
- Changed `AnalyticsHomeScreen` to host tab content as real widgets inside an `IndexedStack` (keeps tabs mounted) and added `initialTab` constructor param to open a specific tab; removed per-tab scroll controllers in favour of per-screen controllers owned by each screen.
- Added routing and entry plumbing: `AnalyticsEntry` and `AnalyticsRoutes` now accept `initialTab`, new route names (`/analytics/employees`, `/analytics/workplaces`, `/analytics/schedule`) and helper builders `buildEmployeesRoute`, `buildWorkplacesRoute`, and `buildScheduleRoute` to open the module on a chosen tab.
- Ensured detail screens (`EmployeeDetailScreen`, `WorkplaceDetailScreen`) continue to use the shared `AnalyticsService`, so the selected month and filters are preserved when navigating to details and back.

### Testing
- Ran `git diff --check` to ensure no whitespace/errors from edits, which passed.
- Verified there are no `export` stubs left in `lib/modules/analytics/screens` using `rg`, which passed.
- Attempted `dart format` and `flutter analyze` but they could not be executed in the environment because `dart`/`flutter` are not installed. These formatting/analysis steps should be run in CI or a local environment before merging.
- Changes committed with message: "Unify analytics tab screens".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1935b1c2d4832f80d9a5087caab4a3)