### PR TITLE
Fix analytics UI crashes and suppress transient Windows Alt key assertion

### DIFF
--- a/lib/app_ui_stability.dart
+++ b/lib/app_ui_stability.dart
@@ -21,5 +21,20 @@ final ThemeData appTheme = ThemeData(
 bool isTransientFlutterVisualAssertion(FlutterErrorDetails details) {
   final exceptionText = details.exceptionAsString();
   return exceptionText.contains("'referenceBox.attached': is not true") ||
-      exceptionText.contains("'!_skipMarkNeedsLayout': is not true");
+      exceptionText.contains("'!_skipMarkNeedsLayout': is not true") ||
+      _isWindowsAltKeyStateAssertion(exceptionText);
+}
+
+/// Flutter on Windows can occasionally report a synthesized Alt key-down event
+/// without modifier flags (for example after focus changes or system menu
+/// shortcuts). The event is rejected before application-level keyboard handlers
+/// can see it, so treat only this narrowly identified framework assertion as a
+/// transient platform-keyboard assertion and keep all other keyboard errors
+/// visible.
+bool _isWindowsAltKeyStateAssertion(String exceptionText) {
+  return exceptionText.contains(
+        'Attempted to send a key down event when no keys are in keysPressed',
+      ) &&
+      exceptionText.contains('RawKeyEventDataWindows') &&
+      exceptionText.contains('Alt Left');
 }

--- a/lib/modules/analytics/screens/analytics_home_screen.dart
+++ b/lib/modules/analytics/screens/analytics_home_screen.dart
@@ -36,6 +36,8 @@ class AnalyticsHomeScreen extends StatefulWidget {
 class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
   late AnalyticsTopTab _tab;
   late AnalyticsService _service;
+  late TaskProvider _taskProvider;
+  late OrdersProvider _ordersProvider;
   bool _bootstrapped = false;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
@@ -50,16 +52,19 @@ class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
     super.didChangeDependencies();
     if (!_bootstrapped) {
       _bootstrapped = true;
+      final personnelProvider = context.read<PersonnelProvider>();
+      _ordersProvider = context.read<OrdersProvider>();
+      _taskProvider = context.read<TaskProvider>();
       _service = AnalyticsService(
-        personnel: context.read<PersonnelProvider>(),
-        orders: context.read<OrdersProvider>(),
-        tasks: context.read<TaskProvider>(),
+        personnel: personnelProvider,
+        orders: _ordersProvider,
+        tasks: _taskProvider,
         permission: widget.permission,
       );
       _service.loadMonth(AnalyticsMonth.current());
       // если пришла обновлённая база — перезагрузим аналитику.
-      context.read<TaskProvider>().addListener(_onProvidersChanged);
-      context.read<OrdersProvider>().addListener(_onProvidersChanged);
+      _taskProvider.addListener(_onProvidersChanged);
+      _ordersProvider.addListener(_onProvidersChanged);
     }
   }
 
@@ -70,9 +75,11 @@ class _AnalyticsHomeScreenState extends State<AnalyticsHomeScreen> {
 
   @override
   void dispose() {
-    context.read<TaskProvider>().removeListener(_onProvidersChanged);
-    context.read<OrdersProvider>().removeListener(_onProvidersChanged);
-    _service.dispose();
+    if (_bootstrapped) {
+      _taskProvider.removeListener(_onProvidersChanged);
+      _ordersProvider.removeListener(_onProvidersChanged);
+      _service.dispose();
+    }
     super.dispose();
   }
 

--- a/lib/modules/analytics/widgets/analytics_topbar.dart
+++ b/lib/modules/analytics/widgets/analytics_topbar.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import '../utils/analytics_colors.dart';
@@ -19,69 +21,137 @@ class AnalyticsTopbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final brandBlock = Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        if (onBack != null) ...[
-          IconButton(
-            icon:
-                const Icon(Icons.arrow_back, color: AnalyticsColors.text),
-            onPressed: onBack,
-            tooltip: 'Назад',
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+      decoration: BoxDecoration(
+        color: const Color(0xD10B1020),
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(color: AnalyticsColors.line),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x59000000),
+            blurRadius: 70,
+            offset: Offset(0, 22),
           ),
-          const SizedBox(width: 6),
         ],
-        Container(
-          width: 44,
-          height: 44,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(14),
-            gradient: AnalyticsColors.accentGradient,
-          ),
-          alignment: Alignment.center,
-          child: const Text(
-            'A',
-            style: TextStyle(
-              color: Color(0xFF00121C),
-              fontWeight: FontWeight.w900,
-              fontSize: 22,
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final tabsBlock = _TabsBlock(
+            selected: selected,
+            onTabChanged: onTabChanged,
+          );
+          final brandBlock = _BrandBlock(
+            maxWidth: constraints.maxWidth,
+            onBack: onBack,
+          );
+
+          if (constraints.maxWidth < 760) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                brandBlock,
+                const SizedBox(height: 12),
+                tabsBlock,
+              ],
+            );
+          }
+
+          return Row(
+            children: [
+              Expanded(child: brandBlock),
+              const SizedBox(width: 16),
+              tabsBlock,
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _BrandBlock extends StatelessWidget {
+  const _BrandBlock({required this.maxWidth, this.onBack});
+
+  final double maxWidth;
+  final VoidCallback? onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: math.min(maxWidth, 560)),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (onBack != null) ...[
+            IconButton(
+              icon: const Icon(Icons.arrow_back, color: AnalyticsColors.text),
+              onPressed: onBack,
+              tooltip: 'Назад',
+            ),
+            const SizedBox(width: 6),
+          ],
+          Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(14),
+              gradient: AnalyticsColors.accentGradient,
+            ),
+            alignment: Alignment.center,
+            child: const Text(
+              'A',
+              style: TextStyle(
+                color: Color(0xFF00121C),
+                fontWeight: FontWeight.w900,
+                fontSize: 22,
+              ),
             ),
           ),
-        ),
-        const SizedBox(width: 12),
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 460),
-          child: const Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'Аналитика производства',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  color: AnalyticsColors.text,
-                  fontWeight: FontWeight.w900,
-                  fontSize: 22,
-                  height: 1.1,
+          const SizedBox(width: 12),
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Аналитика производства',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: AnalyticsColors.text,
+                    fontWeight: FontWeight.w900,
+                    fontSize: 22,
+                    height: 1.1,
+                  ),
                 ),
-              ),
-              SizedBox(height: 4),
-              Text(
-                'сотрудники · рабочие места · графики работы · зарплата',
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style:
-                    TextStyle(color: AnalyticsColors.muted, fontSize: 12),
-              ),
-            ],
+                SizedBox(height: 4),
+                Text(
+                  'сотрудники · рабочие места · графики работы · зарплата',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(color: AnalyticsColors.muted, fontSize: 12),
+                ),
+              ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
+  }
+}
 
-    final tabsBlock = Wrap(
+class _TabsBlock extends StatelessWidget {
+  const _TabsBlock({required this.selected, required this.onTabChanged});
+
+  final AnalyticsTopTab selected;
+  final ValueChanged<AnalyticsTopTab> onTabChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
       spacing: 8,
       runSpacing: 8,
       children: [
@@ -101,32 +171,6 @@ class AnalyticsTopbar extends StatelessWidget {
           onTap: () => onTabChanged(AnalyticsTopTab.schedule),
         ),
       ],
-    );
-
-    return Container(
-      margin: const EdgeInsets.fromLTRB(16, 16, 16, 12),
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
-      decoration: BoxDecoration(
-        color: const Color(0xD10B1020),
-        borderRadius: BorderRadius.circular(22),
-        border: Border.all(color: AnalyticsColors.line),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x59000000),
-            blurRadius: 70,
-            offset: Offset(0, 22),
-          ),
-        ],
-      ),
-      // Внешний Wrap позволяет блокам уйти на новую строку, когда
-      // ширины не хватает (узкое окно), и убирает RenderFlex overflow.
-      child: Wrap(
-        alignment: WrapAlignment.spaceBetween,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        spacing: 16,
-        runSpacing: 12,
-        children: [brandBlock, tabsBlock],
-      ),
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent unsafe ancestor lookups during `dispose()` that caused "Looking up a deactivated widget's ancestor is unsafe" assertions.  
- Eliminate `RenderFlex` overflow in the analytics top bar on narrow windows by making the top bar responsive.  
- Silence a narrow, transient Flutter framework assertion on Windows caused by a synthesized `Alt Left` raw key-down event that pollutes logs while keeping other keyboard errors visible.

### Description
- Cache providers in `didChangeDependencies()` and stop using `context.read()` in `dispose()` by adding `TaskProvider` and `OrdersProvider` fields and removing listeners via those fields in `lib/modules/analytics/screens/analytics_home_screen.dart`.  
- Replace the fixed topbar layout with a responsive implementation using `LayoutBuilder`, `ConstrainedBox`, `_BrandBlock` and `_TabsBlock` so title and tabs wrap and avoid `RenderFlex` overflow in `lib/modules/analytics/widgets/analytics_topbar.dart`.  
- Extend `isTransientFlutterVisualAssertion` in `lib/app_ui_stability.dart` with a narrowly targeted `_isWindowsAltKeyStateAssertion` helper that detects the Windows `RawKeyEventDataWindows` "Attempted to send a key down event when no keys are in keysPressed" for `Alt Left` and treats it as transient.

### Testing
- Ran `git diff --check` with no issues reported.  
- Attempted to run `flutter analyze` but the Flutter SDK is not available in the environment so analysis could not be executed (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19461f3f78832f949f6c14190022f9)