### PR TITLE
Load analytics from task JSON comments instead of missing `public.comments`

### DIFF
--- a/lib/modules/analytics/repositories/analytics_repository.dart
+++ b/lib/modules/analytics/repositories/analytics_repository.dart
@@ -16,19 +16,17 @@ class AnalyticsRepository {
     final monthEnd = month.nextMonthFirstDay.toUtc();
     final reference = (now ?? DateTime.now()).toUtc();
 
-    final List<dynamic> rows = await _client
-        .from('comments')
-        .select(
-            'id, type, text, user_id, timestamp, task_id, tasks!inner(id, stage_id, order_id, orders(id, customer))')
-        .inFilter('type', [
-      'time_event',
-      'quantity_done',
-      'quantity_team_total',
-      'quantity_share',
-      'setup_done',
-    ])
-        .gte('timestamp', monthStart.toIso8601String())
-        .lt('timestamp', monthEnd.toIso8601String());
+    final rows = await _loadTaskCommentRows(
+      types: const {
+        'time_event',
+        'quantity_done',
+        'quantity_team_total',
+        'quantity_share',
+        'setup_done',
+      },
+      from: monthStart,
+      to: monthEnd,
+    );
 
     final events = <AnalyticsEvent>[];
     final Map<String, List<TaskTimeEvent>> rawEventsByGroup = {};
@@ -37,47 +35,55 @@ class AnalyticsRepository {
     final Map<String, _TaskJoinData> taskDataById = {};
 
     for (final row in rows) {
-      if (row is! Map) continue;
-      final map = Map<String, dynamic>.from(row);
-      final type = (map['type'] ?? '').toString();
-      final taskId = (map['task_id'] ?? '').toString();
+      final type = row.type;
+      final taskId = row.taskId;
       if (taskId.isEmpty) continue;
 
-      final taskMap = map['tasks'] is Map ? Map<String, dynamic>.from(map['tasks']) : const <String, dynamic>{};
-      final orderMap = taskMap['orders'] is Map ? Map<String, dynamic>.from(taskMap['orders']) : const <String, dynamic>{};
-      taskDataById[taskId] = _TaskJoinData(
-        stageId: (taskMap['stage_id'] ?? '').toString(),
-        orderId: (taskMap['order_id'] ?? '').toString(),
-        customer: orderMap['customer']?.toString(),
-      );
+      taskDataById[taskId] = row.taskData;
 
-      final timestamp = DateTime.tryParse((map['timestamp'] ?? '').toString())?.toUtc();
-      if (timestamp == null) continue;
-      final commentId = (map['id'] ?? '').toString();
-      final userId = (map['user_id'] ?? '').toString();
+      final timestamp = row.timestamp;
+      final commentId = row.id;
+      final userId = row.userId;
 
       if (type == 'time_event') {
         final ev = TaskTimeEvent.fromPayload(
-          (map['text'] ?? '').toString(),
+          row.text,
           commentId,
           timestamp.millisecondsSinceEpoch,
           userId,
         );
         if (ev == null) continue;
-        final normalized = _normalizeTimeRange(ev.startTime, ev.endTime, reference);
+        final normalized =
+            _normalizeTimeRange(ev.startTime, ev.endTime, reference);
         if (normalized == null) continue;
-        if (!_overlapsMonth(normalized.$1, normalized.$2, monthStart, monthEnd)) continue;
-        rawEventsByGroup.putIfAbsent('$taskId::${ev.subjectUserId}', () => []).add(
+        if (!_overlapsMonth(
+          normalized.$1,
+          normalized.$2,
+          monthStart,
+          monthEnd,
+        )) {
+          continue;
+        }
+        rawEventsByGroup
+            .putIfAbsent('$taskId::${ev.subjectUserId}', () => [])
+            .add(
               ev.copyWith(startTime: normalized.$1, endTime: normalized.$2),
             );
-      } else if (type == 'setup_done' || type == 'quantity_done' || type == 'quantity_team_total' || type == 'quantity_share') {
-        final qty = _parseQty((map['text'] ?? '').toString());
+      } else if (type == 'setup_done' ||
+          type == 'quantity_done' ||
+          type == 'quantity_team_total' ||
+          type == 'quantity_share') {
+        final qty = _parseQty(row.text);
         final groupKey = '$taskId::$userId';
         if (type == 'setup_done') {
           final setupQty = qty > 0 ? qty : 1.0;
-          setupRecordsByGroup.putIfAbsent(groupKey, () => []).add(_QtyRecord(timestamp: timestamp, qty: setupQty));
+          setupRecordsByGroup
+              .putIfAbsent(groupKey, () => [])
+              .add(_QtyRecord(timestamp: timestamp, qty: setupQty));
         } else if (qty > 0) {
-          qtyRecordsByGroup.putIfAbsent(groupKey, () => []).add(_QtyRecord(timestamp: timestamp, qty: qty));
+          qtyRecordsByGroup
+              .putIfAbsent(groupKey, () => [])
+              .add(_QtyRecord(timestamp: timestamp, qty: qty));
         }
       }
     }
@@ -89,8 +95,12 @@ class AnalyticsRepository {
       final taskData = taskDataById[taskId];
 
       list.sort((a, b) => a.startTime.compareTo(b.startTime));
-      final qtyQueue = List<_QtyRecord>.from(qtyRecordsByGroup[groupKey] ?? const [])..sort((a,b)=>a.timestamp.compareTo(b.timestamp));
-      final setupQueue = List<_QtyRecord>.from(setupRecordsByGroup[groupKey] ?? const [])..sort((a,b)=>a.timestamp.compareTo(b.timestamp));
+      final qtyQueue = List<_QtyRecord>.from(
+          qtyRecordsByGroup[groupKey] ?? const <_QtyRecord>[])
+        ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+      final setupQueue = List<_QtyRecord>.from(
+          setupRecordsByGroup[groupKey] ?? const <_QtyRecord>[])
+        ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
 
       for (final raw in list) {
         final eventType = _mapType(raw.type);
@@ -98,12 +108,14 @@ class AnalyticsRepository {
         final effectiveEnd = raw.endTime ?? reference;
         double qty = 0, setupQty = 0;
         if (eventType == AnalyticsEventType.work) {
-          while (qtyQueue.isNotEmpty && !qtyQueue.first.timestamp.isAfter(effectiveEnd)) {
+          while (qtyQueue.isNotEmpty &&
+              !qtyQueue.first.timestamp.isAfter(effectiveEnd)) {
             final rec = qtyQueue.removeAt(0);
             if (!rec.timestamp.isBefore(raw.startTime)) qty += rec.qty;
           }
         } else if (eventType == AnalyticsEventType.setup) {
-          while (setupQueue.isNotEmpty && !setupQueue.first.timestamp.isAfter(effectiveEnd)) {
+          while (setupQueue.isNotEmpty &&
+              !setupQueue.first.timestamp.isAfter(effectiveEnd)) {
             final rec = setupQueue.removeAt(0);
             if (!rec.timestamp.isBefore(raw.startTime)) setupQty += rec.qty;
           }
@@ -115,7 +127,9 @@ class AnalyticsRepository {
           startTime: raw.startTime.toLocal(),
           endTime: raw.endTime?.toLocal(),
           employeeId: employeeId,
-          workplaceId: raw.workplaceId.isNotEmpty ? raw.workplaceId : (taskData?.stageId ?? ''),
+          workplaceId: raw.workplaceId.isNotEmpty
+              ? raw.workplaceId
+              : (taskData?.stageId ?? ''),
           taskId: taskId,
           orderId: taskData?.orderId ?? '',
           customer: taskData?.customer,
@@ -127,7 +141,7 @@ class AnalyticsRepository {
       }
     });
 
-    events.sort((a,b)=>a.startTime.compareTo(b.startTime));
+    events.sort((a, b) => a.startTime.compareTo(b.startTime));
     return events;
   }
 
@@ -141,51 +155,34 @@ class AnalyticsRepository {
     final monthStart = month.firstDay.toUtc();
     final reference = (now ?? monthStart).toUtc();
 
-    final List<dynamic> rows = await _client
-        .from('comments')
-        .select(
-            'id, type, text, user_id, timestamp, task_id, tasks!inner(id, stage_id, order_id, orders(id, customer))')
-        .inFilter('type', [
-      'time_event',
-      'quantity_done',
-      'quantity_team_total',
-      'quantity_share',
-    ])
-        .lt('timestamp', monthStart.toIso8601String())
-        .order('timestamp', ascending: true);
+    final rows = await _loadTaskCommentRows(
+      types: const {
+        'time_event',
+        'quantity_done',
+        'quantity_team_total',
+        'quantity_share',
+      },
+      before: monthStart,
+    );
 
     final Map<String, List<TaskTimeEvent>> rawEventsByGroup = {};
     final Map<String, List<_QtyRecord>> qtyRecordsByGroup = {};
     final Map<String, _TaskJoinData> taskDataById = {};
 
     for (final row in rows) {
-      if (row is! Map) continue;
-      final map = Map<String, dynamic>.from(row);
-      final type = (map['type'] ?? '').toString();
-      final taskId = (map['task_id'] ?? '').toString();
+      final type = row.type;
+      final taskId = row.taskId;
       if (taskId.isEmpty) continue;
 
-      final taskMap = map['tasks'] is Map
-          ? Map<String, dynamic>.from(map['tasks'])
-          : const <String, dynamic>{};
-      final orderMap = taskMap['orders'] is Map
-          ? Map<String, dynamic>.from(taskMap['orders'])
-          : const <String, dynamic>{};
-      taskDataById[taskId] = _TaskJoinData(
-        stageId: (taskMap['stage_id'] ?? '').toString(),
-        orderId: (taskMap['order_id'] ?? '').toString(),
-        customer: orderMap['customer']?.toString(),
-      );
+      taskDataById[taskId] = row.taskData;
 
-      final timestamp =
-          DateTime.tryParse((map['timestamp'] ?? '').toString())?.toUtc();
-      if (timestamp == null) continue;
-      final commentId = (map['id'] ?? '').toString();
-      final userId = (map['user_id'] ?? '').toString();
+      final timestamp = row.timestamp;
+      final commentId = row.id;
+      final userId = row.userId;
 
       if (type == 'time_event') {
         final ev = TaskTimeEvent.fromPayload(
-          (map['text'] ?? '').toString(),
+          row.text,
           commentId,
           timestamp.millisecondsSinceEpoch,
           userId,
@@ -207,7 +204,7 @@ class AnalyticsRepository {
       } else if (type == 'quantity_done' ||
           type == 'quantity_team_total' ||
           type == 'quantity_share') {
-        final qty = _parseQty((map['text'] ?? '').toString());
+        final qty = _parseQty(row.text);
         if (qty <= 0) continue;
         final groupKey = '$taskId::$userId';
         qtyRecordsByGroup
@@ -271,6 +268,133 @@ class AnalyticsRepository {
     return speedsByWorkplace;
   }
 
+  Future<List<_TaskCommentRow>> _loadTaskCommentRows({
+    required Set<String> types,
+    DateTime? from,
+    DateTime? to,
+    DateTime? before,
+  }) async {
+    final List<dynamic> taskRows = await _client
+        .from('tasks')
+        .select('id, stage_id, order_id, comments')
+        .order('created_at', ascending: true);
+
+    final taskMaps = taskRows
+        .whereType<Map>()
+        .map((row) => Map<String, dynamic>.from(row))
+        .toList(growable: false);
+    final orderIds = taskMaps
+        .map((row) => (row['order_id'] ?? '').toString().trim())
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    final customersByOrderId = await _loadCustomersByOrderId(orderIds);
+
+    final result = <_TaskCommentRow>[];
+    for (final task in taskMaps) {
+      final taskId = (task['id'] ?? '').toString();
+      final orderId = (task['order_id'] ?? '').toString();
+      final taskData = _TaskJoinData(
+        stageId: (task['stage_id'] ?? '').toString(),
+        orderId: orderId,
+        customer: customersByOrderId[orderId],
+      );
+
+      for (final comment in _normalizeTaskComments(task['comments'])) {
+        final type = (comment['type'] ?? '').toString();
+        if (!types.contains(type)) continue;
+
+        final timestamp = _parseCommentTimestamp(comment['timestamp']);
+        if (timestamp == null) continue;
+        if (from != null && timestamp.isBefore(from)) continue;
+        if (to != null && !timestamp.isBefore(to)) continue;
+        if (before != null && !timestamp.isBefore(before)) continue;
+
+        result.add(_TaskCommentRow(
+          id: (comment['id'] ?? '').toString(),
+          type: type,
+          text: (comment['text'] ?? '').toString(),
+          userId: (comment['userId'] ?? comment['user_id'] ?? '').toString(),
+          timestamp: timestamp,
+          taskId: taskId,
+          taskData: taskData,
+        ));
+      }
+    }
+
+    result.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return result;
+  }
+
+  Future<Map<String, String>> _loadCustomersByOrderId(
+    Set<String> orderIds,
+  ) async {
+    if (orderIds.isEmpty) return const <String, String>{};
+
+    final rows = await _client
+        .from('orders')
+        .select('id, customer')
+        .inFilter('id', orderIds.toList());
+    if (rows is! List) return const <String, String>{};
+
+    final customers = <String, String>{};
+    for (final row in rows) {
+      if (row is! Map) continue;
+      final id = (row['id'] ?? '').toString();
+      if (id.isEmpty) continue;
+      final customer = row['customer']?.toString();
+      if (customer != null && customer.isNotEmpty) {
+        customers[id] = customer;
+      }
+    }
+    return customers;
+  }
+
+  static List<Map<String, dynamic>> _normalizeTaskComments(dynamic value) {
+    final comments = <Map<String, dynamic>>[];
+    if (value is List) {
+      for (final item in value) {
+        if (item is Map) {
+          comments.add(Map<String, dynamic>.from(item));
+        }
+      }
+    } else if (value is Map) {
+      value.forEach((key, item) {
+        if (item is Map) {
+          final comment = Map<String, dynamic>.from(item);
+          comment.putIfAbsent('id', () => key.toString());
+          comments.add(comment);
+        }
+      });
+    }
+    return comments;
+  }
+
+  static DateTime? _parseCommentTimestamp(dynamic value) {
+    if (value == null) return null;
+    if (value is DateTime) return value.toUtc();
+    if (value is int) {
+      return DateTime.fromMillisecondsSinceEpoch(value, isUtc: true);
+    }
+    if (value is num) {
+      return DateTime.fromMillisecondsSinceEpoch(value.toInt(), isUtc: true);
+    }
+    if (value is String) {
+      final raw = value.trim();
+      if (raw.isEmpty) return null;
+      final intValue = int.tryParse(raw);
+      if (intValue != null) {
+        return DateTime.fromMillisecondsSinceEpoch(intValue, isUtc: true);
+      }
+      final doubleValue = double.tryParse(raw);
+      if (doubleValue != null) {
+        return DateTime.fromMillisecondsSinceEpoch(doubleValue.toInt(),
+            isUtc: true);
+      }
+      return DateTime.tryParse(raw)?.toUtc();
+    }
+    return null;
+  }
+
   static (DateTime, DateTime?)? _normalizeTimeRange(
       DateTime start, DateTime? end, DateTime reference) {
     final utcStart = start.toUtc();
@@ -315,6 +439,26 @@ class AnalyticsRepository {
     if (match != null) return double.tryParse(match.group(0)!) ?? 0;
     return double.tryParse(normalized) ?? 0;
   }
+}
+
+class _TaskCommentRow {
+  final String id;
+  final String type;
+  final String text;
+  final String userId;
+  final DateTime timestamp;
+  final String taskId;
+  final _TaskJoinData taskData;
+
+  const _TaskCommentRow({
+    required this.id,
+    required this.type,
+    required this.text,
+    required this.userId,
+    required this.timestamp,
+    required this.taskId,
+    required this.taskData,
+  });
 }
 
 class _QtyRecord {


### PR DESCRIPTION
### Motivation
- The analytics code attempted to read events from a non-existent `public.comments` table which caused failures when the table was not present.
- Task-related analytics events are actually stored inside `tasks.comments` JSONB, so the repository must read and normalize those to produce correct employee/workplace analytics.

### Description
- Replaced direct reads from `public.comments` with a new loader `_loadTaskCommentRows` that extracts and normalizes comments from `tasks.comments` and attaches `task`/`order` metadata.
- Updated `loadEventsForMonth` and `loadPreviousWorkplaceMonthSpeeds` to consume normalized `_TaskCommentRow` items and preserved previous grouping/quantity/setup aggregation logic.
- Added helpers: `_loadCustomersByOrderId`, `_normalizeTaskComments`, `_parseCommentTimestamp`, and the `_TaskCommentRow` model to handle both array and map JSONB shapes and multiple timestamp formats.
- Kept existing event/time normalization and speed calculation logic while changing only the comment source and intermediate representation.

### Testing
- Ran `git diff --check` which produced no whitespace or diff-check issues (success).
- Attempted `dart format` but the environment lacks the Dart SDK so formatting could not be executed (`dart: command not found`).
- Attempted `flutter analyze` but the environment lacks Flutter so static analysis could not be executed (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1942c982c8832fa988ccb803167c40)