### PR TITLE
Debounce and retry TaskProvider refresh; add analytics audit table migration and manual SQL

### DIFF
--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -206,6 +206,8 @@ class TaskProvider with ChangeNotifier {
   final Set<String> _loadedStageSequenceOrderIds = <String>{};
   RealtimeChannel? _tasksChannel;
   final List<RealtimeChannel> _stageSyncChannels = <RealtimeChannel>[];
+  Future<void>? _activeRefresh;
+  bool _refreshQueued = false;
 
   TaskProvider() {
     _listenToTasks();
@@ -448,22 +450,88 @@ class TaskProvider with ChangeNotifier {
     return null;
   }
 
-  Future<void> refresh() async {
-    await _ensureAuthed();
+  Future<void> refresh() {
+    final active = _activeRefresh;
+    if (active != null) {
+      _refreshQueued = true;
+      return active;
+    }
+
+    final future = _runRefreshLoop();
+    _activeRefresh = future;
+    return future.whenComplete(() {
+      if (identical(_activeRefresh, future)) {
+        _activeRefresh = null;
+      }
+    });
+  }
+
+  Future<void> _runRefreshLoop() async {
+    do {
+      _refreshQueued = false;
+      await _refreshOnceWithRetry();
+    } while (_refreshQueued);
+  }
+
+  Future<void> _refreshOnceWithRetry() async {
     try {
-      await _loadWorkplaceAliases();
-      final rows =
-          await _supabase.from('tasks').select('*').order('created_at');
-      _tasks
-        ..clear()
-        ..addAll(List<Map<String, dynamic>>.from(rows as List).map(_rowToTask));
-      final orderIds = _tasks.map((t) => t.orderId).toSet();
-      _loadedStageSequenceOrderIds.clear();
-      await _preloadStageSequences(orderIds);
+      await _retryTransientSupabase('refresh tasks', () async {
+        await _ensureAuthed();
+        await _loadWorkplaceAliases();
+        final rows =
+            await _supabase.from('tasks').select('*').order('created_at');
+        _tasks
+          ..clear()
+          ..addAll(
+              List<Map<String, dynamic>>.from(rows as List).map(_rowToTask));
+        final orderIds = _tasks.map((t) => t.orderId).toSet();
+        _loadedStageSequenceOrderIds.clear();
+        await _preloadStageSequences(orderIds);
+      });
       notifyListeners();
     } catch (e, st) {
       debugPrint('❌ refresh tasks error: $e\n$st');
     }
+  }
+
+  Future<T> _retryTransientSupabase<T>(
+    String operation,
+    Future<T> Function() action,
+  ) async {
+    Object? lastError;
+    StackTrace? lastStackTrace;
+
+    for (var attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        return await action().timeout(const Duration(seconds: 25));
+      } catch (e, st) {
+        lastError = e;
+        lastStackTrace = st;
+        if (!_isTransientSupabaseError(e) || attempt == 3) {
+          break;
+        }
+        debugPrint(
+          '⚠️ $operation: transient Supabase connection error, '
+          'retry $attempt/3: $e',
+        );
+        await Future<void>.delayed(Duration(milliseconds: 350 * attempt));
+      }
+    }
+
+    Error.throwWithStackTrace(lastError!, lastStackTrace!);
+  }
+
+  bool _isTransientSupabaseError(Object error) {
+    final text = error.toString().toLowerCase();
+    return text.contains('handshakeexception') ||
+        text.contains('connection terminated during handshake') ||
+        text.contains('socketexception') ||
+        text.contains('connection closed') ||
+        text.contains('connection reset') ||
+        text.contains('connection refused') ||
+        text.contains('failed host lookup') ||
+        text.contains('timed out') ||
+        text.contains('timeout');
   }
 
   void _listenToTasks() {

--- a/supabase/manual_sql/fix_public_analytics_audit_table.sql
+++ b/supabase/manual_sql/fix_public_analytics_audit_table.sql
@@ -1,0 +1,66 @@
+-- Copy/paste this whole file into the Supabase SQL editor.
+-- Do not copy a GitHub diff hunk that starts with "@@ ... @@"; that marker is
+-- not SQL and causes: ERROR 42601: syntax error at or near "@@".
+-- Also do not copy isolated IF/THEN lines from superbase.sql; run this
+-- complete standalone script instead.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.analytics (
+  id uuid primary key default gen_random_uuid(),
+  "orderId" text not null default '',
+  "stageId" text not null default '',
+  "userId" text not null default '',
+  action text not null default '',
+  category text not null default '',
+  details text not null default '',
+  "timestamp" bigint not null default (extract(epoch from now()) * 1000)::bigint,
+  created_at timestamptz not null default now()
+);
+
+alter table public.analytics
+  add column if not exists "orderId" text not null default '',
+  add column if not exists "stageId" text not null default '',
+  add column if not exists "userId" text not null default '',
+  add column if not exists action text not null default '',
+  add column if not exists category text not null default '',
+  add column if not exists details text not null default '',
+  add column if not exists "timestamp" bigint not null default (extract(epoch from now()) * 1000)::bigint,
+  add column if not exists created_at timestamptz not null default now();
+
+do $$
+declare
+  id_type text;
+begin
+  select data_type into id_type
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'analytics'
+    and column_name = 'id';
+
+  if id_type = 'uuid' then
+    alter table public.analytics alter column id set default gen_random_uuid();
+  elsif id_type = 'text' then
+    alter table public.analytics alter column id set default gen_random_uuid()::text;
+  end if;
+end $$;
+
+create index if not exists analytics_user_timestamp_idx
+  on public.analytics ("userId", "timestamp" desc);
+
+create index if not exists analytics_order_stage_idx
+  on public.analytics ("orderId", "stageId");
+
+alter table public.analytics enable row level security;
+
+drop policy if exists analytics_insert_authenticated on public.analytics;
+create policy analytics_insert_authenticated on public.analytics
+  for insert
+  to authenticated
+  with check (true);
+
+drop policy if exists analytics_select_authenticated on public.analytics;
+create policy analytics_select_authenticated on public.analytics
+  for select
+  to authenticated
+  using (true);

--- a/supabase/migrations/20260529_create_audit_analytics_table.sql
+++ b/supabase/migrations/20260529_create_audit_analytics_table.sql
@@ -1,0 +1,67 @@
+-- =====================================================================
+-- Legacy audit log table used by AuditLogService
+-- =====================================================================
+-- The production analytics module lives under lib/modules/analytics and uses
+-- dedicated tables. This table is the lightweight application audit journal
+-- used by login/tasks/personnel/warehouse code paths.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.analytics (
+  id uuid primary key default gen_random_uuid(),
+  "orderId" text not null default '',
+  "stageId" text not null default '',
+  "userId" text not null default '',
+  action text not null default '',
+  category text not null default '',
+  details text not null default '',
+  "timestamp" bigint not null default (extract(epoch from now()) * 1000)::bigint,
+  created_at timestamptz not null default now()
+);
+
+alter table public.analytics
+  add column if not exists "orderId" text not null default '',
+  add column if not exists "stageId" text not null default '',
+  add column if not exists "userId" text not null default '',
+  add column if not exists action text not null default '',
+  add column if not exists category text not null default '',
+  add column if not exists details text not null default '',
+  add column if not exists "timestamp" bigint not null default (extract(epoch from now()) * 1000)::bigint,
+  add column if not exists created_at timestamptz not null default now();
+
+create index if not exists analytics_user_timestamp_idx
+  on public.analytics ("userId", "timestamp" desc);
+
+create index if not exists analytics_order_stage_idx
+  on public.analytics ("orderId", "stageId");
+
+do $$
+declare
+  id_type text;
+begin
+  select data_type into id_type
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'analytics'
+    and column_name = 'id';
+
+  if id_type = 'uuid' then
+    alter table public.analytics alter column id set default gen_random_uuid();
+  elsif id_type = 'text' then
+    alter table public.analytics alter column id set default gen_random_uuid()::text;
+  end if;
+end $$;
+
+alter table public.analytics enable row level security;
+
+drop policy if exists analytics_insert_authenticated on public.analytics;
+create policy analytics_insert_authenticated on public.analytics
+  for insert
+  to authenticated
+  with check (true);
+
+drop policy if exists analytics_select_authenticated on public.analytics;
+create policy analytics_select_authenticated on public.analytics
+  for select
+  to authenticated
+  using (true);


### PR DESCRIPTION
### Motivation
- Prevent overlapping concurrent refreshes of tasks and make refreshes resilient to transient Supabase connection errors.
- Add a lightweight application audit/analytics table with indexes and row-level security for audit logging.

### Description
- Update `TaskProvider` refresh flow to serialize concurrent refreshes by introducing `_activeRefresh`, `_refreshQueued`, `_runRefreshLoop`, and queuing behavior so subsequent `refresh()` calls wait or queue a repeat run.
- Wrap Supabase operations inside a `_retryTransientSupabase` helper that retries transient connection errors up to 3 attempts with a timeout and backoff, and add `_isTransientSupabaseError` to detect common transient error messages.
- Ensure `refresh()` uses the retry wrapper and preserves `notifyListeners()` after loading tasks and preloading stage sequences.
- Add SQL migration `supabase/migrations/20260529_create_audit_analytics_table.sql` to create/ensure the `public.analytics` audit table, indexes, UUID defaults, and row-level security policies, and add `supabase/manual_sql/fix_public_analytics_audit_table.sql` as a standalone script for manual fixes in the Supabase SQL editor.

### Testing
- No automated tests were added or modified in this change and the existing test suite was not executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183a6639a4832f90b86c6f003efac5)