### PR TITLE
Enforce analytics role-based permissions and protect finance operations

### DIFF
--- a/lib/modules/analytics/analytics_module.dart
+++ b/lib/modules/analytics/analytics_module.dart
@@ -14,9 +14,10 @@ import 'package:flutter/material.dart';
 
 import 'screens/analytics_home_screen.dart';
 import 'services/analytics_permission_service.dart';
+import 'widgets/analytics_states.dart';
 import 'widgets/analytics_topbar.dart';
 
-class AnalyticsEntry extends StatelessWidget {
+class AnalyticsEntry extends StatefulWidget {
   const AnalyticsEntry({
     super.key,
     required this.isTechLeader,
@@ -36,14 +37,36 @@ class AnalyticsEntry extends StatelessWidget {
   final AnalyticsTopTab initialTab;
 
   @override
-  Widget build(BuildContext context) {
-    final permission = AnalyticsPermissionService(
-      isTechLeader: isTechLeader,
-      currentEmployeeId: currentEmployeeId,
+  State<AnalyticsEntry> createState() => _AnalyticsEntryState();
+}
+
+class _AnalyticsEntryState extends State<AnalyticsEntry> {
+  late final Future<AnalyticsPermissionService> _permissionFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _permissionFuture = AnalyticsPermissionService.fromTrustedSupabaseContext(
+      fallbackIsTechLeader: widget.isTechLeader,
+      currentEmployeeId: widget.currentEmployeeId,
     );
-    return AnalyticsHomeScreen(
-      permission: permission,
-      initialTab: initialTab,
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<AnalyticsPermissionService>(
+      future: _permissionFuture,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Scaffold(
+            body: AnalyticsLoadingState(label: 'Проверяем права доступа…'),
+          );
+        }
+        return AnalyticsHomeScreen(
+          permission: snapshot.requireData,
+          initialTab: widget.initialTab,
+        );
+      },
     );
   }
 }

--- a/lib/modules/analytics/analytics_routes.dart
+++ b/lib/modules/analytics/analytics_routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'analytics_module.dart';
+import 'screens/analytics_access_denied_screen.dart';
 import 'widgets/analytics_topbar.dart';
 
 class AnalyticsRoutes {
@@ -10,6 +11,14 @@ class AnalyticsRoutes {
   static const String employees = '/analytics/employees';
   static const String workplaces = '/analytics/workplaces';
   static const String schedule = '/analytics/schedule';
+  static const String accessDenied = '/analytics/access-denied';
+
+  static Route<dynamic> buildAccessDeniedRoute() {
+    return MaterialPageRoute(
+      settings: const RouteSettings(name: accessDenied),
+      builder: (_) => const AnalyticsAccessDeniedScreen(),
+    );
+  }
 
   static Route<dynamic> buildHomeRoute({
     required bool isTechLeader,

--- a/lib/modules/analytics/repositories/salary_adjustments_repository.dart
+++ b/lib/modules/analytics/repositories/salary_adjustments_repository.dart
@@ -1,6 +1,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/salary_adjustments.dart';
+import '../services/analytics_permission_service.dart';
 
 class SalaryAdjustmentsRepository {
   SalaryAdjustmentsRepository({SupabaseClient? client})
@@ -26,7 +27,14 @@ class SalaryAdjustmentsRepository {
     return result;
   }
 
-  Future<SalaryAdjustments> upsert(SalaryAdjustments adj, {String? updatedBy}) async {
+  Future<SalaryAdjustments> upsert(
+    SalaryAdjustments adj, {
+    required AnalyticsPermissionService? permission,
+    String? updatedBy,
+  }) async {
+    if (permission?.canEdit != true) {
+      throw StateError('У вас нет прав на изменение финансовых данных.');
+    }
     final iso = _isoDate(DateTime(adj.month.year, adj.month.month, 1));
     final result = await _client
         .from('employee_month_salary_adjustments')

--- a/lib/modules/analytics/repositories/salary_settings_repository.dart
+++ b/lib/modules/analytics/repositories/salary_settings_repository.dart
@@ -1,6 +1,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/salary_settings.dart';
+import '../services/analytics_permission_service.dart';
 
 class SalarySettingsRepository {
   SalarySettingsRepository({SupabaseClient? client})
@@ -28,12 +29,16 @@ class SalarySettingsRepository {
 
   /// Сохраняет настройки для указанного месяца (upsert).
   Future<SalarySettings> save({
+    required AnalyticsPermissionService? permission,
     required DateTime month,
     required double nightPercent,
     required double mealAmount,
     required double socialDefault,
     String? updatedBy,
   }) async {
+    if (permission?.canEdit != true) {
+      throw StateError('У вас нет прав на изменение финансовых данных.');
+    }
     final firstDay = DateTime(month.year, month.month, 1);
     final iso = _isoDate(firstDay);
     final result = await _client

--- a/lib/modules/analytics/repositories/workplace_coefficient_repository.dart
+++ b/lib/modules/analytics/repositories/workplace_coefficient_repository.dart
@@ -1,6 +1,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../models/workplace_coefficient.dart';
+import '../services/analytics_permission_service.dart';
 
 class WorkplaceCoefficientRepository {
   WorkplaceCoefficientRepository({SupabaseClient? client})
@@ -48,11 +49,15 @@ class WorkplaceCoefficientRepository {
   }
 
   Future<void> upsert({
+    required AnalyticsPermissionService? permission,
     required String workplaceId,
     required double coefficient,
     required DateTime month,
     String? updatedBy,
   }) async {
+    if (permission?.canEdit != true) {
+      throw StateError('У вас нет прав на изменение финансовых данных.');
+    }
     final iso = _isoDate(DateTime(month.year, month.month, 1));
     await _client.from('workplace_coefficients').upsert(
       {

--- a/lib/modules/analytics/screens/analytics_access_denied_screen.dart
+++ b/lib/modules/analytics/screens/analytics_access_denied_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/analytics_shell.dart';
+import '../widgets/analytics_states.dart';
+
+/// Явный экран для маршрутов аналитики, которые недоступны текущему пользователю.
+class AnalyticsAccessDeniedScreen extends StatelessWidget {
+  const AnalyticsAccessDeniedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const AnalyticsShell(
+      child: Center(child: AnalyticsAccessDeniedState()),
+    );
+  }
+}

--- a/lib/modules/analytics/screens/analytics_home_screen.dart
+++ b/lib/modules/analytics/screens/analytics_home_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/analytics_shell.dart';
 import '../widgets/analytics_states.dart';
 import '../widgets/analytics_topbar.dart';
 import '../widgets/salary_settings_drawer.dart';
+import 'analytics_access_denied_screen.dart';
 import 'employee_detail_screen.dart';
 import 'employees_analytics_screen.dart';
 import 'work_schedule_screen.dart';
@@ -53,6 +54,7 @@ class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
         personnel: context.read<PersonnelProvider>(),
         orders: context.read<OrdersProvider>(),
         tasks: context.read<TaskProvider>(),
+        permission: widget.permission,
       );
       _service.loadMonth(AnalyticsMonth.current());
       // если пришла обновлённая база — перезагрузим аналитику.
@@ -83,11 +85,15 @@ class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
         final state = _service.state;
         final canViewAll = permission.canViewAllEmployees;
 
-        // Сотрудник без прав видит только свою деталку.
+        // Сотрудник без прав видит только свою деталку; прямые
+        // маршруты в разделы списка/графиков/рабочих мест блокируются явно.
+        if (!canViewAll && widget.initialTab != AnalyticsTopTab.employees) {
+          return const AnalyticsAccessDeniedScreen();
+        }
+
         if (!canViewAll) {
           if (permission.currentEmployeeId == null) {
-            return const AnalyticsShell(
-                child: Center(child: AnalyticsAccessDeniedState()));
+            return const AnalyticsAccessDeniedScreen();
           }
           // Сразу подсунем деталку сотрудника.
           return EmployeeDetailScreen(

--- a/lib/modules/analytics/screens/employee_detail_screen.dart
+++ b/lib/modules/analytics/screens/employee_detail_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/analytics_states.dart';
 import '../widgets/day_events_table.dart';
 import '../widgets/employee_workplace_strip.dart';
 import '../widgets/timeline_widget.dart';
+import 'analytics_access_denied_screen.dart';
 
 class EmployeeDetailScreen extends StatefulWidget {
   const EmployeeDetailScreen({
@@ -52,8 +53,7 @@ class _EmployeeDetailScreenState extends State<EmployeeDetailScreen> {
   @override
   Widget build(BuildContext context) {
     if (!widget.permission.canViewEmployee(_employeeId)) {
-      return const AnalyticsShell(
-          child: Center(child: AnalyticsAccessDeniedState()));
+      return const AnalyticsAccessDeniedScreen();
     }
     return AnimatedBuilder(
       animation: widget.service,

--- a/lib/modules/analytics/screens/employees_analytics_screen.dart
+++ b/lib/modules/analytics/screens/employees_analytics_screen.dart
@@ -70,7 +70,7 @@ class _EmployeesAnalyticsScreenState extends State<EmployeesAnalyticsScreen> {
           child: EmployeesTable(
             service: widget.service,
             personnel: personnel,
-            canViewFinance: widget.permission.canViewFinance,
+            permission: widget.permission,
             onEmployeeTap: (id) {
               Navigator.of(context).push(MaterialPageRoute(
                 builder: (_) => EmployeeDetailScreen(

--- a/lib/modules/analytics/services/analytics_permission_service.dart
+++ b/lib/modules/analytics/services/analytics_permission_service.dart
@@ -1,10 +1,17 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 import '../../personnel/employee_model.dart';
 import '../../personnel/personnel_constants.dart';
 
 /// Управление правами доступа к аналитике.
 ///
-/// - Технический лидер (positionId == kTechLeaderId) или флаг
-///   userMetadata.role == 'lead' / 'tech_leader' — полный доступ.
+/// Источник прав не должен ограничиваться входным bool из UI: сервис умеет
+/// поднимать роль из доверенного Supabase-профиля текущего пользователя
+/// (app/user metadata и таблицы ролей/профилей) и только затем применять
+/// локальный fallback по должности сотрудника.
+///
+/// - Технический лидер (positionId == kTechLeaderId) или роль
+///   `lead` / `tech_lead` / `tech_leader` — полный доступ.
 /// - Иначе обычный сотрудник: видит только себя, без финансов.
 class AnalyticsPermissionService {
   AnalyticsPermissionService({
@@ -14,6 +21,7 @@ class AnalyticsPermissionService {
 
   /// true, если текущий пользователь — Технический лидер.
   final bool isTechLeader;
+
   /// id сотрудника, под которым выполнен вход (или null).
   final String? currentEmployeeId;
 
@@ -33,7 +41,14 @@ class AnalyticsPermissionService {
     return currentEmployeeId == employeeId;
   }
 
-  /// Фабрика на основе данных профиля.
+  /// Единая проверка для всех финансовых write-операций.
+  void ensureCanEditFinance() {
+    if (!canEdit) {
+      throw StateError('У вас нет прав на изменение финансовых данных.');
+    }
+  }
+
+  /// Фабрика на основе уже загруженных локальных данных профиля.
   factory AnalyticsPermissionService.fromContext({
     required bool isTechLeaderRole,
     EmployeeModel? employee,
@@ -44,5 +59,86 @@ class AnalyticsPermissionService {
       isTechLeader: isTechLeaderRole || hasTechLeaderPosition,
       currentEmployeeId: employee?.id,
     );
+  }
+
+  /// Собирает права из Supabase и локального fallback.
+  ///
+  /// Поддержаны несколько распространённых схем хранения ролей, чтобы модуль
+  /// не зависел от конкретного названия таблицы в проекте:
+  /// - `auth.users.app_metadata/user_metadata.role`;
+  /// - `user_roles` с колонками `user_id`, `role`;
+  /// - `profiles` с колонками `id`, `role`;
+  /// - `employee_roles` с колонками `employee_id`, `role`.
+  static Future<AnalyticsPermissionService> fromTrustedSupabaseContext({
+    required bool fallbackIsTechLeader,
+    required String? currentEmployeeId,
+    SupabaseClient? client,
+  }) async {
+    final supabase = client ?? Supabase.instance.client;
+    final user = supabase.auth.currentUser;
+    var trustedLead = fallbackIsTechLeader;
+
+    trustedLead = trustedLead || _isLeadRole(user?.appMetadata?['role']);
+    trustedLead = trustedLead || _isLeadRole(user?.userMetadata?['role']);
+
+    if (user != null && !trustedLead) {
+      trustedLead = await _hasRoleInTable(
+        client: supabase,
+        table: 'user_roles',
+        idColumn: 'user_id',
+        id: user.id,
+      );
+    }
+    if (user != null && !trustedLead) {
+      trustedLead = await _hasRoleInTable(
+        client: supabase,
+        table: 'profiles',
+        idColumn: 'id',
+        id: user.id,
+      );
+    }
+    final employeeId = currentEmployeeId?.trim();
+    if (!trustedLead && employeeId != null && employeeId.isNotEmpty) {
+      trustedLead = await _hasRoleInTable(
+        client: supabase,
+        table: 'employee_roles',
+        idColumn: 'employee_id',
+        id: employeeId,
+      );
+    }
+
+    return AnalyticsPermissionService(
+      isTechLeader: trustedLead,
+      currentEmployeeId: currentEmployeeId,
+    );
+  }
+
+  static Future<bool> _hasRoleInTable({
+    required SupabaseClient client,
+    required String table,
+    required String idColumn,
+    required String id,
+  }) async {
+    try {
+      final rows = await client
+          .from(table)
+          .select('role')
+          .eq(idColumn, id)
+          .limit(20);
+      if (rows is! List) return false;
+      return rows.any((row) {
+        if (row is! Map) return false;
+        return _isLeadRole(row['role']);
+      });
+    } on PostgrestException {
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static bool _isLeadRole(Object? rawRole) {
+    final role = rawRole?.toString().trim().toLowerCase();
+    return role == 'lead' || role == 'tech_lead' || role == 'tech_leader';
   }
 }

--- a/lib/modules/analytics/services/analytics_service.dart
+++ b/lib/modules/analytics/services/analytics_service.dart
@@ -17,6 +17,7 @@ import '../repositories/salary_adjustments_repository.dart';
 import '../repositories/salary_settings_repository.dart';
 import '../repositories/work_schedule_repository.dart';
 import '../repositories/workplace_coefficient_repository.dart';
+import 'analytics_permission_service.dart';
 
 /// Состояние данных аналитики на выбранный месяц.
 class AnalyticsState {
@@ -104,13 +105,15 @@ class AnalyticsService extends ChangeNotifier {
     EmployeeStatusRepository? statusRepo,
     ClaimsRepository? claimsRepo,
     AnalyticsRepository? analyticsRepo,
+    AnalyticsPermissionService? permission,
   })  : _coefficientsRepo = coefficientsRepo ?? WorkplaceCoefficientRepository(),
         _salarySettingsRepo = salarySettingsRepo ?? SalarySettingsRepository(),
         _adjustmentsRepo = adjustmentsRepo ?? SalaryAdjustmentsRepository(),
         _scheduleRepo = scheduleRepo ?? WorkScheduleRepository(),
         _statusRepo = statusRepo ?? EmployeeStatusRepository(),
         _claimsRepo = claimsRepo ?? ClaimsRepository(),
-        _analyticsRepo = analyticsRepo ?? AnalyticsRepository();
+        _analyticsRepo = analyticsRepo ?? AnalyticsRepository(),
+        _permission = permission;
 
   final PersonnelProvider personnel;
   final OrdersProvider orders;
@@ -123,6 +126,7 @@ class AnalyticsService extends ChangeNotifier {
   final EmployeeStatusRepository _statusRepo;
   final ClaimsRepository _claimsRepo;
   final AnalyticsRepository _analyticsRepo;
+  final AnalyticsPermissionService? _permission;
 
   AnalyticsState _state =
       AnalyticsState(month: AnalyticsMonth.current(), loading: true);
@@ -190,7 +194,11 @@ class AnalyticsService extends ChangeNotifier {
     required double coefficient,
     String? actorId,
   }) async {
+    if (_permission?.canEdit != true) {
+      throw StateError('У вас нет прав на изменение финансовых данных.');
+    }
     await _coefficientsRepo.upsert(
+      permission: _permission,
       workplaceId: workplaceId,
       coefficient: coefficient,
       month: _state.month.firstDay,
@@ -209,7 +217,11 @@ class AnalyticsService extends ChangeNotifier {
     required double socialDefault,
     String? actorId,
   }) async {
+    if (_permission?.canEdit != true) {
+      throw StateError('У вас нет прав на изменение финансовых данных.');
+    }
     final saved = await _salarySettingsRepo.save(
+      permission: _permission,
       month: _state.month.firstDay,
       nightPercent: nightPercent,
       mealAmount: mealAmount,
@@ -223,7 +235,14 @@ class AnalyticsService extends ChangeNotifier {
   /// Сохраняет ручные корректировки зарплаты по сотруднику за месяц.
   Future<void> saveSalaryAdjustments(SalaryAdjustments adj,
       {String? actorId}) async {
-    final saved = await _adjustmentsRepo.upsert(adj, updatedBy: actorId);
+    if (_permission?.canEdit != true) {
+      throw StateError('У вас нет прав на изменение финансовых данных.');
+    }
+    final saved = await _adjustmentsRepo.upsert(
+      adj,
+      permission: _permission,
+      updatedBy: actorId,
+    );
     final next = Map<String, SalaryAdjustments>.from(_state.adjustments);
     next[saved.employeeId] = saved;
     _state = _state.copyWith(adjustments: next);

--- a/lib/modules/analytics/widgets/employees_table.dart
+++ b/lib/modules/analytics/widgets/employees_table.dart
@@ -10,6 +10,7 @@ import '../models/analytics_event.dart';
 import '../models/employee_status.dart';
 import '../models/pay_type.dart';
 import '../models/salary_adjustments.dart';
+import '../services/analytics_permission_service.dart';
 import '../services/analytics_service.dart';
 import '../utils/analytics_colors.dart';
 import '../utils/analytics_constants.dart';
@@ -20,17 +21,18 @@ class EmployeesTable extends StatelessWidget {
     super.key,
     required this.service,
     required this.personnel,
-    required this.canViewFinance,
+    required this.permission,
     required this.onEmployeeTap,
   });
 
   final AnalyticsService service;
   final PersonnelProvider personnel;
-  final bool canViewFinance;
+  final AnalyticsPermissionService permission;
   final ValueChanged<String> onEmployeeTap;
 
   @override
   Widget build(BuildContext context) {
+    final canViewFinance = permission.canViewFinance;
     final state = service.state;
     final events = state.events;
     final eventsByEmployee = <String, List<AnalyticsEvent>>{};
@@ -47,8 +49,9 @@ class EmployeesTable extends StatelessWidget {
       for (final s in state.statuses) s.id: s,
     };
 
-    final activeEmployees =
-        personnel.employees.where((e) => !e.isFired).toList()
+    final activeEmployees = personnel.employees
+        .where((e) => !e.isFired && permission.canViewEmployee(e.id))
+        .toList()
           ..sort((a, b) => ('${a.lastName} ${a.firstName}')
               .compareTo('${b.lastName} ${b.firstName}'));
 
@@ -176,7 +179,9 @@ class EmployeesTable extends StatelessWidget {
     }).toList();
 
     return InkWell(
-      onTap: () => onEmployeeTap(r.employee.id),
+      onTap: permission.canViewEmployee(r.employee.id)
+          ? () => onEmployeeTap(r.employee.id)
+          : null,
       child: Container(
         decoration: BoxDecoration(
           color: AnalyticsColors.card2.withOpacity(0.6),


### PR DESCRIPTION
### Motivation
- Support deriving the analytics role from a trusted Supabase profile/roles (app/user metadata and common role tables) instead of relying only on a UI-provided bool.
- Prevent unauthorized users from updating financial data (salary settings/adjustments/workplace coefficients) by enforcing checks both in the service layer and in repositories.
- Centralize visibility rules for employees/finance columns and provide a clear access-denied UX for blocked routes.

### Description
- Added `AnalyticsPermissionService.fromTrustedSupabaseContext(...)` that resolves roles from `auth` metadata and common tables (`user_roles`, `profiles`, `employee_roles`) and added `ensureCanEditFinance()` and `canView*` helpers to centralize permissions (new/updated: `lib/modules/analytics/services/analytics_permission_service.dart`).
- Made `AnalyticsEntry` wait for the trusted permission context via a `FutureBuilder` and upgraded it to a `StatefulWidget` so UI uses the resolved permissions before rendering (updated: `lib/modules/analytics/analytics_module.dart`).
- Plumbed permission checks into `AnalyticsService` so writes call permission guards and pass the permission down to repositories (updated: `lib/modules/analytics/services/analytics_service.dart`).
- Updated repositories for salary settings, salary adjustments and workplace coefficients to accept an optional `AnalyticsPermissionService? permission` parameter and to validate `permission.canEdit` before performing `upsert`/`save` (updated: `lib/modules/analytics/repositories/salary_settings_repository.dart`, `salary_adjustments_repository.dart`, `workplace_coefficient_repository.dart`).
- Centralized UI usage of permissions: `EmployeesTable` now receives `AnalyticsPermissionService permission` (instead of a lone `canViewFinance` bool), filters rows by `permission.canViewEmployee`, gates row taps, and shows/hides finance columns via `permission.canViewFinance` (updated: `lib/modules/analytics/widgets/employees_table.dart` and `lib/modules/analytics/screens/employees_analytics_screen.dart`).
- Added an explicit access-denied screen/route and used it where direct navigation to disallowed analytics tabs or employee details should be blocked (added: `lib/modules/analytics/screens/analytics_access_denied_screen.dart`; updated: `analytics_home_screen.dart`, `employee_detail_screen.dart`, `analytics_routes.dart`).

### Testing
- Ran `git diff --check` to ensure no whitespace/merge issues and it passed successfully. 
- Attempted to run `dart format` / `flutter analyze` but the environment lacks `dart`/`flutter`, so those automated checks could not be executed here (no unit or analyzer runs were performed).
- All code changes were committed locally as a single change set titled "Secure analytics finance permissions".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19381bc7b0832fa67e1c949c29bdfb)