### PR TITLE
Fix analytics schedule grid overflow

### DIFF
--- a/lib/modules/analytics/widgets/schedule_grid.dart
+++ b/lib/modules/analytics/widgets/schedule_grid.dart
@@ -10,6 +10,9 @@ import '../models/work_schedule_entry.dart';
 import '../services/analytics_service.dart';
 import '../utils/analytics_colors.dart';
 
+const double _employeeColumnWidth = 220;
+const double _dayColumnWidth = 74;
+
 class ScheduleGrid extends StatelessWidget {
   const ScheduleGrid({
     super.key,
@@ -43,9 +46,10 @@ class ScheduleGrid extends StatelessWidget {
               .compareTo('${b.lastName} ${b.firstName}'));
 
     return LayoutBuilder(builder: (context, constraints) {
+      final contentWidth = _employeeColumnWidth + _dayColumnWidth * days.length;
       final width = constraints.maxWidth.isFinite
-          ? math.max(constraints.maxWidth, 2400.0)
-          : 2400.0;
+          ? math.max(constraints.maxWidth, contentWidth)
+          : contentWidth;
       return SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: SizedBox(
@@ -71,7 +75,7 @@ class ScheduleGrid extends StatelessWidget {
       child: Row(
         children: [
           SizedBox(
-            width: 220,
+            width: _employeeColumnWidth,
             child: Padding(
               padding: const EdgeInsets.all(12),
               child: const Text('Сотрудник',
@@ -83,7 +87,7 @@ class ScheduleGrid extends StatelessWidget {
           ),
           for (final d in days)
             SizedBox(
-              width: 74,
+              width: _dayColumnWidth,
               child: Padding(
                 padding: const EdgeInsets.all(8),
                 child: Text(
@@ -118,7 +122,7 @@ class ScheduleGrid extends StatelessWidget {
       child: Row(
         children: [
           SizedBox(
-            width: 220,
+            width: _employeeColumnWidth,
             child: Padding(
               padding: const EdgeInsets.all(12),
               child: Text(
@@ -132,7 +136,7 @@ class ScheduleGrid extends StatelessWidget {
           ),
           for (final d in days)
             SizedBox(
-              width: 74,
+              width: _dayColumnWidth,
               child: _Cell(
                 month: month,
                 employeeId: employee.id,


### PR DESCRIPTION
### Motivation
- Prevent horizontal `RenderFlex` overflow in the analytics schedule grid by ensuring the scrollable container width matches the sum of the employee column and day columns rather than a hardcoded large minimum.
- Make header and row column widths consistent by centralizing the column sizes as constants so children do not exceed the scrollable area.

### Description
- Introduced constants `const double _employeeColumnWidth = 220;` and `const double _dayColumnWidth = 74;` at the top of `lib/modules/analytics/widgets/schedule_grid.dart`.
- Compute `contentWidth = _employeeColumnWidth + _dayColumnWidth * days.length` and use it when determining the `SizedBox` width inside the horizontal `SingleChildScrollView` instead of the previous fixed `2400.0` value.
- Replaced literal `220` and `74` widths in both the header and employee rows with the new `_employeeColumnWidth` and `_dayColumnWidth` constants so the header and rows match the scrollable content width.

### Testing
- Ran `git diff --check` to validate there are no trailing whitespace or diff issues and it succeeded.
- Attempted `dart format lib/modules/analytics/widgets/schedule_grid.dart` but it was not run because the Dart SDK is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194caf84d4832f95df6aafdcfd06f1)