### PR TITLE
Debounce task refresh, background stage-sequence preloads, fix paint-reservations RPC and Windows tooltip

### DIFF
--- a/lib/modules/orders/edit_order_screen.dart
+++ b/lib/modules/orders/edit_order_screen.dart
@@ -51,8 +51,9 @@ class EditOrderScreen extends StatefulWidget {
   State<EditOrderScreen> createState() => _EditOrderScreenState();
 }
 
-const bool _disableSwitchableStageDotTooltipDiagnostic =
-    bool.fromEnvironment('DISABLE_SWITCHABLE_STAGE_DOT_TOOLTIP_DIAGNOSTIC');
+final bool _disableSwitchableStageDotTooltipDiagnostic =
+    defaultTargetPlatform == TargetPlatform.windows ||
+        bool.fromEnvironment('DISABLE_SWITCHABLE_STAGE_DOT_TOOLTIP_DIAGNOSTIC');
 
 class _SwitchableStageOption {
   const _SwitchableStageOption(this.stageId, this.label);

--- a/lib/modules/tasks/task_provider.dart
+++ b/lib/modules/tasks/task_provider.dart
@@ -208,6 +208,9 @@ class TaskProvider with ChangeNotifier {
   final List<RealtimeChannel> _stageSyncChannels = <RealtimeChannel>[];
   Future<void>? _activeRefresh;
   bool _refreshQueued = false;
+  Timer? _refreshDebounceTimer;
+  bool _stageSequencePreloadRunning = false;
+  Set<String>? _pendingStageSequencePreloadOrderIds;
 
   TaskProvider() {
     _listenToTasks();
@@ -475,6 +478,7 @@ class TaskProvider with ChangeNotifier {
 
   Future<void> _refreshOnceWithRetry() async {
     try {
+      late final Set<String> orderIds;
       await _retryTransientSupabase('refresh tasks', () async {
         await _ensureAuthed();
         await _loadWorkplaceAliases();
@@ -484,11 +488,14 @@ class TaskProvider with ChangeNotifier {
           ..clear()
           ..addAll(
               List<Map<String, dynamic>>.from(rows as List).map(_rowToTask));
-        final orderIds = _tasks.map((t) => t.orderId).toSet();
-        _loadedStageSequenceOrderIds.clear();
-        await _preloadStageSequences(orderIds);
+        orderIds = _tasks
+            .map((t) => t.orderId.trim())
+            .where((id) => id.isNotEmpty)
+            .toSet();
+        _invalidateStageSequenceCache(orderIds);
       });
       notifyListeners();
+      _scheduleStageSequencePreload(orderIds);
     } catch (e, st) {
       debugPrint('❌ refresh tasks error: $e\n$st');
     }
@@ -551,8 +558,8 @@ class TaskProvider with ChangeNotifier {
           event: PostgresChangeEvent.all,
           schema: 'public',
           table: 'tasks',
-          callback: (payload) async {
-            await refresh();
+          callback: (payload) {
+            _scheduleRefresh();
           },
         )
         .subscribe();
@@ -603,8 +610,8 @@ class TaskProvider with ChangeNotifier {
             event: PostgresChangeEvent.all,
             schema: schema,
             table: table,
-            callback: (_) async {
-              await refresh();
+            callback: (_) {
+              _scheduleRefresh();
             },
           )
           .subscribe();
@@ -619,6 +626,61 @@ class TaskProvider with ChangeNotifier {
       _supabase.removeChannel(channel);
     }
     _stageSyncChannels.clear();
+  }
+
+
+  void _scheduleRefresh({Duration delay = const Duration(milliseconds: 350)}) {
+    _refreshDebounceTimer?.cancel();
+    _refreshDebounceTimer = Timer(delay, () {
+      _refreshDebounceTimer = null;
+      refresh();
+    });
+  }
+
+  void _invalidateStageSequenceCache(Set<String> activeOrderIds) {
+    _loadedStageSequenceOrderIds.removeWhere((id) => !activeOrderIds.contains(id));
+    _orderStageSequences.removeWhere((id, _) => !activeOrderIds.contains(id));
+    _orderStageNames.removeWhere((id, _) => !activeOrderIds.contains(id));
+    _orderStageGroupMaps.removeWhere((id, _) => !activeOrderIds.contains(id));
+  }
+
+  void _scheduleStageSequencePreload(Iterable<String> orderIds) {
+    final pending = orderIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .where((id) => !_loadedStageSequenceOrderIds.contains(id))
+        .toSet();
+    if (pending.isEmpty) return;
+
+    final existing = _pendingStageSequencePreloadOrderIds;
+    if (existing == null) {
+      _pendingStageSequencePreloadOrderIds = pending;
+    } else {
+      existing.addAll(pending);
+    }
+
+    if (_stageSequencePreloadRunning) return;
+    _stageSequencePreloadRunning = true;
+    unawaited(_drainStageSequencePreloadQueue());
+  }
+
+  Future<void> _drainStageSequencePreloadQueue() async {
+    try {
+      while (_pendingStageSequencePreloadOrderIds?.isNotEmpty ?? false) {
+        final batch = _pendingStageSequencePreloadOrderIds!;
+        _pendingStageSequencePreloadOrderIds = null;
+        await _preloadStageSequences(batch);
+        notifyListeners();
+      }
+    } catch (e, st) {
+      debugPrint('❌ preload stage sequences error: $e\n$st');
+    } finally {
+      _stageSequencePreloadRunning = false;
+      if (_pendingStageSequencePreloadOrderIds?.isNotEmpty ?? false) {
+        _stageSequencePreloadRunning = true;
+        unawaited(_drainStageSequencePreloadQueue());
+      }
+    }
   }
 
   // ===== updates =====
@@ -640,7 +702,13 @@ class TaskProvider with ChangeNotifier {
       if (orderId.isEmpty) {
         continue;
       }
-      final data = await _fetchStageSequence(orderId);
+      final data = await _fetchStageSequence(orderId).timeout(
+        const Duration(seconds: 8),
+        onTimeout: () {
+          debugPrint('⚠️ preload stage sequence timeout for order $orderId');
+          return const _StageSequenceData.empty();
+        },
+      );
       _loadedStageSequenceOrderIds.add(orderId);
       if (data.ids.isNotEmpty) {
         _orderStageSequences[orderId] = data.ids;
@@ -2354,6 +2422,8 @@ class TaskProvider with ChangeNotifier {
 
   @override
   void dispose() {
+    _refreshDebounceTimer?.cancel();
+    _refreshDebounceTimer = null;
     if (_tasksChannel != null) {
       _supabase.removeChannel(_tasksChannel!);
       _tasksChannel = null;

--- a/supabase/migrations/20260604_fix_paint_reserved_qty_safe_update.sql
+++ b/supabase/migrations/20260604_fix_paint_reserved_qty_safe_update.sql
@@ -1,0 +1,55 @@
+-- Avoid safe-update failures when paint reservation RPCs have no touched paints.
+-- Supabase/PostgREST can run with pg_safeupdate enabled; in that mode the
+-- old NULL branch updated the whole paints table without a WHERE clause.
+
+do $$
+declare
+  v_paint_id_type text;
+begin
+  select format_type(a.atttypid, a.atttypmod)
+    into v_paint_id_type
+    from pg_attribute a
+    join pg_class c on c.oid = a.attrelid
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public'
+     and c.relname = 'paints'
+     and a.attname = 'id'
+     and a.attnum > 0
+     and not a.attisdropped;
+
+  if v_paint_id_type is null then
+    raise exception 'public.paints.id column not found';
+  end if;
+
+  execute 'drop function if exists public.recalculate_paint_reserved_qty(' || v_paint_id_type || '[])';
+  execute format($sql$
+    create function public.recalculate_paint_reserved_qty(p_paint_ids %1$s[] default null)
+    returns void
+    language plpgsql
+    security definer
+    set search_path = public
+    as $fn$
+    declare
+      v_paint_ids %1$s[];
+    begin
+      select array_agg(distinct paint_id)
+        into v_paint_ids
+        from unnest(p_paint_ids) as paint_id
+       where paint_id is not null;
+
+      if coalesce(array_length(v_paint_ids, 1), 0) = 0 then
+        return;
+      end if;
+
+      update paints p
+         set reserved_qty = coalesce((
+               select sum(greatest(r.reserved_qty - r.used_qty - r.released_qty, 0))
+                 from order_paint_reservations r
+                where r.paint_id = p.id
+             ), 0)
+       where p.id = any(v_paint_ids);
+    end;
+    $fn$
+  $sql$, v_paint_id_type);
+  execute 'grant execute on function public.recalculate_paint_reserved_qty(' || v_paint_id_type || '[]) to authenticated, anon';
+end $$;


### PR DESCRIPTION
### Motivation
- Reduce frequent/time-consuming realtime-triggered `refresh` operations that caused `TimeoutException` during task refresh. 
- Prevent a long-running per-order stage-sequence load from making the whole refresh path time out. 
- Eliminate Windows-only accessibility noise from a local tooltip that seemed to trigger malformed accessibility announcements. 
- Fix unsafe `UPDATE` behavior in paint-reservation RPCs that produced `UPDATE requires a WHERE clause` under pg_safeupdate. 

### Description
- Debounced Supabase realtime callbacks by replacing immediate `await refresh()` calls with a `_scheduleRefresh()` Timer to collapse rapid event bursts, and changed channel callbacks to call `_scheduleRefresh()` instead of awaiting `refresh`. 
- Moved stage-sequence preloading out of the critical `refresh` path by collecting order IDs, invalidating stale cache via `_invalidateStageSequenceCache()`, and performing background preloads with `_scheduleStageSequencePreload()` and `_drainStageSequencePreloadQueue()` so long per-order fetches don't fail the main `refresh`. 
- Added a per-order timeout to stage-sequence fetching using `.timeout(const Duration(seconds: 8))` and guarded background preload state with `_stageSequencePreloadRunning` and `_pendingStageSequencePreloadOrderIds`. 
- Cleaned up the refresh debounce `Timer` in `dispose()` to avoid leaks and converted the diagnostic escape-hatch for the stage-dot tooltip to be active on Windows by default in `lib/modules/orders/edit_order_screen.dart`. 
- Added a Supabase migration `supabase/migrations/20260604_fix_paint_reserved_qty_safe_update.sql` that replaces the old `recalculate_paint_reserved_qty` with a safe implementation which no-ops when no paint IDs are provided and updates `paints` using `WHERE p.id = any(...)` to avoid full-table updates under `pg_safeupdate`. 

### Testing
- Ran `git diff --check` to ensure no trivial whitespace/conflict markers and it passed. 
- Attempted to run `dart format` and `flutter analyze` but the container does not have `dart`/`flutter` installed so those checks were not executed. 
- Verified the migration file was created under `supabase/migrations/20260604_fix_paint_reserved_qty_safe_update.sql` and the code changes are present in `lib/modules/tasks/task_provider.dart` and `lib/modules/orders/edit_order_screen.dart` (no database/system runtime tests executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21562b9660832fb358b6bd5454baeb)